### PR TITLE
chore: refine rule matcher for hash join conversion rule

### DIFF
--- a/datafusion-optd-cli/src/main.rs
+++ b/datafusion-optd-cli/src/main.rs
@@ -35,7 +35,6 @@ use std::collections::HashMap;
 use std::env;
 use std::path::Path;
 use std::str::FromStr;
-use std::sync::Mutex;
 use std::sync::{Arc, OnceLock};
 
 #[global_allocator]

--- a/optd-core/src/cascades/memo.rs
+++ b/optd-core/src/cascades/memo.rs
@@ -164,7 +164,7 @@ impl<T: RelNodeTyp> Memo<T> {
             data: rel_node.data.clone(),
         };
         let Some(&expr_id) = self.expr_node_to_expr_id.get(&memo_node) else {
-            unreachable!()
+            unreachable!("not found {}", memo_node)
         };
         let group_id = self.get_group_id_of_expr_id(expr_id);
         return (group_id, expr_id);

--- a/optd-core/src/lib.rs
+++ b/optd-core/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod cascades;
 pub mod cost;
 pub mod heuristics;
+pub mod optimizer;
 pub mod property;
 pub mod rel_node;
 pub mod rules;

--- a/optd-core/src/optimizer.rs
+++ b/optd-core/src/optimizer.rs
@@ -1,0 +1,11 @@
+use anyhow::Result;
+
+use crate::{
+    property::PropertyBuilder,
+    rel_node::{RelNodeRef, RelNodeTyp},
+};
+
+pub trait Optimizer<T: RelNodeTyp> {
+    fn optimize(&mut self, root_rel: RelNodeRef<T>) -> Result<RelNodeRef<T>>;
+    fn get_property<P: PropertyBuilder<T>>(&self, root_rel: RelNodeRef<T>, idx: usize) -> P::Prop;
+}

--- a/optd-core/src/rules.rs
+++ b/optd-core/src/rules.rs
@@ -2,13 +2,16 @@ mod ir;
 
 use std::collections::HashMap;
 
-use crate::rel_node::{RelNode, RelNodeTyp};
+use crate::{
+    optimizer::Optimizer,
+    rel_node::{RelNode, RelNodeTyp},
+};
 
 pub use ir::RuleMatcher;
 
-pub trait Rule<T: RelNodeTyp>: 'static + Send + Sync {
+pub trait Rule<T: RelNodeTyp, O: Optimizer<T>>: 'static + Send + Sync {
     fn matcher(&self) -> &RuleMatcher<T>;
