### PR TITLE
chore: assoc rule only need one way

### DIFF
--- a/optd-datafusion-repr/src/cost.rs
+++ b/optd-datafusion-repr/src/cost.rs
@@ -110,6 +110,7 @@ impl CostModel<OptRelNodeTyp> for OptCostModel {
                     0.0,
                 )
             }
+            _ if node.is_expression() => Self::cost(0.0, 0.0, 0.0),
             _ => Self::cost(1.0, 0.0, 0.0),
         }
     }

--- a/optd-datafusion-repr/src/rules.rs
+++ b/optd-datafusion-repr/src/rules.rs
@@ -4,6 +4,6 @@ mod join_commute;
 mod physical;
 
 pub use filter_join::FilterJoinPullUpRule;
-pub use join_assoc::{JoinAssocLeftRule, JoinAssocRightRule};
+pub use join_assoc::JoinAssocRule;
 pub use join_commute::JoinCommuteRule;
 pub use physical::PhysicalConversionRule;

--- a/optd-datafusion-repr/src/rules/join_assoc.rs
+++ b/optd-datafusion-repr/src/rules/join_assoc.rs
@@ -5,13 +5,8 @@ use optd_core::rules::{OneOrMany, Rule, RuleMatcher};
 
 use crate::plan_nodes::{JoinType, OptRelNodeTyp};
 
-/// Implements A join (B join C) = (A join B) join C
-pub struct JoinAssocLeftRule {
-    matcher: RuleMatcher<OptRelNodeTyp>,
-}
-
 /// Implements (A join B) join C = A join (B join C)
-pub struct JoinAssocRightRule {
+pub struct JoinAssocRule {
     matcher: RuleMatcher<OptRelNodeTyp>,
 }
 
@@ -23,7 +18,7 @@ const COND_BC: usize = 4;
 const JOIN_NODE_TOP: usize = 5;
 const JOIN_NODE_DOWN: usize = 6;
 
-impl JoinAssocLeftRule {
+impl JoinAssocRule {
     pub fn new() -> Self {
         Self {
             matcher: RuleMatcher::MatchAndPickNode {
@@ -47,31 +42,7 @@ impl JoinAssocLeftRule {
     }
 }
 
-impl JoinAssocRightRule {
-    pub fn new() -> Self {
-        Self {
-            matcher: RuleMatcher::MatchAndPickNode {
-                typ: OptRelNodeTyp::Join(JoinType::Inner),
-                pick_to: JOIN_NODE_TOP,
-                children: vec![
-                    RuleMatcher::MatchAndPickNode {
-                        typ: OptRelNodeTyp::Join(JoinType::Inner),
-                        children: vec![
-                            RuleMatcher::PickOne { pick_to: CHILD_A },
-                            RuleMatcher::PickOne { pick_to: CHILD_B },
-                            RuleMatcher::PickOne { pick_to: COND_AB },
-                        ],
-                        pick_to: JOIN_NODE_DOWN,
-                    },
-                    RuleMatcher::PickOne { pick_to: CHILD_C },
-                    RuleMatcher::PickOne { pick_to: COND_BC },
-                ],
-            },
-        }
-    }
-}
-
-impl Rule<OptRelNodeTyp> for JoinAssocLeftRule {
+impl Rule<OptRelNodeTyp> for JoinAssocRule {
     fn matcher(&self) -> &RuleMatcher<OptRelNodeTyp> {
         &self.matcher
     }
@@ -113,52 +84,6 @@ impl Rule<OptRelNodeTyp> for JoinAssocLeftRule {
     }
 
     fn name(&self) -> &'static str {
-        "join_assoc_rotate_left"
-    }
-}
-
-impl Rule<OptRelNodeTyp> for JoinAssocRightRule {
-    fn matcher(&self) -> &RuleMatcher<OptRelNodeTyp> {
-        &self.matcher
-    }
-
-    fn apply(
-        &self,
-        mut input: HashMap<usize, OneOrMany<RelNode<OptRelNodeTyp>>>,
-    ) -> Vec<RelNode<OptRelNodeTyp>> {
-        let RelNode {
-            typ: top_typ,
-            data: top_data,
-            ..
-        } = input.remove(&JOIN_NODE_TOP).unwrap().as_one();
-        let RelNode {
-            typ: down_typ,
-            data: down_data,
-            ..
-        } = input.remove(&JOIN_NODE_DOWN).unwrap().as_one();
-        let child_a = input.remove(&CHILD_A).unwrap().as_one();
-        let child_b = input.remove(&CHILD_B).unwrap().as_one();
-        let child_c = input.remove(&CHILD_C).unwrap().as_one();
-        let cond_ab = input.remove(&COND_AB).unwrap().as_one();
-        let cond_bc = input.remove(&COND_BC).unwrap().as_one();
-        let node = RelNode {
-            typ: top_typ,
-            children: vec![
-                child_a.into(),
-                RelNode {
-                    typ: down_typ,
-                    children: vec![child_b.into(), child_c.into(), cond_bc.into()],
-                    data: down_data,
-                }
-                .into(),
-                cond_ab.into(),
-            ],
-            data: top_data,
-        };
-        vec![node]
-    }
-
-    fn name(&self) -> &'static str {
-        "join_assoc_rotate_right"
+        "join_assoc"
     }
 }


### PR DESCRIPTION
one direction left-rotate assoc + commute rule can yield the right rotation tree.