### PR TITLE
feat: add join assoc rule to datafusion bridge

### DIFF
--- a/optd-core/src/cascades/optimizer.rs
+++ b/optd-core/src/cascades/optimizer.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 use super::{
-    memo::{GroupInfo, RelMemoNodeRef},
+    memo::{Group, GroupInfo, RelMemoNodeRef},
     tasks::OptimizeGroupTask,
     Memo, Task,
 };
@@ -113,7 +113,9 @@ impl<T: RelNodeTyp> CascadesOptimizer<T> {
             for expr_id in self.memo.get_all_exprs_in_group(group_id) {
                 let memo_node = self.memo.get_expr_memoed(expr_id);
                 println!("  expr_id={} | {}", expr_id, memo_node);
-                let bindings = self.memo.get_all_expr_bindings(expr_id, false, Some(1));
+                let bindings = self
+                    .memo
+                    .get_all_expr_bindings(expr_id, false, true, Some(1));
                 for binding in bindings {
                     println!("    {}", binding);
                 }
@@ -189,15 +191,13 @@ impl<T: RelNodeTyp> CascadesOptimizer<T> {
         expr_id: ExprId,
         level: Option<usize>,
     ) -> Vec<RelNodeRef<T>> {
-        self.memo.get_all_expr_bindings(expr_id, false, level)
+        self.memo
+            .get_all_expr_bindings(expr_id, false, false, level)
     }
 
-    pub(super) fn get_all_expr_physical_bindings(
-        &self,
-        expr_id: ExprId,
-        level: Option<usize>,
-    ) -> Vec<RelNodeRef<T>> {
-        self.memo.get_all_expr_bindings(expr_id, true, level)
+    pub fn get_all_group_physical_bindings(&self, group_id: GroupId) -> Vec<RelNodeRef<T>> {
+        self.memo
+            .get_all_group_bindings(group_id, true, true, Some(10))
     }
 
     pub(super) fn is_group_explored(&self, group_id: GroupId) -> bool {

--- a/optd-datafusion-repr/src/lib.rs
+++ b/optd-datafusion-repr/src/lib.rs
@@ -11,7 +11,7 @@ pub use optd_core::rel_node::Value;
 use optd_core::{cascades::CascadesOptimizer, optimizer::Optimizer};
 use plan_nodes::{OptRelNodeRef, OptRelNodeTyp};
 use properties::schema::{Catalog, Schema, SchemaPropertyBuilder};
-use rules::{HashJoinRule, JoinCommuteRule, PhysicalConversionRule};
+use rules::{HashJoinRule, JoinAssocRule, JoinCommuteRule, PhysicalConversionRule};
 
 pub mod cost;
 pub mod plan_nodes;
@@ -23,10 +23,15 @@ pub struct DatafusionOptimizer {
 }
 
 impl DatafusionOptimizer {
+    pub fn optd_optimizer(&self) -> &CascadesOptimizer<OptRelNodeTyp> {
+        &self.optimizer
+    }
+
     pub fn new_physical(catalog: Box<dyn Catalog>) -> Self {
         let mut rules = PhysicalConversionRule::all_conversions();
         rules.push(Arc::new(HashJoinRule::new()));
         rules.push(Arc::new(JoinCommuteRule::new()));
+        rules.push(Arc::new(JoinAssocRule::new()));
         Self {
             optimizer: CascadesOptimizer::new(
                 rules,

--- a/optd-datafusion-repr/src/rules/joins.rs
+++ b/optd-datafusion-repr/src/rules/joins.rs
@@ -19,39 +19,39 @@ define_rule!(
     (Join(JoinType::Inner), left, right, [cond])
 );
 
-fn rewrite_column_refs(expr: Expr, left_size: usize, right_size: usize) -> Expr {
-    let expr = expr.into_rel_node();
-    if let Some(expr) = ColumnRefExpr::from_rel_node(expr.clone()) {
-        let index = expr.index();
-        if index < left_size {
-            return ColumnRefExpr::new(index + right_size).into_expr();
-        } else {
-            return ColumnRefExpr::new(index - left_size).into_expr();
-        }
-    }
-    let children = expr.children.clone();
-    let children = children
-        .into_iter()
-        .map(|x| {
-            rewrite_column_refs(Expr::from_rel_node(x).unwrap(), left_size, right_size)
-                .into_rel_node()
-        })
-        .collect_vec();
-    Expr::from_rel_node(
-        RelNode {
-            typ: expr.typ.clone(),
-            children,
-            data: expr.data.clone(),
-        }
-        .into(),
-    )
-    .unwrap()
-}
-
 fn apply_join_commute(
     optimizer: &impl Optimizer<OptRelNodeTyp>,
     JoinCommuteRulePicks { left, right, cond }: JoinCommuteRulePicks,
 ) -> Vec<RelNode<OptRelNodeTyp>> {
+    fn rewrite_column_refs(expr: Expr, left_size: usize, right_size: usize) -> Expr {
+        let expr = expr.into_rel_node();
+        if let Some(expr) = ColumnRefExpr::from_rel_node(expr.clone()) {
+            let index = expr.index();
+            if index < left_size {
+                return ColumnRefExpr::new(index + right_size).into_expr();
+            } else {
+                return ColumnRefExpr::new(index - left_size).into_expr();
+            }
+        }
+        let children = expr.children.clone();
+        let children = children
+            .into_iter()
+            .map(|x| {
+                rewrite_column_refs(Expr::from_rel_node(x).unwrap(), left_size, right_size)
+                    .into_rel_node()
+            })
+            .collect_vec();
+        Expr::from_rel_node(
+            RelNode {
+                typ: expr.typ.clone(),
+                children,
+                data: expr.data.clone(),
+            }
+            .into(),
+        )
+        .unwrap()
+    }
+
     let left_schema = optimizer.get_property::<SchemaPropertyBuilder>(Arc::new(left.clone()), 0);
     let right_schema = optimizer.get_property::<SchemaPropertyBuilder>(Arc::new(right.clone()), 0);
     let cond = rewrite_column_refs(
@@ -82,14 +82,14 @@ define_rule!(
     apply_join_assoc,
     (
         Join(JoinType::Inner),
-        (Join(JoinType::Inner), a, b, cond1),
+        (Join(JoinType::Inner), a, b, [cond1]),
         c,
-        cond2
+        [cond2]
     )
 );
 
 fn apply_join_assoc(
-    _optimizer: &impl Optimizer<OptRelNodeTyp>,
+    optimizer: &impl Optimizer<OptRelNodeTyp>,
     JoinAssocRulePicks {
         a,
         b,
@@ -98,13 +98,53 @@ fn apply_join_assoc(
         cond2,
     }: JoinAssocRulePicks,
 ) -> Vec<RelNode<OptRelNodeTyp>> {
+    fn rewrite_column_refs(expr: Expr, a_size: usize) -> Option<Expr> {
+        let expr = expr.into_rel_node();
+        if let Some(expr) = ColumnRefExpr::from_rel_node(expr.clone()) {
+            let index = expr.index();
+            if index < a_size {
+                return None;
+            } else {
+                return Some(ColumnRefExpr::new(index - a_size).into_expr());
+            }
+        }
+        let children = expr.children.clone();
+        let children = children
+            .into_iter()
+            .map(|x| rewrite_column_refs(Expr::from_rel_node(x).unwrap(), a_size))
+            .collect::<Option<Vec<_>>>()?;
+        Some(
+            Expr::from_rel_node(
+                RelNode {
+                    typ: expr.typ.clone(),
+                    children: children
+                        .into_iter()
+                        .map(|x| x.into_rel_node())
+                        .collect_vec(),
+                    data: expr.data.clone(),
+                }
+                .into(),
+            )
+            .unwrap(),
+        )
+    }
+    let a_schema = optimizer.get_property::<SchemaPropertyBuilder>(Arc::new(a.clone()), 0);
+    let b_schema = optimizer.get_property::<SchemaPropertyBuilder>(Arc::new(b.clone()), 0);
+    let c_schema = optimizer.get_property::<SchemaPropertyBuilder>(Arc::new(c.clone()), 0);
+    println!(
+        "rule fired for a={a}, b={b}, c={c}, cond1={cond1}, cond2={cond2}, a_schema={a_schema:?}, b_schema={b_schema:?}, c_schema={c_schema:?}",
+    );
+    let cond2 = Expr::from_rel_node(cond2.into()).unwrap();
+    let Some(cond2) = rewrite_column_refs(cond2, a_schema.len()) else {
+        return vec![];
+    };
     let node = RelNode {
         typ: OptRelNodeTyp::Join(JoinType::Inner),
         children: vec![
             a.into(),
             RelNode {
                 typ: OptRelNodeTyp::Join(JoinType::Inner),
-                children: vec![b.into(), c.into(), cond2.into()],
+                children: vec![b.into(), c.into(), cond2.into_rel_node()],
                 data: None,
             }
             .into(),
@@ -166,3 +206,36 @@ fn apply_hash_join(
     }
     vec![]
 }
+
+// define_rule!(
+//     ProjectionPullUpJoin,
+//     apply_projection_pull_up_join,
+//     (
+//         Join(JoinType::Inner),
+//         (Projection, left, [list]),
+//         right,
+//         [cond]
+//     )
+// );
+
+// fn apply_projection_pull_up_join(
+//     optimizer: &impl Optimizer<OptRelNodeTyp>,
+//     ProjectionPullUpJoinPicks {
+//         left,
+//         right,
+//         list,
+//         cond,
+//     }: ProjectionPullUpJoinPicks,
+// ) -> Vec<RelNode<OptRelNodeTyp>> {
+//     let list = ExprList::from_rel_node(cond.into()).unwrap();
+//     if list
+//         .to_vec()
+//         .iter()
+//         .any(|x| x.typ() != OptRelNodeTyp::ColumnRef)
+//     {
+//         return vec![];
+//     }
+//     let left_schema = optimizer.get_property::<SchemaPropertyBuilder>(Arc::new(left.clone()), 0);
+//     let right_schema = optimizer.get_property::<SchemaPropertyBuilder>(Arc::new(right.clone()), 0);
+//     vec![node]
+// }

--- a/test2.sql
+++ b/test2.sql
@@ -1,0 +1,8 @@
+create table t1(t1v1 int, t1v2 int);
+create table t2(t2v1 int);
+create table t3(t3v2 int);
+insert into t1 values (0, 0), (1, 1), (2, 2);
+insert into t2 values (0), (1), (2);
+insert into t3 values (0), (1), (2);
+
+select * from t2, t1, t3 where t1v1 = t2v1 and t1v2 = t3v2;


### PR DESCRIPTION
this only works for t2, t1, t3 for now. if it is t1, t2, t3, we will need join commute before assoc, and we will need to pull projection up through join in order to apply the join assoc rule.

also added a utility function for printing join ordering.