-    fn apply(&self, input: HashMap<usize, RelNode<T>>) -> Vec<RelNode<T>>;
+    fn apply(&self, optimizer: &O, input: HashMap<usize, RelNode<T>>) -> Vec<RelNode<T>>;
     fn name(&self) -> &'static str;
     fn is_impl_rule(&self) -> bool {
         false

--- a/optd-core/src/rules/ir.rs
+++ b/optd-core/src/rules/ir.rs
@@ -10,7 +10,7 @@ pub enum RuleMatcher<T: RelNodeTyp> {
     /// Match a node of type `typ`.
     MatchNode { typ: T, children: Vec<Self> },
     /// Match anything,
-    PickOne { pick_to: usize },
+    PickOne { pick_to: usize, expand: bool },
     /// Match all things in the group
     PickMany { pick_to: usize },
     /// Ignore one

--- a/optd-datafusion-bridge/Cargo.toml
+++ b/optd-datafusion-bridge/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 arrow-schema = "*"
 datafusion = "32.0.0"
 async-trait = "0.1"
+optd-core = { path = "../optd-core" }
 optd-datafusion-repr = { path = "../optd-datafusion-repr" }
 anyhow = "1"
 async-recursion = "1"

--- a/optd-datafusion-bridge/src/from_optd.rs
+++ b/optd-datafusion-bridge/src/from_optd.rs
@@ -5,15 +5,13 @@ use arrow_schema::Schema;
 use async_recursion::async_recursion;
 use datafusion::{
     arrow::datatypes::SchemaRef,
-    common::DFSchema,
     datasource::source_as_provider,
-    logical_expr::{expr::ScalarFunction, Operator},
-    parquet::basic::SortOrder,
+    logical_expr::Operator,
     physical_expr,
     physical_plan::{
         self, aggregates::AggregateMode, expressions::create_aggregate_expr,
-        functions::create_physical_fun, joins::utils::JoinFilter, projection::ProjectionExec,
-        sorts::sort::SortExec, AggregateExpr, ExecutionPlan, PhysicalExpr,
+        joins::utils::JoinFilter, projection::ProjectionExec, AggregateExpr, ExecutionPlan,
+        PhysicalExpr,
     },
     scalar::ScalarValue,
 };
@@ -108,6 +106,7 @@ impl OptdPlanContext<'_> {
                     }
                     ConstantType::Date => ScalarValue::Date32(Some(value.as_i64() as i32)),
                     ConstantType::Utf8String => ScalarValue::Utf8(Some(value.as_str().to_string())),
+                    ConstantType::Any => unimplemented!(),
                 };
                 Ok(Arc::new(
                     datafusion::physical_plan::expressions::Literal::new(value),

--- a/optd-datafusion-bridge/src/lib.rs
+++ b/optd-datafusion-bridge/src/lib.rs
@@ -6,7 +6,7 @@ mod into_optd;
 use arrow_schema::DataType;
 use async_trait::async_trait;
 use datafusion::{
-    catalog::{schema, CatalogList},
+    catalog::CatalogList,
     error::Result,
     execution::context::{QueryPlanner, SessionState},
     logical_expr::{LogicalPlan, TableSource},

--- a/optd-datafusion-repr/src/plan_nodes.rs
+++ b/optd-datafusion-repr/src/plan_nodes.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 
 use optd_core::{
     cascades::{CascadesOptimizer, GroupId},
+    optimizer::Optimizer,
     rel_node::{RelNode, RelNodeRef, RelNodeTyp},
 };
 
@@ -192,7 +193,7 @@ impl PlanNode {
 
     pub fn schema(&self, optimizer: CascadesOptimizer<OptRelNodeTyp>) -> Schema {
         let group_id = optimizer.resolve_group_id(self.0.clone());
-        optimizer.get_property::<SchemaPropertyBuilder>(group_id, 0)
+        optimizer.get_property_by_group::<SchemaPropertyBuilder>(group_id, 0)
     }
 }
 

--- a/optd-datafusion-repr/src/plan_nodes/expr.rs
+++ b/optd-datafusion-repr/src/plan_nodes/expr.rs
@@ -67,6 +67,7 @@ pub enum ConstantType {
     Int,
     Date,
     Decimal,
+    Any,
 }
 
 #[derive(Clone, Debug)]
@@ -157,29 +158,13 @@ impl ColumnRefExpr {
         ))
     }
 
-    pub fn with_child(&self, child_idx: usize) -> ColumnRefExpr {
-        ColumnRefExpr(Expr(
-            RelNode {
-                typ: OptRelNodeTyp::ColumnRef,
-                children: vec![],
-                data: Some(Value::Int((self.index() + (child_idx << 32)) as i64)),
-            }
-            .into(),
-        ))
-    }
-
     fn get_data_usize(&self) -> usize {
         self.0 .0.data.as_ref().unwrap().as_i64() as usize
     }
 
     /// Gets the column index.
     pub fn index(&self) -> usize {
-        self.get_data_usize() & ((1 << 32) - 1)
-    }
-
-    /// Gets the child id.
-    pub fn child_id(&self) -> usize {
-        self.get_data_usize() >> 32
+        self.get_data_usize()
     }
 }
 

--- a/optd-datafusion-repr/src/properties/schema.rs
+++ b/optd-datafusion-repr/src/properties/schema.rs
@@ -38,12 +38,14 @@ impl PropertyBuilder<OptRelNodeTyp> for SchemaPropertyBuilder {
                 let name = data.unwrap().as_str().to_string();
                 self.catalog.get(&name)
             }
+            OptRelNodeTyp::Projection => children[1].clone(),
             OptRelNodeTyp::Filter => children[0].clone(),
             OptRelNodeTyp::Join(_) => {
                 let mut schema = children[0].clone();
                 schema.0.extend(children[1].clone().0);
                 schema
             }
+            OptRelNodeTyp::List => Schema(vec![ConstantType::Any; children.len()]),
             _ => Schema(vec![]),
         }
     }

--- a/optd-datafusion-repr/src/rules.rs
+++ b/optd-datafusion-repr/src/rules.rs
@@ -1,8 +1,8 @@
-mod filter_join;
+// mod filter_join;
 mod joins;
 mod macros;
 mod physical;
 
-pub use filter_join::FilterJoinPullUpRule;
-pub use joins::{JoinAssocRule, JoinCommuteRule};
+// pub use filter_join::FilterJoinPullUpRule;
+pub use joins::{HashJoinRule, JoinAssocRule, JoinCommuteRule};
 pub use physical::PhysicalConversionRule;

--- a/optd-datafusion-repr/src/rules/filter_join.rs
+++ b/optd-datafusion-repr/src/rules/filter_join.rs
@@ -25,16 +25,22 @@ impl FilterJoinPullUpRule {
                         children: vec![
                             RuleMatcher::PickOne {
                                 pick_to: LEFT_CHILD,
+                                expand: false,
                             },
                             RuleMatcher::PickOne {
                                 pick_to: FILTER_COND,
+                                expand: true,
                             },
                         ],
                     },
                     RuleMatcher::PickOne {
                         pick_to: RIGHT_CHILD,
+                        expand: false,
                     },
