### PR TITLE
feat: support sort+agg and convert plan nodes

### DIFF
--- a/optd-datafusion-bridge/src/into_optd.rs
+++ b/optd-datafusion-bridge/src/into_optd.rs
@@ -1,8 +1,9 @@
 use anyhow::{bail, Result};
 use datafusion::logical_expr::{self, logical_plan, LogicalPlan};
 use optd_datafusion_repr::plan_nodes::{
-    ColumnRefExpr, Expr, ExprList, LogicalProjection, LogicalScan, OptRelNode, OptRelNodeRef,
-    PlanNode,
+    BinOpExpr, BinOpType, ColumnRefExpr, ConstantExpr, Expr, ExprList, JoinType, LogicalAgg,
+    LogicalFilter, LogicalJoin, LogicalProjection, LogicalScan, LogicalSort, OptRelNode,
+    OptRelNodeRef, PlanNode,
 };
 
 use crate::OptdPlanContext;
@@ -35,7 +36,8 @@ impl OptdPlanContext<'_> {
             Expr::BinaryExpr(node) => {
                 let left = self.into_optd_expr(node.left.as_ref())?;
                 let right = self.into_optd_expr(node.right.as_ref())?;
-                bail!("binary expr")
+                let op = BinOpType::Add;
+                Ok(BinOpExpr::new(left, right, op).into_expr())
             }
             _ => bail!("{:?}", expr),
         }
