### PR TITLE
add better cost model with rowcnt, network and io cost

### DIFF
--- a/optd-core/src/bin/test_optimize.rs
+++ b/optd-core/src/bin/test_optimize.rs
@@ -57,10 +57,15 @@ pub fn main() {
     let fnal = LogicalJoin::new(scan3.0, join_filter.0, join_cond.0, JoinType::Inner);
     let node = optimizer.optimize(fnal.0.into_rel_node());
     optimizer.dump();
+    let node = node.unwrap();
+    println!(
+        "cost={}",
+        optimizer
+            .cost()
+            .explain(&optimizer.cost().compute_plan_node_cost(&node))
+    );
     println!(
         "{}",
-        PlanNode::from_rel_node(node.unwrap())
-            .unwrap()
-            .explain_to_string()
+        PlanNode::from_rel_node(node).unwrap().explain_to_string()
     );
 }

--- a/optd-core/src/cascades/memo.rs
+++ b/optd-core/src/cascades/memo.rs
@@ -7,7 +7,10 @@ use std::{
 use anyhow::{bail, Result};
 use itertools::Itertools;
 
-use crate::rel_node::{RelNode, RelNodeRef, RelNodeTyp, Value};
+use crate::{
+    cost::Cost,
+    rel_node::{RelNode, RelNodeRef, RelNodeTyp, Value},
+};
 
 use super::optimizer::{ExprId, GroupId};
 
@@ -38,7 +41,7 @@ impl<T: RelNodeTyp> std::fmt::Display for RelMemoNode<T> {
 pub struct Winner {
     pub impossible: bool,
     pub expr_id: ExprId,
-    pub cost: f64,
+    pub cost: Cost,
 }
 
 #[derive(Default, Debug, Clone)]

--- a/optd-core/src/cascades/optimizer.rs
+++ b/optd-core/src/cascades/optimizer.rs
@@ -31,7 +31,7 @@ pub struct CascadesOptimizer<T: RelNodeTyp> {
     explored_group: HashSet<GroupId>,
     fired_rules: HashMap<ExprId, HashSet<RuleId>>,
     rules: Arc<[Arc<dyn Rule<T>>]>,
-    cost: Box<dyn CostModel<T>>,
+    cost: Arc<dyn CostModel<T>>,
     pub ctx: OptimizerContext,
 }
 
@@ -63,13 +63,13 @@ impl<T: RelNodeTyp> CascadesOptimizer<T> {
             explored_group: HashSet::new(),
             fired_rules: HashMap::new(),
             rules: rules.into(),
-            cost,
+            cost: cost.into(),
             ctx: OptimizerContext::default(),
         }
     }
 
-    pub fn cost(&self) -> &dyn CostModel<T> {
-        self.cost.as_ref()
+    pub fn cost(&self) -> Arc<dyn CostModel<T>> {
+        self.cost.clone()
     }
 
     pub(super) fn rules(&self) -> Arc<[Arc<dyn Rule<T>>]> {
@@ -85,7 +85,7 @@ impl<T: RelNodeTyp> CascadesOptimizer<T> {
                     format!(
                         "winner={} cost={} {}",
                         winner.expr_id,
-                        winner.cost,
+                        self.cost.explain(&winner.cost),
                         self.memo.get_expr_memoed(winner.expr_id)
                     )
                 }

--- a/optd-core/src/cost.rs
+++ b/optd-core/src/cost.rs
@@ -8,53 +8,129 @@ use crate::{
 };
 
 fn compute_plan_node_cost<T: RelNodeTyp, C: CostModel<T>>(
-    cost: &C,
+    model: &C,
     node: &RelNode<T>,
-    total_cost: &mut f64,
-) -> f64 {
+    total_cost: &mut Cost,
+) -> Cost {
     let children = node
         .children
         .iter()
-        .map(|child| compute_plan_node_cost(cost, child, total_cost))
+        .map(|child| compute_plan_node_cost(model, child, total_cost))
         .collect_vec();
-    let (cost, row_cnt) = cost.compute_cost(&node.typ, &node.data, children);
-    *total_cost += cost;
-    row_cnt
+    let cost = model.compute_cost(&node.typ, &node.data, &children);
+    model.accumulate(total_cost, &cost);
+    cost
 }
 
-pub trait CostModel<T: RelNodeTyp>: 'static + Send + Sync {
-    fn compute_cost(&self, node: &T, data: &Option<Value>, children: Vec<f64>) -> (f64, f64);
+#[derive(Default, Clone, Debug, PartialOrd, PartialEq)]
+pub struct Cost(pub Vec<f64>);
 
-    fn compute_plan_node_cost(&self, node: &RelNode<T>) -> f64;
+pub trait CostModel<T: RelNodeTyp>: 'static + Send + Sync {
+    fn compute_cost(&self, node: &T, data: &Option<Value>, children: &[Cost]) -> Cost;
+
+    fn compute_plan_node_cost(&self, node: &RelNode<T>) -> Cost;
+
+    fn explain(&self, cost: &Cost) -> String;
+
+    fn accumulate(&self, total_cost: &mut Cost, cost: &Cost);
+
+    fn zero(&self) -> Cost;
 }
 
 pub struct OptCostModel {
     table_stat: HashMap<String, usize>,
 }
 
+pub const ROW_COUNT: usize = 1;
+pub const COMPUTE_COST: usize = 2;
+pub const IO_COST: usize = 3;
+
+impl OptCostModel {
+    fn row_cnt(Cost(cost): &Cost) -> f64 {
+        cost[ROW_COUNT]
+    }
+
+    fn compute_cost(Cost(cost): &Cost) -> f64 {
+        cost[COMPUTE_COST]
+    }
+
+    fn io_cost(Cost(cost): &Cost) -> f64 {
+        cost[IO_COST]
+    }
+
+    fn cost_tuple(Cost(cost): &Cost) -> (f64, f64, f64) {
+        (cost[ROW_COUNT], cost[COMPUTE_COST], cost[IO_COST])
+    }
+
+    fn weighted_cost(row_cnt: f64, compute_cost: f64, io_cost: f64) -> f64 {
+        let _ = row_cnt;
+        compute_cost + io_cost * 10.0
+    }
+
+    pub fn cost(row_cnt: f64, compute_cost: f64, io_cost: f64) -> Cost {
+        Cost(vec![
+            Self::weighted_cost(row_cnt, compute_cost, io_cost),
+            row_cnt,
+            compute_cost,
+            io_cost,
+        ])
+    }
+}
+
 impl CostModel<OptRelNodeTyp> for OptCostModel {
-    fn compute_cost(
-        &self,
-        node: &OptRelNodeTyp,
-        data: &Option<Value>,
-        children: Vec<f64>,
-    ) -> (f64, f64) {
+    fn explain(&self, cost: &Cost) -> String {
+        format!(
+            "weighted={},row_cnt={},compute={},io={}",
+            cost.0[0],
+            Self::row_cnt(cost),
+            Self::compute_cost(cost),
+            Self::io_cost(cost)
+        )
+    }
+
+    fn accumulate(&self, total_cost: &mut Cost, cost: &Cost) {
+        total_cost.0[ROW_COUNT] += Self::row_cnt(cost);
+        total_cost.0[COMPUTE_COST] += Self::compute_cost(cost);
+        total_cost.0[IO_COST] += Self::io_cost(cost);
+        total_cost.0[0] = Self::weighted_cost(
+            total_cost.0[ROW_COUNT],
+            total_cost.0[COMPUTE_COST],
+            total_cost.0[IO_COST],
+        );
+    }
+
+    fn zero(&self) -> Cost {
+        Self::cost(0.0, 0.0, 0.0)
+    }
+
+    fn compute_cost(&self, node: &OptRelNodeTyp, data: &Option<Value>, children: &[Cost]) -> Cost {
         match node {
             OptRelNodeTyp::PhysicalScan => {
                 let table_name = data.as_ref().unwrap().as_str();
-                let row_cnt = self.table_stat.get(table_name.as_ref()).copied().unwrap();
-                (row_cnt as f64, row_cnt as f64)
+                let row_cnt = self.table_stat.get(table_name.as_ref()).copied().unwrap() as f64;
+                Self::cost(row_cnt, 0.0, row_cnt)
             }
-            OptRelNodeTyp::PhysicalFilter => (children[0], children[0] * 0.01),
+            OptRelNodeTyp::PhysicalFilter => {
+                let (row_cnt, _, _) = Self::cost_tuple(&children[0]);
+                let selectivity = 0.1;
+                Self::cost(row_cnt * selectivity, row_cnt, 0.0)
+            }
             OptRelNodeTyp::PhysicalNestedLoopJoin(_) => {
-                (children[0] * children[1], children[0] * children[1] * 0.1)
+                let (row_cnt_1, _, _) = Self::cost_tuple(&children[0]);
+                let (row_cnt_2, _, _) = Self::cost_tuple(&children[1]);
+                let selectivity = 0.1;
+                Self::cost(
+                    row_cnt_1 * row_cnt_2 * selectivity,
+                    row_cnt_1 * row_cnt_2,
+                    0.0,
+                )
             }
-            _ => (1.0, 1.0),
+            _ => Self::cost(1.0, 0.0, 0.0),
         }
     }
 
-    fn compute_plan_node_cost(&self, node: &RelNode<OptRelNodeTyp>) -> f64 {
-        let mut cost = 0.0;
+    fn compute_plan_node_cost(&self, node: &RelNode<OptRelNodeTyp>) -> Cost {
+        let mut cost = self.zero();
         compute_plan_node_cost(self, node, &mut cost);
         cost
     }


### PR DESCRIPTION
cost model is now represented in `Vec<f64>`, whereas the first value is weighted cost.

close https://github.com/cmu-db/optd/issues/3