### PR TITLE
feat: add heuristics optimizer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ members = [
     "optd-core",
     "optd-datafusion-bridge",
     "optd-datafusion-repr",
+    "optd-sqlplannertest",
 ]
 resolver = "2"

--- a/optd-core/src/heuristics.rs
+++ b/optd-core/src/heuristics.rs
@@ -1,0 +1,3 @@
+mod optimizer;
+
+pub use optimizer::{ApplyOrder, HeuristicsOptimizer};

--- a/optd-core/src/heuristics/optimizer.rs
+++ b/optd-core/src/heuristics/optimizer.rs
@@ -1,0 +1,159 @@
+use std::{collections::HashMap, sync::Arc};
+
+use anyhow::Result;
+
+use crate::{
+    rel_node::{RelNode, RelNodeRef, RelNodeTyp},
+    rules::{Rule, RuleMatcher},
+};
+
+pub enum ApplyOrder {
+    TopDown,
+    BottomUp,
+}
+
+pub struct HeuristicsOptimizer<T: RelNodeTyp> {
+    rules: Arc<[Arc<dyn Rule<T>>]>,
+    apply_order: ApplyOrder,
+}
+
+fn match_node<T: RelNodeTyp>(
+    typ: &T,
+    children: &[RuleMatcher<T>],
+    pick_to: Option<usize>,
+    node: RelNodeRef<T>,
+) -> Option<HashMap<usize, RelNode<T>>> {
+    if let RuleMatcher::PickMany { .. } | RuleMatcher::IgnoreMany = children.last().unwrap() {
+    } else {
+        assert_eq!(
+            children.len(),
+            node.children.len(),
+            "children size unmatched, please fix the rule: {}",
+            node
+        );
+    }
+
+    let mut should_end = false;
+    let mut pick = HashMap::new();
+    for (idx, child) in children.iter().enumerate() {
+        assert!(!should_end, "many matcher should be at the end");
+        match child {
+            RuleMatcher::IgnoreOne => {}
+            RuleMatcher::IgnoreMany => {
+                should_end = true;
+            }
+            RuleMatcher::PickOne { pick_to } => {
+                let res = pick.insert(*pick_to, node.child(idx).as_ref().clone());
+                assert!(res.is_none(), "dup pick");
+            }
+            RuleMatcher::PickMany { pick_to } => {
+                let res = pick.insert(
+                    *pick_to,
+                    RelNode::new_list(node.children[idx..].to_vec()).into(),
+                );
+                assert!(res.is_none(), "dup pick");
+                should_end = true;
+            }
+            _ => {
+                if let Some(new_picks) = match_and_pick(child, node.child(idx)) {
+                    pick.extend(new_picks.iter().map(|(k, v)| (*k, v.clone())));
+                } else {
+                    return None;
+                }
+            }
+        }
+    }
+    if let Some(pick_to) = pick_to {
+        let res: Option<RelNode<T>> = pick.insert(
+            pick_to,
+            RelNode {
+                typ: *typ,
+                children: node.children.clone(),
+                data: node.data.clone(),
+            },
+        );
+        assert!(res.is_none(), "dup pick");
+    }
+    Some(pick)
+}
+
+fn match_and_pick<T: RelNodeTyp>(
+    matcher: &RuleMatcher<T>,
+    node: RelNodeRef<T>,
+) -> Option<HashMap<usize, RelNode<T>>> {
+    match matcher {
+        RuleMatcher::MatchAndPickNode {
+            typ,
+            children,
+            pick_to,
+        } => {
+            if &node.typ != typ {
+                return None;
+            }
+            match_node(typ, children, Some(*pick_to), node)
+        }
+        RuleMatcher::MatchNode { typ, children } => {
+            if &node.typ != typ {
+                return None;
+            }
+            match_node(typ, children, None, node)
+        }
+        _ => panic!("top node should be match node"),
+    }
+}
+
+impl<T: RelNodeTyp> HeuristicsOptimizer<T> {
+    pub fn new_with_rules(rules: Vec<Arc<dyn Rule<T>>>, apply_order: ApplyOrder) -> Self {
+        Self {
+            rules: rules.into(),
+            apply_order,
+        }
+    }
+
+    fn optimize_inputs(&mut self, inputs: &[RelNodeRef<T>]) -> Result<Vec<RelNodeRef<T>>> {
+        let mut optimized_inputs = Vec::with_capacity(inputs.len());
+        for input in inputs {
+            optimized_inputs.push(self.optimize(input.clone())?);
+        }
+        Ok(optimized_inputs)
+    }
+
+    fn apply_rules(&mut self, mut root_rel: RelNodeRef<T>) -> Result<RelNodeRef<T>> {
+        for rule in self.rules.as_ref() {
+            let matcher = rule.matcher();
+            if let Some(picks) = match_and_pick(matcher, root_rel.clone()) {
+                let mut results = rule.apply(picks);
+                assert_eq!(results.len(), 1);
+                root_rel = results.remove(0).into();
+            }
+        }
+        Ok(root_rel)
+    }
+
+    pub fn optimize(&mut self, root_rel: RelNodeRef<T>) -> Result<RelNodeRef<T>> {
+        match self.apply_order {
+            ApplyOrder::BottomUp => {
+                let optimized_children = self.optimize_inputs(&root_rel.children)?;
+                let node = self.apply_rules(
+                    RelNode {
+                        typ: root_rel.typ.clone(),
+                        children: optimized_children,
+                        data: root_rel.data.clone(),
+                    }
+                    .into(),
+                )?;
+                Ok(node)
+            }
+            ApplyOrder::TopDown => {
+                let root_rel = self.apply_rules(root_rel)?;
+                let optimized_children = self.optimize_inputs(&root_rel.children)?;
+                Ok(RelNode {
+                    typ: root_rel.typ.clone(),
+                    children: optimized_children,
+                    data: root_rel.data.clone(),
+                }
+                .into())
+            }
+        }
+    }
+}