@@ -46,19 +48,70 @@ impl OptdPlanContext<'_> {
         node: &logical_plan::Projection,
     ) -> Result<LogicalProjection> {
         let input = self.into_optd_plan_node(node.input.as_ref())?;
-        let exprs = node
-            .expr
+        let expr_list = self.into_optd_expr_list(&node.expr)?;
+        Ok(LogicalProjection::new(input, expr_list))
+    }
+
+    fn into_optd_filter(&mut self, node: &logical_plan::Filter) -> Result<LogicalFilter> {
+        let input = self.into_optd_plan_node(node.input.as_ref())?;
+        let expr = self.into_optd_expr(&node.predicate)?;
+        Ok(LogicalFilter::new(input, expr))
+    }
+
+    fn into_optd_expr_list(&mut self, exprs: &[logical_expr::Expr]) -> Result<ExprList> {
+        let exprs = exprs
             .iter()
             .map(|expr| self.into_optd_expr(expr))
             .collect::<Result<Vec<_>>>()?;
-        let expr_list = ExprList::new(exprs);
-        Ok(LogicalProjection::new(input, expr_list))
+        Ok(ExprList::new(exprs))
+    }
+
+    fn into_optd_sort(&mut self, node: &logical_plan::Sort) -> Result<LogicalSort> {
+        let input = self.into_optd_plan_node(node.input.as_ref())?;
+        let expr_list = self.into_optd_expr_list(&node.expr)?;
+        Ok(LogicalSort::new(input, expr_list))
+    }
+
+    fn into_optd_agg(&mut self, node: &logical_plan::Aggregate) -> Result<LogicalAgg> {
+        let input = self.into_optd_plan_node(node.input.as_ref())?;
+        let agg_exprs = self.into_optd_expr_list(&node.aggr_expr)?;
+        let group_exprs = self.into_optd_expr_list(&node.group_expr)?;
+        Ok(LogicalAgg::new(input, agg_exprs, group_exprs))
+    }
+
+    fn into_optd_join(&mut self, node: &logical_plan::Join) -> Result<LogicalJoin> {
+        use logical_plan::JoinType as DFJoinType;
+        let left = self.into_optd_plan_node(node.left.as_ref())?;
+        let right = self.into_optd_plan_node(node.right.as_ref())?;
+        let join_type = match node.join_type {
+            DFJoinType::Inner => JoinType::Inner,
+            DFJoinType::Left => JoinType::LeftOuter,
+            DFJoinType::Right => JoinType::RightOuter,
+            DFJoinType::Full => JoinType::FullOuter,
+            DFJoinType::LeftAnti => JoinType::LeftAnti,
+            DFJoinType::RightAnti => JoinType::RightAnti,
+            DFJoinType::LeftSemi => JoinType::LeftSemi,
+            DFJoinType::RightSemi => JoinType::RightSemi,
+        };
+        // TODO: on condition
+
+        Ok(LogicalJoin::new(
+            left,
+            right,
+            ConstantExpr::bool(true).into_expr(),
+            join_type,
+        ))
     }
 
     fn into_optd_plan_node(&mut self, node: &LogicalPlan) -> Result<PlanNode> {
         let node = match node {
             LogicalPlan::TableScan(node) => self.into_optd_table_scan(node)?.into_plan_node(),
             LogicalPlan::Projection(node) => self.into_optd_projection(node)?.into_plan_node(),
+            LogicalPlan::Sort(node) => self.into_optd_sort(node)?.into_plan_node(),
+            LogicalPlan::Aggregate(node) => self.into_optd_agg(node)?.into_plan_node(),
+            LogicalPlan::SubqueryAlias(node) => self.into_optd_plan_node(node.input.as_ref())?,
+            LogicalPlan::Join(node) => self.into_optd_join(node)?.into_plan_node(),
+            LogicalPlan::Filter(node) => self.into_optd_filter(node)?.into_plan_node(),
             _ => bail!("{:?}", node),
         };
         Ok(node)

--- a/optd-datafusion-repr/src/plan_nodes/agg.rs
+++ b/optd-datafusion-repr/src/plan_nodes/agg.rs
@@ -1,0 +1,30 @@
+use super::expr::ExprList;
+use super::macros::define_plan_node;
+
+use super::{OptRelNode, OptRelNodeRef, OptRelNodeTyp, PlanNode};
+
+#[derive(Clone, Debug)]
+pub struct LogicalAgg(pub PlanNode);
+
+define_plan_node!(
+    LogicalAgg : PlanNode,
+    Agg, [
+        { 0, child: PlanNode }
+    ], [
+        { 1, exprs: ExprList },
+        { 2, groups: ExprList }
+    ]
+);
+
+#[derive(Clone, Debug)]
+pub struct PhysicalAgg(pub PlanNode);
+
+define_plan_node!(
+    PhysicalAgg : PlanNode,
+    PhysicalAgg, [
+        { 0, child: PlanNode }
+    ], [
+        { 1, aggrs: ExprList },
+        { 2, groups: ExprList }
+    ]
+);

--- a/optd-datafusion-repr/src/plan_nodes/apply.rs
+++ b/optd-datafusion-repr/src/plan_nodes/apply.rs
@@ -20,8 +20,8 @@ impl ApplyType {
         match self {
             Self::Cross => JoinType::Cross,
             Self::LeftOuter => JoinType::LeftOuter,
-            Self::Semi => JoinType::Semi,
-            Self::AntiSemi => JoinType::AntiSemi,
+            Self::Semi => JoinType::LeftSemi,
+            Self::AntiSemi => JoinType::LeftAnti,
         }
     }
 }

--- a/optd-datafusion-repr/src/plan_nodes/expr.rs
+++ b/optd-datafusion-repr/src/plan_nodes/expr.rs
@@ -75,6 +75,14 @@ impl ConstantExpr {
         ))
     }
 
