### PR TITLE
feat: implment column ref as logical property

### DIFF
--- a/datafusion-optd-cli/src/main.rs
+++ b/datafusion-optd-cli/src/main.rs
@@ -199,7 +199,7 @@ pub async fn main() -> Result<()> {
             state = state.with_physical_optimizer_rules(vec![]);
         }
         // use optd-bridge query planner
-        let optimizer = DatafusionOptimizer::new_physical(Box::new(DatafusionCatalog::new(
+        let optimizer = DatafusionOptimizer::new_physical(Arc::new(DatafusionCatalog::new(
             state.catalog_list(),
         )));
         state = state.with_query_planner(Arc::new(OptdQueryPlanner::new(optimizer)));

--- a/optd-adaptive-demo/src/bin/optd-adaptive-three-join.rs
+++ b/optd-adaptive-demo/src/bin/optd-adaptive-three-join.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<()> {
         let runtime_env = RuntimeEnv::new(rn_config.clone())?;
         let mut state =
             SessionState::new_with_config_rt(session_config.clone(), Arc::new(runtime_env));
-        let mut optimizer: DatafusionOptimizer = DatafusionOptimizer::new_physical(Box::new(
+        let mut optimizer: DatafusionOptimizer = DatafusionOptimizer::new_physical(Arc::new(
             DatafusionCatalog::new(state.catalog_list()),
         ));
         optimizer.optd_optimizer_mut().prop.partial_explore_iter = None;
@@ -45,7 +45,7 @@ async fn main() -> Result<()> {
         let mut state =
             SessionState::new_with_config_rt(session_config.clone(), Arc::new(runtime_env));
         let mut optimizer: DatafusionOptimizer =
-            DatafusionOptimizer::new_alternative_physical_for_demo(Box::new(
+            DatafusionOptimizer::new_alternative_physical_for_demo(Arc::new(
                 DatafusionCatalog::new(state.catalog_list()),
             ));
         optimizer.optd_optimizer_mut().prop.partial_explore_iter = None;

--- a/optd-adaptive-demo/src/bin/optd-adaptive-tpch-q8.rs
+++ b/optd-adaptive-demo/src/bin/optd-adaptive-tpch-q8.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<()> {
     let mut ctx = {
         let mut state =
             SessionState::new_with_config_rt(session_config.clone(), Arc::new(runtime_env));
-        let optimizer = DatafusionOptimizer::new_physical(Box::new(DatafusionCatalog::new(
+        let optimizer = DatafusionOptimizer::new_physical(Arc::new(DatafusionCatalog::new(
             state.catalog_list(),
         )));
         // clean up optimizer rules so that we can plug in our own optimizer

--- a/optd-datafusion-repr/src/properties.rs
+++ b/optd-datafusion-repr/src/properties.rs
@@ -1,1 +1,2 @@
+pub mod column_ref;
 pub mod schema;

--- a/optd-datafusion-repr/src/properties/column_ref.rs
+++ b/optd-datafusion-repr/src/properties/column_ref.rs
@@ -101,7 +101,7 @@ impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
             | OptRelNodeTyp::Limit
             | OptRelNodeTyp::SortOrder(_) => children[0].clone(),
             OptRelNodeTyp::Cast => {
-                // TODO: we just assume the column value does not change.
+                // FIXME: we just assume the column value does not change.
                 children[0].clone()
             }
             OptRelNodeTyp::Constant(_)
@@ -110,7 +110,7 @@ impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
             | OptRelNodeTyp::Between => {
                 vec![ColumnRef::Derived]
             }
-            _ => todo!("derive column ref for {:?}", typ),
+            _ => unimplemented!("Unsupported rel node type {:?}", typ),
         }
     }
 

--- a/optd-datafusion-repr/src/properties/column_ref.rs
+++ b/optd-datafusion-repr/src/properties/column_ref.rs
@@ -25,12 +25,7 @@ impl ColumnRefPropertyBuilder {
     }
 
     fn concat_children_properties(children: &[&GroupColumnRefs]) -> GroupColumnRefs {
-        children
-            .iter()
-            .map(Deref::deref)
-            .cloned()
-            .flatten()
-            .collect()
+        children.iter().flat_map(Deref::deref).cloned().collect()
     }
 }
 

--- a/optd-datafusion-repr/src/properties/column_ref.rs
+++ b/optd-datafusion-repr/src/properties/column_ref.rs
@@ -43,9 +43,7 @@ impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
         data: Option<optd_core::rel_node::Value>,
         children: &[&Self::Prop],
     ) -> Self::Prop {
-        // Print the params for debugging.
-        println!("typ: {:?}, data: {:?}, children: {:?}", typ, data, children);
-        let p = match typ {
+        match typ {
             // Should account for PhysicalScan.
             OptRelNodeTyp::Scan => {
                 let table_name = data.unwrap().as_str().to_string();
@@ -113,9 +111,7 @@ impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
                 vec![ColumnRef::Derived]
             }
             _ => todo!("derive column ref for {:?}", typ),
-        };
-        println!("p: {:?}", p);
-        p
+        }
     }
 
     fn property_name(&self) -> &'static str {

--- a/optd-datafusion-repr/src/properties/column_ref.rs
+++ b/optd-datafusion-repr/src/properties/column_ref.rs
@@ -1,0 +1,124 @@
+use std::{ops::Deref, sync::Arc};
+
+use optd_core::property::PropertyBuilder;
+
+use crate::plan_nodes::OptRelNodeTyp;
+
+use super::schema::Catalog;
+
+#[derive(Clone, Debug)]
+pub enum ColumnRef {
+    BaseTableColumnRef { table: String, col_idx: usize },
+    ChildColumnRef { col_idx: usize },
+    Derived,
+}
+
+pub type GroupColumnRefs = Vec<ColumnRef>;
+
+pub struct ColumnRefPropertyBuilder {
+    catalog: Arc<dyn Catalog>,
+}
+
+impl ColumnRefPropertyBuilder {
+    pub fn new(catalog: Arc<dyn Catalog>) -> Self {
+        Self { catalog }
+    }
+
+    fn concat_children_properties(children: &[&GroupColumnRefs]) -> GroupColumnRefs {
+        children
+            .iter()
+            .map(Deref::deref)
+            .cloned()
+            .flatten()
+            .collect()
+    }
+}
+
+impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
+    type Prop = GroupColumnRefs;
+
+    fn derive(
+        &self,
+        typ: OptRelNodeTyp,
+        data: Option<optd_core::rel_node::Value>,
+        children: &[&Self::Prop],
+    ) -> Self::Prop {
+        // Print the params for debugging.
+        println!("typ: {:?}, data: {:?}, children: {:?}", typ, data, children);
+        let p = match typ {
+            // Should account for PhysicalScan.
+            OptRelNodeTyp::Scan => {
+                let table_name = data.unwrap().as_str().to_string();
+                let schema = self.catalog.get(&table_name);
+                let column_cnt = schema.fields.len();
+                (0..column_cnt)
+                    .map(|i| ColumnRef::BaseTableColumnRef {
+                        table: table_name.clone(),
+                        col_idx: i,
+                    })
+                    .collect()
+            }
+            OptRelNodeTyp::ColumnRef => {
+                let col_idx = data.unwrap().as_i64();
+                vec![ColumnRef::ChildColumnRef {
+                    col_idx: col_idx as usize,
+                }]
+            }
+            OptRelNodeTyp::List => {
+                // Concatentate the children properties.
+                Self::concat_children_properties(children)
+            }
+            OptRelNodeTyp::Projection => children[1]
+                .iter()
+                .map(|p| match p {
+                    ColumnRef::ChildColumnRef { col_idx } => children[0][*col_idx].clone(),
+                    ColumnRef::Derived => ColumnRef::Derived,
+                    _ => panic!("projection expr must be Derived or ChildColumnRef"),
+                })
+                .collect(),
+            // Should account for all physical join types.
+            OptRelNodeTyp::Join(_) => {
+                // Concatenate left and right children properties.
+                Self::concat_children_properties(&children[0..2])
+            }
+            OptRelNodeTyp::Agg => {
+                // Group by columns first.
+                let mut group_by_col_refs: Vec<_> = children[2]
+                    .iter()
+                    .map(|p| {
+                        let col_idx = match p {
+                            ColumnRef::ChildColumnRef { col_idx } => *col_idx,
+                            _ => panic!("group by expr must be ColumnRef"),
+                        };
+                        children[0][col_idx].clone()
+                    })
+                    .collect();
+                // Then the aggregate expressions. These columns, (e.g. SUM, COUNT, etc.) are derived columns.
+                let agg_expr_cnt = children[1].len();
+                group_by_col_refs.extend((0..agg_expr_cnt).map(|_| ColumnRef::Derived));
+                group_by_col_refs
+            }
+            OptRelNodeTyp::Filter
+            | OptRelNodeTyp::Sort
+            | OptRelNodeTyp::Limit
+            | OptRelNodeTyp::SortOrder(_) => children[0].clone(),
+            OptRelNodeTyp::Cast => {
+                // TODO: we just assume the column value does not change.
+                children[0].clone()
+            }
+            OptRelNodeTyp::Constant(_)
+            | OptRelNodeTyp::Func(_)
+            | OptRelNodeTyp::BinOp(_)
+            | OptRelNodeTyp::Between => {
+                vec![ColumnRef::Derived]
+            }
+            _ => todo!("derive column ref for {:?}", typ),
+        };
+        println!("p: {:?}", p);
+        p
+    }
+
+    fn property_name(&self) -> &'static str {
+        "column_ref"
+    }
+}

--- a/optd-datafusion-repr/src/properties/column_ref.rs
+++ b/optd-datafusion-repr/src/properties/column_ref.rs
@@ -102,7 +102,8 @@ impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
             OptRelNodeTyp::Constant(_)
             | OptRelNodeTyp::Func(_)
             | OptRelNodeTyp::BinOp(_)
-            | OptRelNodeTyp::Between => {
+            | OptRelNodeTyp::Between
+            | OptRelNodeTyp::EmptyRelation => {
                 vec![ColumnRef::Derived]
             }
             _ => unimplemented!("Unsupported rel node type {:?}", typ),

--- a/optd-datafusion-repr/src/properties/schema.rs
+++ b/optd-datafusion-repr/src/properties/schema.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use optd_core::property::PropertyBuilder;
 
 use crate::plan_nodes::{ConstantType, OptRelNodeTyp};
@@ -28,11 +30,11 @@ pub trait Catalog: Send + Sync + 'static {
 }
 
 pub struct SchemaPropertyBuilder {
-    catalog: Box<dyn Catalog>,
+    catalog: Arc<dyn Catalog>,
 }
 
 impl SchemaPropertyBuilder {
-    pub fn new(catalog: Box<dyn Catalog>) -> Self {
+    pub fn new(catalog: Arc<dyn Catalog>) -> Self {
         Self { catalog }
     }
 }

--- a/optd-sqlplannertest/src/lib.rs
+++ b/optd-sqlplannertest/src/lib.rs
@@ -47,7 +47,7 @@ impl DatafusionDb {
         let ctx = {
             let mut state =
                 SessionState::new_with_config_rt(session_config.clone(), Arc::new(runtime_env));
-            let optimizer = DatafusionOptimizer::new_physical(Box::new(DatafusionCatalog::new(
+            let optimizer = DatafusionOptimizer::new_physical(Arc::new(DatafusionCatalog::new(
                 state.catalog_list(),
             )));
             if !with_logical {


### PR DESCRIPTION
Derive base table column ref for logical nodes, so that we can know which columns the `ColumnRef` objects in a predicate refers to.

Tested manually on the two demos. Not sure how to unit test it.