### PR TITLE
test: add tpc-h q8 and fix expression parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
  "arrow-json",
  "arrow-ord",
  "arrow-row",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "arrow-select",
  "arrow-string",
 ]
@@ -168,7 +168,7 @@ dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "chrono",
  "half",
  "num",
@@ -183,7 +183,7 @@ dependencies = [
  "ahash",
  "arrow-buffer",
  "arrow-data",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "chrono",
  "chrono-tz",
  "half",
@@ -211,7 +211,7 @@ dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "arrow-select",
  "chrono",
  "comfy-table",
@@ -230,7 +230,7 @@ dependencies = [
  "arrow-buffer",
  "arrow-cast",
  "arrow-data",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "chrono",
  "csv",
  "csv-core",
@@ -246,7 +246,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "475a4c3699c8b4095ca61cecf15da6f67841847a5f5aac983ccb9a377d02f73a"
 dependencies = [
  "arrow-buffer",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "half",
  "num",
 ]
@@ -261,7 +261,7 @@ dependencies = [
  "arrow-buffer",
  "arrow-cast",
  "arrow-data",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "flatbuffers",
 ]
 
@@ -275,7 +275,7 @@ dependencies = [
  "arrow-buffer",
  "arrow-cast",
  "arrow-data",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "chrono",
  "half",
  "indexmap 2.1.0",
@@ -294,7 +294,7 @@ dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "arrow-select",
  "half",
  "num",
@@ -310,7 +310,7 @@ dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "half",
  "hashbrown 0.14.3",
 ]
@@ -322,12 +322,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d1d179c117b158853e0101bfbed5615e86fe97ee356b4af901f1c5001e1ce4b"
 
 [[package]]
-name = "arrow-schema"
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e28a5e781bf1b0f981333684ad13f5901f4cd2f20589eab7cf1797da8fc167"
-
-[[package]]
 name = "arrow-select"
 version = "47.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,7 +331,7 @@ dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "num",
 ]
 
@@ -350,7 +344,7 @@ dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "arrow-select",
  "num",
  "regex",
@@ -1150,7 +1144,7 @@ dependencies = [
  "apache-avro",
  "arrow",
  "arrow-array",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "async-compression",
  "async-trait",
  "bytes",
@@ -1201,7 +1195,7 @@ dependencies = [
  "arrow",
  "arrow-array",
  "arrow-buffer",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "chrono",
  "half",
  "num_cpus",
@@ -1303,7 +1297,7 @@ dependencies = [
  "arrow",
  "arrow-array",
  "arrow-buffer",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "base64",
  "blake2",
  "blake3",
@@ -1337,7 +1331,7 @@ dependencies = [
  "arrow",
  "arrow-array",
  "arrow-buffer",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "async-trait",
  "chrono",
  "datafusion-common",
@@ -1365,7 +1359,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b568d44c87ead99604d704f942e257c8a236ee1bbf890ee3e034ad659dcb2c21"
 dependencies = [
  "arrow",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "datafusion-common",
  "datafusion-expr",
  "log",
@@ -2486,7 +2480,7 @@ name = "optd-datafusion-bridge"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "arrow-schema 49.0.0",
+ "arrow-schema",
  "async-recursion",
  "async-trait",
  "datafusion",
@@ -2617,7 +2611,7 @@ dependencies = [
  "arrow-cast",
  "arrow-data",
  "arrow-ipc",
- "arrow-schema 47.0.0",
+ "arrow-schema",
  "arrow-select",
  "base64",
  "brotli",

--- a/optd-core/src/rel_node.rs
+++ b/optd-core/src/rel_node.rs
@@ -38,6 +38,8 @@ pub enum Value {
     Float(OrderedFloat<f64>),
     String(Arc<str>),
     Bool(bool),
+    Date32(i32),
+    Decimal128(i128),
     Serialized(Arc<[u8]>),
 }
 
@@ -55,6 +57,8 @@ impl std::fmt::Display for Value {
             Self::Float(x) => write!(f, "{x}"),
             Self::String(x) => write!(f, "\"{x}\""),
             Self::Bool(x) => write!(f, "{x}"),
+            Self::Date32(x) => write!(f, "{x}"),
+            Self::Decimal128(x) => write!(f, "{x}"),
             Self::Serialized(x) => write!(f, "<len:{}>", x.len()),
         }
     }

--- a/optd-datafusion-bridge/Cargo.toml
+++ b/optd-datafusion-bridge/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arrow-schema = "*"
+arrow-schema = "47.0.0"
 datafusion = "32.0.0"
 datafusion-expr = "32.0.0"
 async-trait = "0.1"

--- a/optd-datafusion-repr/src/plan_nodes.rs
+++ b/optd-datafusion-repr/src/plan_nodes.rs
@@ -23,8 +23,9 @@ pub use agg::{LogicalAgg, PhysicalAgg};
 pub use apply::{ApplyType, LogicalApply};
 pub use empty_relation::{LogicalEmptyRelation, PhysicalEmptyRelation};
 pub use expr::{
-    BinOpExpr, BinOpType, ColumnRefExpr, ConstantExpr, ConstantType, ExprList, FuncExpr, FuncType,
-    LogOpExpr, LogOpType, SortOrderExpr, SortOrderType, UnOpExpr, UnOpType,
+    BetweenExpr, BinOpExpr, BinOpType, CastExpr, ColumnRefExpr, ConstantExpr, ConstantType,
+    ExprList, FuncExpr, FuncType, LogOpExpr, LogOpType, SortOrderExpr, SortOrderType, UnOpExpr,
+    UnOpType,
 };
 pub use filter::{LogicalFilter, PhysicalFilter};
 pub use join::{JoinType, LogicalJoin, PhysicalHashJoin, PhysicalNestedLoopJoin};
@@ -73,6 +74,8 @@ pub enum OptRelNodeTyp {
     LogOp(LogOpType),
     Func(FuncType),
     SortOrder(SortOrderType),
+    Between,
+    Cast,
 }
 
 impl OptRelNodeTyp {
@@ -111,6 +114,8 @@ impl OptRelNodeTyp {
                 | Self::Func(_)
                 | Self::SortOrder(_)
                 | Self::LogOp(_)
+                | Self::Between
+                | Self::Cast
         )
     }
 }
@@ -369,6 +374,12 @@ pub fn explain(rel_node: OptRelNodeRef) -> Pretty<'static> {
             .unwrap()
             .dispatch_explain(),
         OptRelNodeTyp::PhysicalLimit => PhysicalLimit::from_rel_node(rel_node)
+            .unwrap()
+            .dispatch_explain(),
+        OptRelNodeTyp::Between => BetweenExpr::from_rel_node(rel_node)
+            .unwrap()
+            .dispatch_explain(),
+        OptRelNodeTyp::Cast => CastExpr::from_rel_node(rel_node)
             .unwrap()
             .dispatch_explain(),
     }

--- a/optd-sqlplannertest/tests/tpch.planner.sql
+++ b/optd-sqlplannertest/tests/tpch.planner.sql
@@ -1,0 +1,302 @@
+-- TPC-H schema
+CREATE TABLE NATION  (
+    N_NATIONKEY  INT NOT NULL,
+    N_NAME       CHAR(25) NOT NULL,
+    N_REGIONKEY  INT NOT NULL,
+    N_COMMENT    VARCHAR(152)
+);
+
+CREATE TABLE REGION  (
+    R_REGIONKEY  INT NOT NULL,
+    R_NAME       CHAR(25) NOT NULL,
+    R_COMMENT    VARCHAR(152)
+);
+
+CREATE TABLE PART  (
+    P_PARTKEY     INT NOT NULL,
+    P_NAME        VARCHAR(55) NOT NULL,
+    P_MFGR        CHAR(25) NOT NULL,
+    P_BRAND       CHAR(10) NOT NULL,
+    P_TYPE        VARCHAR(25) NOT NULL,
+    P_SIZE        INT NOT NULL,
+    P_CONTAINER   CHAR(10) NOT NULL,
+    P_RETAILPRICE DECIMAL(15,2) NOT NULL,
+    P_COMMENT     VARCHAR(23) NOT NULL
+);
+
+CREATE TABLE SUPPLIER (
+    S_SUPPKEY     INT NOT NULL,
+    S_NAME        CHAR(25) NOT NULL,
+    S_ADDRESS     VARCHAR(40) NOT NULL,
+    S_NATIONKEY   INT NOT NULL,
+    S_PHONE       CHAR(15) NOT NULL,
+    S_ACCTBAL     DECIMAL(15,2) NOT NULL,
+    S_COMMENT     VARCHAR(101) NOT NULL
+);
+
+CREATE TABLE PARTSUPP (
+    PS_PARTKEY     INT NOT NULL,
+    PS_SUPPKEY     INT NOT NULL,
+    PS_AVAILQTY    INT NOT NULL,
+    PS_SUPPLYCOST  DECIMAL(15,2)  NOT NULL,
+    PS_COMMENT     VARCHAR(199) NOT NULL
+);
+
+CREATE TABLE CUSTOMER (
+    C_CUSTKEY     INT NOT NULL,
+    C_NAME        VARCHAR(25) NOT NULL,
+    C_ADDRESS     VARCHAR(40) NOT NULL,
+    C_NATIONKEY   INT NOT NULL,
+    C_PHONE       CHAR(15) NOT NULL,
+    C_ACCTBAL     DECIMAL(15,2)   NOT NULL,
+    C_MKTSEGMENT  CHAR(10) NOT NULL,
+    C_COMMENT     VARCHAR(117) NOT NULL
+);
+
+CREATE TABLE ORDERS (
+    O_ORDERKEY       INT NOT NULL,
+    O_CUSTKEY        INT NOT NULL,
+    O_ORDERSTATUS    CHAR(1) NOT NULL,
+    O_TOTALPRICE     DECIMAL(15,2) NOT NULL,
+    O_ORDERDATE      DATE NOT NULL,
+    O_ORDERPRIORITY  CHAR(15) NOT NULL,  
+    O_CLERK          CHAR(15) NOT NULL, 
+    O_SHIPPRIORITY   INT NOT NULL,
+    O_COMMENT        VARCHAR(79) NOT NULL
+);
+
+CREATE TABLE LINEITEM (
+    L_ORDERKEY      INT NOT NULL,
+    L_PARTKEY       INT NOT NULL,
+    L_SUPPKEY       INT NOT NULL,
+    L_LINENUMBER    INT NOT NULL,
+    L_QUANTITY      DECIMAL(15,2) NOT NULL,
+    L_EXTENDEDPRICE DECIMAL(15,2) NOT NULL,
+    L_DISCOUNT      DECIMAL(15,2) NOT NULL,
+    L_TAX           DECIMAL(15,2) NOT NULL,
+    L_RETURNFLAG    CHAR(1) NOT NULL,
+    L_LINESTATUS    CHAR(1) NOT NULL,
+    L_SHIPDATE      DATE NOT NULL,
+    L_COMMITDATE    DATE NOT NULL,
+    L_RECEIPTDATE   DATE NOT NULL,
+    L_SHIPINSTRUCT  CHAR(25) NOT NULL,
+    L_SHIPMODE      CHAR(10) NOT NULL,
+    L_COMMENT       VARCHAR(44) NOT NULL
+);
+
+/*
+
+*/
+
+-- TPC-H Q8 without top-most limit node
+select
+    o_year,
+    sum(case
+        when nation = 'IRAQ' then volume
+        else 0
+    end) / sum(volume) as mkt_share
+from
+    (
+        select
+            extract(year from o_orderdate) as o_year,
+            l_extendedprice * (1 - l_discount) as volume,
+            n2.n_name as nation
+        from
+            part,
+            supplier,
+            lineitem,
+            orders,
+            customer,
+            nation n1,
+            nation n2,
+            region
+        where
+            p_partkey = l_partkey
+            and s_suppkey = l_suppkey
+            and l_orderkey = o_orderkey
+            and o_custkey = c_custkey
+            and c_nationkey = n1.n_nationkey
+            and n1.n_regionkey = r_regionkey
+            and r_name = 'AMERICA'
+            and s_nationkey = n2.n_nationkey
+            and o_orderdate between date '1995-01-01' and date '1996-12-31'
+            and p_type = 'ECONOMY ANODIZED STEEL'
+    ) as all_nations
+group by
+    o_year
+order by
+    o_year;
+
+/*
+LogicalSort
+├── exprs:SortOrder { order: Asc }
+│   └── #0
+└── LogicalProjection
+    ├── exprs:
+    │   ┌── #0
+    │   └── Div
+    │       ├── #1
+    │       └── #2
+    └── LogicalAgg
+        ├── exprs:
+        │   ┌── Agg(Sum)
+        │   │   └── Case
+        │   │       └── 
+        │   │           ┌── Eq
+        │   │           │   ├── #2
+        │   │           │   └── "IRAQ"
+        │   │           ├── #1
+        │   │           └── Cast { cast_to: Decimal128(0), expr: 0 }
+        │   └── Agg(Sum)
+        │       └── [ #1 ]
+        ├── groups: [ #0 ]
+        └── LogicalProjection
+            ├── exprs:
+            │   ┌── Scalar(DatePart)
+            │   │   └── [ "YEAR", #36 ]
+            │   ├── Mul
+            │   │   ├── #21
+            │   │   └── Sub
+            │   │       ├── Cast { cast_to: Decimal128(0), expr: 1 }
+            │   │       └── #22
+            │   └── #54
+            └── LogicalFilter
+                ├── cond:And
+                │   ├── And
+                │   │   ├── And
+                │   │   │   ├── And
+                │   │   │   │   ├── And
+                │   │   │   │   │   ├── And
+                │   │   │   │   │   │   ├── And
+                │   │   │   │   │   │   │   ├── And
+                │   │   │   │   │   │   │   │   ├── And
+                │   │   │   │   │   │   │   │   │   ├── Eq
+                │   │   │   │   │   │   │   │   │   │   ├── #0
+                │   │   │   │   │   │   │   │   │   │   └── #17
+                │   │   │   │   │   │   │   │   │   └── Eq
+                │   │   │   │   │   │   │   │   │       ├── #9
+                │   │   │   │   │   │   │   │   │       └── #18
+                │   │   │   │   │   │   │   │   └── Eq
+                │   │   │   │   │   │   │   │       ├── #16
+                │   │   │   │   │   │   │   │       └── #32
+                │   │   │   │   │   │   │   └── Eq
+                │   │   │   │   │   │   │       ├── #33
+                │   │   │   │   │   │   │       └── #41
+                │   │   │   │   │   │   └── Eq
+                │   │   │   │   │   │       ├── #44
+                │   │   │   │   │   │       └── #49
+                │   │   │   │   │   └── Eq
+                │   │   │   │   │       ├── #51
+                │   │   │   │   │       └── #57
+                │   │   │   │   └── Eq
+                │   │   │   │       ├── #58
+                │   │   │   │       └── "AMERICA"
+                │   │   │   └── Eq
+                │   │   │       ├── #12
+                │   │   │       └── #53
+                │   │   └── Between { expr: #36, lower: Cast { cast_to: Date32(0), expr: "1995-01-01" }, upper: Cast { cast_to: Date32(0), expr: "1996-12-31" } }
+                │   └── Eq
+                │       ├── #4
+                │       └── "ECONOMY ANODIZED STEEL"
+                └── LogicalJoin { join_type: Cross, cond: true }
+                    ├── LogicalJoin { join_type: Cross, cond: true }
+                    │   ├── LogicalJoin { join_type: Cross, cond: true }
+                    │   │   ├── LogicalJoin { join_type: Cross, cond: true }
+                    │   │   │   ├── LogicalJoin { join_type: Cross, cond: true }
+                    │   │   │   │   ├── LogicalJoin { join_type: Cross, cond: true }
+                    │   │   │   │   │   ├── LogicalJoin { join_type: Cross, cond: true }
+                    │   │   │   │   │   │   ├── LogicalScan { table: part }
+                    │   │   │   │   │   │   └── LogicalScan { table: supplier }
+                    │   │   │   │   │   └── LogicalScan { table: lineitem }
+                    │   │   │   │   └── LogicalScan { table: orders }
+                    │   │   │   └── LogicalScan { table: customer }
+                    │   │   └── LogicalScan { table: nation }
+                    │   └── LogicalScan { table: nation }
+                    └── LogicalScan { table: region }
+PhysicalSort
+├── exprs:SortOrder { order: Asc }
+│   └── #0
+└── PhysicalProjection
+    ├── exprs:
+    │   ┌── #0
+    │   └── Div
+    │       ├── #1
+    │       └── #2
+    └── PhysicalAgg
+        ├── aggrs:
+        │   ┌── Agg(Sum)
+        │   │   └── Case
+        │   │       └── 
+        │   │           ┌── Eq
+        │   │           │   ├── #2
+        │   │           │   └── "IRAQ"
+        │   │           ├── #1
+        │   │           └── Cast { cast_to: Decimal128(0), expr: 0 }
+        │   └── Agg(Sum)
+        │       └── [ #1 ]
+        ├── groups: [ #0 ]
+        └── PhysicalProjection
+            ├── exprs:
+            │   ┌── Scalar(DatePart)
+            │   │   └── [ "YEAR", #36 ]
+            │   ├── Mul
+            │   │   ├── #21
+            │   │   └── Sub
+            │   │       ├── Cast { cast_to: Decimal128(0), expr: 1 }
+            │   │       └── #22
+            │   └── #54
+            └── PhysicalFilter
+                ├── cond:And
+                │   ├── And
+                │   │   ├── And
+                │   │   │   ├── And
+                │   │   │   │   ├── And
+                │   │   │   │   │   ├── And
+                │   │   │   │   │   │   ├── And
+                │   │   │   │   │   │   │   ├── And
+                │   │   │   │   │   │   │   │   ├── And
+                │   │   │   │   │   │   │   │   │   ├── Eq
+                │   │   │   │   │   │   │   │   │   │   ├── #0
+                │   │   │   │   │   │   │   │   │   │   └── #17
+                │   │   │   │   │   │   │   │   │   └── Eq
+                │   │   │   │   │   │   │   │   │       ├── #9
+                │   │   │   │   │   │   │   │   │       └── #18
+                │   │   │   │   │   │   │   │   └── Eq
+                │   │   │   │   │   │   │   │       ├── #16
+                │   │   │   │   │   │   │   │       └── #32
+                │   │   │   │   │   │   │   └── Eq
+                │   │   │   │   │   │   │       ├── #33
+                │   │   │   │   │   │   │       └── #41
+                │   │   │   │   │   │   └── Eq
+                │   │   │   │   │   │       ├── #44
+                │   │   │   │   │   │       └── #49
+                │   │   │   │   │   └── Eq
+                │   │   │   │   │       ├── #51
+                │   │   │   │   │       └── #57
+                │   │   │   │   └── Eq
+                │   │   │   │       ├── #58
+                │   │   │   │       └── "AMERICA"
+                │   │   │   └── Eq
+                │   │   │       ├── #12
+                │   │   │       └── #53
+                │   │   └── Between { expr: #36, lower: Cast { cast_to: Date32(0), expr: "1995-01-01" }, upper: Cast { cast_to: Date32(0), expr: "1996-12-31" } }
+                │   └── Eq
+                │       ├── #4
+                │       └── "ECONOMY ANODIZED STEEL"
+                └── PhysicalNestedLoopJoin { join_type: Cross, cond: true }
+                    ├── PhysicalNestedLoopJoin { join_type: Cross, cond: true }
+                    │   ├── PhysicalNestedLoopJoin { join_type: Cross, cond: true }
+                    │   │   ├── PhysicalNestedLoopJoin { join_type: Cross, cond: true }
+                    │   │   │   ├── PhysicalNestedLoopJoin { join_type: Cross, cond: true }
+                    │   │   │   │   ├── PhysicalNestedLoopJoin { join_type: Cross, cond: true }
+                    │   │   │   │   │   ├── PhysicalNestedLoopJoin { join_type: Cross, cond: true }
+                    │   │   │   │   │   │   ├── PhysicalScan { table: part }
+                    │   │   │   │   │   │   └── PhysicalScan { table: supplier }
+                    │   │   │   │   │   └── PhysicalScan { table: lineitem }
+                    │   │   │   │   └── PhysicalScan { table: orders }
+                    │   │   │   └── PhysicalScan { table: customer }
+                    │   │   └── PhysicalScan { table: nation }
+                    │   └── PhysicalScan { table: nation }
+                    └── PhysicalScan { table: region }
+*/
+

--- a/optd-sqlplannertest/tests/tpch.yml
+++ b/optd-sqlplannertest/tests/tpch.yml
@@ -1,0 +1,129 @@
+- sql: |
+      CREATE TABLE NATION  (
+          N_NATIONKEY  INT NOT NULL,
+          N_NAME       CHAR(25) NOT NULL,
+          N_REGIONKEY  INT NOT NULL,
+          N_COMMENT    VARCHAR(152)
+      );
+
+      CREATE TABLE REGION  (
+          R_REGIONKEY  INT NOT NULL,
+          R_NAME       CHAR(25) NOT NULL,
+          R_COMMENT    VARCHAR(152)
+      );
+
+      CREATE TABLE PART  (
+          P_PARTKEY     INT NOT NULL,
+          P_NAME        VARCHAR(55) NOT NULL,
+          P_MFGR        CHAR(25) NOT NULL,
+          P_BRAND       CHAR(10) NOT NULL,
+          P_TYPE        VARCHAR(25) NOT NULL,
+          P_SIZE        INT NOT NULL,
+          P_CONTAINER   CHAR(10) NOT NULL,
+          P_RETAILPRICE DECIMAL(15,2) NOT NULL,
+          P_COMMENT     VARCHAR(23) NOT NULL
+      );
+
+      CREATE TABLE SUPPLIER (
+          S_SUPPKEY     INT NOT NULL,
+          S_NAME        CHAR(25) NOT NULL,
+          S_ADDRESS     VARCHAR(40) NOT NULL,
+          S_NATIONKEY   INT NOT NULL,
+          S_PHONE       CHAR(15) NOT NULL,
+          S_ACCTBAL     DECIMAL(15,2) NOT NULL,
+          S_COMMENT     VARCHAR(101) NOT NULL
+      );
+
+      CREATE TABLE PARTSUPP (
+          PS_PARTKEY     INT NOT NULL,
+          PS_SUPPKEY     INT NOT NULL,
+          PS_AVAILQTY    INT NOT NULL,
+          PS_SUPPLYCOST  DECIMAL(15,2)  NOT NULL,
+          PS_COMMENT     VARCHAR(199) NOT NULL
+      );
+
+      CREATE TABLE CUSTOMER (
+          C_CUSTKEY     INT NOT NULL,
+          C_NAME        VARCHAR(25) NOT NULL,
+          C_ADDRESS     VARCHAR(40) NOT NULL,
+          C_NATIONKEY   INT NOT NULL,
+          C_PHONE       CHAR(15) NOT NULL,
+          C_ACCTBAL     DECIMAL(15,2)   NOT NULL,
+          C_MKTSEGMENT  CHAR(10) NOT NULL,
+          C_COMMENT     VARCHAR(117) NOT NULL
+      );
+
+      CREATE TABLE ORDERS (
+          O_ORDERKEY       INT NOT NULL,
+          O_CUSTKEY        INT NOT NULL,
+          O_ORDERSTATUS    CHAR(1) NOT NULL,
+          O_TOTALPRICE     DECIMAL(15,2) NOT NULL,
+          O_ORDERDATE      DATE NOT NULL,
+          O_ORDERPRIORITY  CHAR(15) NOT NULL,  
+          O_CLERK          CHAR(15) NOT NULL, 
+          O_SHIPPRIORITY   INT NOT NULL,
+          O_COMMENT        VARCHAR(79) NOT NULL
+      );
+
+      CREATE TABLE LINEITEM (
+          L_ORDERKEY      INT NOT NULL,
+          L_PARTKEY       INT NOT NULL,
+          L_SUPPKEY       INT NOT NULL,
+          L_LINENUMBER    INT NOT NULL,
+          L_QUANTITY      DECIMAL(15,2) NOT NULL,
+          L_EXTENDEDPRICE DECIMAL(15,2) NOT NULL,
+          L_DISCOUNT      DECIMAL(15,2) NOT NULL,
+          L_TAX           DECIMAL(15,2) NOT NULL,
+          L_RETURNFLAG    CHAR(1) NOT NULL,
+          L_LINESTATUS    CHAR(1) NOT NULL,
+          L_SHIPDATE      DATE NOT NULL,
+          L_COMMITDATE    DATE NOT NULL,
+          L_RECEIPTDATE   DATE NOT NULL,
+          L_SHIPINSTRUCT  CHAR(25) NOT NULL,
+          L_SHIPMODE      CHAR(10) NOT NULL,
+          L_COMMENT       VARCHAR(44) NOT NULL
+      );
+  desc: TPC-H schema
+  tasks:
+      - execute
+- sql: |
+      select
+          o_year,
+          sum(case
+              when nation = 'IRAQ' then volume
+              else 0
+          end) / sum(volume) as mkt_share
+      from
+          (
+              select
+                  extract(year from o_orderdate) as o_year,
+                  l_extendedprice * (1 - l_discount) as volume,
+                  n2.n_name as nation
+              from
+                  part,
+                  supplier,
+                  lineitem,
+                  orders,
+                  customer,
+                  nation n1,
+                  nation n2,
+                  region
+              where
+                  p_partkey = l_partkey
+                  and s_suppkey = l_suppkey
+                  and l_orderkey = o_orderkey
+                  and o_custkey = c_custkey
+                  and c_nationkey = n1.n_nationkey
+                  and n1.n_regionkey = r_regionkey
+                  and r_name = 'AMERICA'
+                  and s_nationkey = n2.n_nationkey
+                  and o_orderdate between date '1995-01-01' and date '1996-12-31'
+                  and p_type = 'ECONOMY ANODIZED STEEL'
+          ) as all_nations
+      group by
+          o_year
+      order by
+          o_year;
+  desc: TPC-H Q8 without top-most limit node
+  tasks:
+      - explain:logical_optd,physical_optd


### PR DESCRIPTION
TPC-H Q8 has been broken since cross join support b/c it adds join filter support but some expressions were not handled. This pull request adds tests for TPC-H Q8 and implements between + cast expressions. Note that the type inference is broken and someone should add a `Type` rel node to df-repr in order to process types correctly.