+    pub fn bool(value: bool) -> Self {
+        Self::new(Value::Bool(value))
+    }
+
+    pub fn int(value: i64) -> Self {
+        Self::new(Value::Int(value))
+    }
+
     /// Gets the constant value.
     pub fn value(&self) -> Value {
         self.0 .0.data.clone().unwrap()
@@ -335,6 +343,67 @@ impl OptRelNode for FuncExpr {
                 .iter()
                 .map(|child| child.explain())
                 .collect(),
+        )
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub enum SortOrderType {
+    Asc,
+    Desc,
+}
+
+impl Display for SortOrderType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SortOrderExpr(Expr);
+
+impl SortOrderExpr {
+    pub fn new(order: SortOrderType, child: Expr) -> Self {
+        SortOrderExpr(Expr(
+            RelNode {
+                typ: OptRelNodeTyp::SortOrder(order),
+                children: vec![child.into_rel_node()],
+                data: None,
+            }
+            .into(),
+        ))
+    }
+
+    pub fn child(&self) -> Expr {
+        Expr::from_rel_node(self.0.child(0)).unwrap()
+    }
+
+    pub fn order(&self) -> SortOrderType {
+        if let OptRelNodeTyp::SortOrder(order) = self.0.typ() {
+            order
+        } else {
+            panic!("not a sort order expr")
+        }
+    }
+}
+
+impl OptRelNode for SortOrderExpr {
+    fn into_rel_node(self) -> OptRelNodeRef {
+        self.0.into_rel_node()
+    }
+
+    fn from_rel_node(rel_node: OptRelNodeRef) -> Option<Self> {
+        if !matches!(rel_node.typ, OptRelNodeTyp::SortOrder(_)) {
+            return None;
+        }
+        Expr::from_rel_node(rel_node).map(Self)
+    }
+
+    fn dispatch_explain(&self) -> Pretty<'static> {
+        Pretty::simple_record(
+            "SortOrder",
+            vec![("order", self.order().to_string().into())],
+            vec![self.child().explain()],
         )
     }
 }