--- a/optd-core/src/lib.rs
+++ b/optd-core/src/lib.rs
@@ -2,5 +2,6 @@
 
 pub mod cascades;
 pub mod cost;
+pub mod heuristics;
 pub mod rel_node;
 pub mod rules;

--- a/optd-datafusion-repr/src/cost.rs
+++ b/optd-datafusion-repr/src/cost.rs
@@ -98,14 +98,14 @@ impl CostModel<OptRelNodeTyp> for OptCostModel {
             OptRelNodeTyp::PhysicalFilter => {
                 let (row_cnt, _, _) = Self::cost_tuple(&children[0]);
                 let selectivity = 0.001;
-                Self::cost(row_cnt * selectivity, row_cnt, 0.0)
+                Self::cost((row_cnt * selectivity).max(1.0), row_cnt, 0.0)
             }
             OptRelNodeTyp::PhysicalNestedLoopJoin(_) => {
                 let (row_cnt_1, _, _) = Self::cost_tuple(&children[0]);
                 let (row_cnt_2, _, _) = Self::cost_tuple(&children[1]);
                 let selectivity = 0.01;
                 Self::cost(
-                    row_cnt_1 * row_cnt_2 * selectivity,
+                    (row_cnt_1 * row_cnt_2 * selectivity).max(1.0),
                     row_cnt_1 * row_cnt_2,
                     0.0,
                 )

--- a/optd-sqlplannertest/Cargo.toml
+++ b/optd-sqlplannertest/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "optd-sqlplannertest"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/optd-sqlplannertest/src/lib.rs
+++ b/optd-sqlplannertest/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}


### PR DESCRIPTION
though the focus of optd is a pure-cascades optimizer framework, having a heuristics framework can still greatly help testing the optimizer rules without being interfered by the cost model / randomness during the cascades process.