-                    RuleMatcher::PickOne { pick_to: JOIN_COND },
+                    RuleMatcher::PickOne {
+                        pick_to: JOIN_COND,
+                        expand: true,
+                    },
                 ],
             },
         }
@@ -68,6 +74,6 @@ impl Rule<OptRelNodeTyp> for FilterJoinPullUpRule {
     }
 
     fn name(&self) -> &'static str {
-        "join_commute"
+        "filter_join"
     }
 }

--- a/optd-datafusion-repr/src/rules/joins.rs
+++ b/optd-datafusion-repr/src/rules/joins.rs
@@ -1,10 +1,13 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
+use optd_core::optimizer::Optimizer;
 use optd_core::rel_node::RelNode;
 use optd_core::rules::{Rule, RuleMatcher};
 
-use super::macros::define_rule;
+use super::macros::{define_impl_rule, define_rule};
 use crate::plan_nodes::{JoinType, OptRelNodeTyp};
+use crate::properties::schema::SchemaPropertyBuilder;
 
 define_rule!(
     JoinCommuteRule,
@@ -13,6 +16,7 @@ define_rule!(
 );
 
 fn apply_join_commute(
+    _optimizer: &impl Optimizer<OptRelNodeTyp>,
     JoinCommuteRulePicks { left, right, cond }: JoinCommuteRulePicks,
 ) -> Vec<RelNode<OptRelNodeTyp>> {
     let node = RelNode {
@@ -35,6 +39,7 @@ define_rule!(
 );
 
 fn apply_join_assoc(
+    _optimizer: &impl Optimizer<OptRelNodeTyp>,
     JoinAssocRulePicks {
         a,
         b,
@@ -58,4 +63,29 @@ fn apply_join_assoc(
         data: None,
     };
     vec![node]
+}
+
+define_impl_rule!(
+    HashJoinRule,
+    apply_hash_join,
+    (Join(JoinType::Inner), left, right, [cond])
+);
+
+fn apply_hash_join(
+    optimizer: &impl Optimizer<OptRelNodeTyp>,
+    HashJoinRulePicks { left, right, cond }: HashJoinRulePicks,
+) -> Vec<RelNode<OptRelNodeTyp>> {
+    println!("!!!");
+    println!(
+        "left: {}, schema={:?}",
+        left,
+        optimizer.get_property::<SchemaPropertyBuilder>(Arc::new(left.clone()), 0)
+    );
+    println!(
+        "right: {}, schema={:?}",
+        right,
+        optimizer.get_property::<SchemaPropertyBuilder>(Arc::new(right.clone()), 0)
+    );
+    println!("cond: {}", cond);
+    vec![]
 }

--- a/optd-datafusion-repr/src/rules/physical.rs
+++ b/optd-datafusion-repr/src/rules/physical.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use optd_core::optimizer::Optimizer;
 use optd_core::rel_node::RelNode;
 use optd_core::rules::{Rule, RuleMatcher};
 
@@ -23,7 +24,7 @@ impl PhysicalConversionRule {
 }
 
 impl PhysicalConversionRule {
-    pub fn all_conversions() -> Vec<Arc<dyn Rule<OptRelNodeTyp>>> {
+    pub fn all_conversions<O: Optimizer<OptRelNodeTyp>>() -> Vec<Arc<dyn Rule<OptRelNodeTyp, O>>> {
         vec![
             Arc::new(PhysicalConversionRule::new(OptRelNodeTyp::Scan)),
             Arc::new(PhysicalConversionRule::new(OptRelNodeTyp::Projection)),
@@ -37,13 +38,14 @@ impl PhysicalConversionRule {
     }
 }
 
-impl Rule<OptRelNodeTyp> for PhysicalConversionRule {
+impl<O: Optimizer<OptRelNodeTyp>> Rule<OptRelNodeTyp, O> for PhysicalConversionRule {
     fn matcher(&self) -> &RuleMatcher<OptRelNodeTyp> {
         &self.matcher
     }
 
     fn apply(
         &self,
+        _optimizer: &O,
         mut input: HashMap<usize, RelNode<OptRelNodeTyp>>,
     ) -> Vec<RelNode<OptRelNodeTyp>> {
         let RelNode {


### PR DESCRIPTION
we made a bad design choice to make expression a kind of RelNode. it should always be expanded to the full node and be excluded from the search process. to compensate for this, we added a `expand` field on the rule matcher, so as to recover the original representation of the expression when doing rule matching.