--- a/optd-datafusion-repr/src/plan_nodes/join.rs
+++ b/optd-datafusion-repr/src/plan_nodes/join.rs
@@ -11,8 +11,10 @@ pub enum JoinType {
     LeftOuter,
     RightOuter,
     Cross,
-    Semi,
-    AntiSemi,
+    LeftSemi,
+    RightSemi,
+    LeftAnti,
+    RightAnti,
 }
 
 impl Display for JoinType {

--- a/optd-datafusion-repr/src/plan_nodes/sort.rs
+++ b/optd-datafusion-repr/src/plan_nodes/sort.rs
@@ -1,0 +1,28 @@
+use super::expr::ExprList;
+use super::macros::define_plan_node;
+
+use super::{OptRelNode, OptRelNodeRef, OptRelNodeTyp, PlanNode};
+
+#[derive(Clone, Debug)]
+pub struct LogicalSort(pub PlanNode);
+
+define_plan_node!(
+    LogicalSort : PlanNode,
+    Sort, [
+        { 0, child: PlanNode }
+    ], [
+        { 1, exprs: ExprList }
+    ]
+);
+
+#[derive(Clone, Debug)]
+pub struct PhysicalSort(pub PlanNode);
+
+define_plan_node!(
+    PhysicalSort : PlanNode,
+    PhysicalSort, [
+        { 0, child: PlanNode }
+    ], [
+        { 1, exprs: ExprList }
+    ]
+);

--- a/test.sql
+++ b/test.sql
@@ -1,2 +1,123 @@
-create table t1(v1 int);
-select * from t1;
+CREATE TABLE NATION  (
+    N_NATIONKEY  INT NOT NULL,
+    N_NAME       CHAR(25) NOT NULL,
+    N_REGIONKEY  INT NOT NULL,
+    N_COMMENT    VARCHAR(152)
+);
+
+CREATE TABLE REGION  (
+    R_REGIONKEY  INT NOT NULL,
+    R_NAME       CHAR(25) NOT NULL,
+    R_COMMENT    VARCHAR(152)
+);
+
+CREATE TABLE PART  (
+    P_PARTKEY     INT NOT NULL,
+    P_NAME        VARCHAR(55) NOT NULL,
+    P_MFGR        CHAR(25) NOT NULL,
+    P_BRAND       CHAR(10) NOT NULL,
+    P_TYPE        VARCHAR(25) NOT NULL,
+    P_SIZE        INT NOT NULL,
+    P_CONTAINER   CHAR(10) NOT NULL,
+    P_RETAILPRICE DECIMAL(15,2) NOT NULL,
+    P_COMMENT     VARCHAR(23) NOT NULL
+);
+
+CREATE TABLE SUPPLIER (
+    S_SUPPKEY     INT NOT NULL,
+    S_NAME        CHAR(25) NOT NULL,
+    S_ADDRESS     VARCHAR(40) NOT NULL,
+    S_NATIONKEY   INT NOT NULL,
+    S_PHONE       CHAR(15) NOT NULL,
+    S_ACCTBAL     DECIMAL(15,2) NOT NULL,
+    S_COMMENT     VARCHAR(101) NOT NULL
+);
+
+CREATE TABLE PARTSUPP (
+    PS_PARTKEY     INT NOT NULL,
+    PS_SUPPKEY     INT NOT NULL,
+    PS_AVAILQTY    INT NOT NULL,
+    PS_SUPPLYCOST  DECIMAL(15,2)  NOT NULL,
+    PS_COMMENT     VARCHAR(199) NOT NULL
+);
+
+CREATE TABLE CUSTOMER (
+    C_CUSTKEY     INT NOT NULL,
+    C_NAME        VARCHAR(25) NOT NULL,
+    C_ADDRESS     VARCHAR(40) NOT NULL,
+    C_NATIONKEY   INT NOT NULL,
+    C_PHONE       CHAR(15) NOT NULL,
+    C_ACCTBAL     DECIMAL(15,2)   NOT NULL,
+    C_MKTSEGMENT  CHAR(10) NOT NULL,
+    C_COMMENT     VARCHAR(117) NOT NULL
+);
+
+CREATE TABLE ORDERS (
+    O_ORDERKEY       INT NOT NULL,
+    O_CUSTKEY        INT NOT NULL,
+    O_ORDERSTATUS    CHAR(1) NOT NULL,
+    O_TOTALPRICE     DECIMAL(15,2) NOT NULL,
+    O_ORDERDATE      DATE NOT NULL,
+    O_ORDERPRIORITY  CHAR(15) NOT NULL,  
+    O_CLERK          CHAR(15) NOT NULL, 
+    O_SHIPPRIORITY   INT NOT NULL,
+    O_COMMENT        VARCHAR(79) NOT NULL
+);
+
+CREATE TABLE LINEITEM (
+    L_ORDERKEY      INT NOT NULL,
+    L_PARTKEY       INT NOT NULL,
+    L_SUPPKEY       INT NOT NULL,
+    L_LINENUMBER    INT NOT NULL,
+    L_QUANTITY      DECIMAL(15,2) NOT NULL,
+    L_EXTENDEDPRICE DECIMAL(15,2) NOT NULL,
+    L_DISCOUNT      DECIMAL(15,2) NOT NULL,
+    L_TAX           DECIMAL(15,2) NOT NULL,
+    L_RETURNFLAG    CHAR(1) NOT NULL,
+    L_LINESTATUS    CHAR(1) NOT NULL,
+    L_SHIPDATE      DATE NOT NULL,
+    L_COMMITDATE    DATE NOT NULL,
+    L_RECEIPTDATE   DATE NOT NULL,
+    L_SHIPINSTRUCT  CHAR(25) NOT NULL,
+    L_SHIPMODE      CHAR(10) NOT NULL,
+    L_COMMENT       VARCHAR(44) NOT NULL
+);
+
+select
+    o_year,
+    sum(case
+        when nation = 'IRAQ' then volume
+        else 0
+    end) / sum(volume) as mkt_share
+from
+    (
+        select
+            extract(year from o_orderdate) as o_year,
+            l_extendedprice * (1 - l_discount) as volume,
+            n2.n_name as nation
+        from
+            part,
+            supplier,
+            lineitem,
+            orders,
+            customer,
+            nation n1,
+            nation n2,
+            region
+        where
+            p_partkey = l_partkey
+            and s_suppkey = l_suppkey
+            and l_orderkey = o_orderkey
+            and o_custkey = c_custkey
+            and c_nationkey = n1.n_nationkey
+            and n1.n_regionkey = r_regionkey
+            and r_name = 'AMERICA'
+            and s_nationkey = n2.n_nationkey
+            and o_orderdate between date '1995-01-01' and date '1996-12-31'
+            and p_type = 'ECONOMY ANODIZED STEEL'
+    ) as all_nations
+group by
+    o_year
+order by
+    o_year;
+


### PR DESCRIPTION
we'll start with adaptive query optimization of TPC-H Q8. we plug optd after Datafusion has optimized its logical plan to unnest the queries. this pull request adds support for all plan nodes used in TPC-H Q8. need to add expression nodes and convert it back to physical plans.