### PR TITLE
feat: support tpch q5 and q6

### DIFF
--- a/optd-datafusion-bridge/src/from_optd.rs
+++ b/optd-datafusion-bridge/src/from_optd.rs
@@ -49,6 +49,7 @@ fn from_optd_schema(optd_schema: OptdSchema) -> Schema {
         ConstantType::Int16 => DataType::Int16,
         ConstantType::Int32 => DataType::Int32,
         ConstantType::Int64 => DataType::Int64,
+        ConstantType::Float64 => DataType::Float64,
         ConstantType::Date => DataType::Date32,
         ConstantType::Decimal => DataType::Float64,
         ConstantType::Utf8String => DataType::Utf8,
@@ -145,6 +146,7 @@ impl OptdPlanContext<'_> {
                     ConstantType::Int16 => ScalarValue::Int16(Some(value.as_i16())),
                     ConstantType::Int32 => ScalarValue::Int32(Some(value.as_i32())),
                     ConstantType::Int64 => ScalarValue::Int64(Some(value.as_i64())),
+                    ConstantType::Float64 => ScalarValue::Float64(Some(value.as_f64())),
                     ConstantType::Decimal => {
                         ScalarValue::Decimal128(Some(value.as_f64() as i128), 20, 0)
                         // TODO(chi): no hard code decimal

--- a/optd-datafusion-bridge/src/from_optd.rs
+++ b/optd-datafusion-bridge/src/from_optd.rs
@@ -23,7 +23,7 @@ use datafusion::{
 use optd_datafusion_repr::{
     plan_nodes::{
         BetweenExpr, BinOpExpr, BinOpType, CastExpr, ColumnRefExpr, ConstantExpr, ConstantType,
-        Expr, ExprList, FuncExpr, FuncType, JoinType, LogOpExpr, LogOpType, OptRelNode,
+        Expr, ExprList, FuncExpr, FuncType, JoinType, LikeExpr, LogOpExpr, LogOpType, OptRelNode,
         OptRelNodeRef, OptRelNodeTyp, PhysicalAgg, PhysicalEmptyRelation, PhysicalFilter,
         PhysicalHashJoin, PhysicalLimit, PhysicalNestedLoopJoin, PhysicalProjection, PhysicalScan,
         PhysicalSort, PlanNode, SortOrderExpr, SortOrderType,
@@ -214,7 +214,9 @@ impl OptdPlanContext<'_> {
                     BinOpType::Eq => Operator::Eq,
                     BinOpType::Neq => Operator::NotEq,
                     BinOpType::Leq => Operator::LtEq,
+                    BinOpType::Lt => Operator::Lt,
                     BinOpType::Geq => Operator::GtEq,
+                    BinOpType::Gt => Operator::Gt,
                     BinOpType::And => Operator::And,
                     BinOpType::Add => Operator::Plus,
                     BinOpType::Sub => Operator::Minus,
@@ -254,6 +256,19 @@ impl OptdPlanContext<'_> {
                 };
                 Ok(Arc::new(
                     datafusion::physical_plan::expressions::CastExpr::new(child, data_type, None),
+                ))
+            }
+            OptRelNodeTyp::Like => {
+                let expr = LikeExpr::from_rel_node(expr.into_rel_node()).unwrap();
+                let child = Self::conv_from_optd_expr(expr.child(), context)?;
+                let pattern = Self::conv_from_optd_expr(expr.pattern(), context)?;
+                Ok(Arc::new(
+                    datafusion::physical_plan::expressions::LikeExpr::new(
+                        expr.negated(),
+                        expr.case_insensitive(),
+                        child,
+                        pattern,
+                    ),
                 ))
             }
             _ => unimplemented!("{}", expr.into_rel_node()),

--- a/optd-datafusion-bridge/src/into_optd.rs
+++ b/optd-datafusion-bridge/src/into_optd.rs
@@ -106,7 +106,7 @@ impl OptdPlanContext<'_> {
                 }
                 ScalarValue::Float64(x) => {
                     let x = x.as_ref().unwrap();
-                    Ok(ConstantExpr::decimal(*x).into_expr())
+                    Ok(ConstantExpr::float64(*x).into_expr())
                 }
                 ScalarValue::Utf8(x) => {
                     let x = x.as_ref().unwrap();

--- a/optd-datafusion-bridge/src/into_optd.rs
+++ b/optd-datafusion-bridge/src/into_optd.rs
@@ -104,6 +104,10 @@ impl OptdPlanContext<'_> {
                     let x = x.as_ref().unwrap();
                     Ok(ConstantExpr::int64(*x).into_expr())
                 }
+                ScalarValue::Float64(x) => {
+                    let x = x.as_ref().unwrap();
+                    Ok(ConstantExpr::decimal(*x).into_expr())
+                }
                 ScalarValue::Utf8(x) => {
                     let x = x.as_ref().unwrap();
                     Ok(ConstantExpr::string(x).into_expr())

--- a/optd-datafusion-bridge/src/into_optd.rs
+++ b/optd-datafusion-bridge/src/into_optd.rs
@@ -9,9 +9,10 @@ use optd_core::rel_node::RelNode;
 use optd_datafusion_repr::{
     plan_nodes::{
         BetweenExpr, BinOpExpr, BinOpType, CastExpr, ColumnRefExpr, ConstantExpr, Expr, ExprList,
-        FuncExpr, FuncType, JoinType, LogOpExpr, LogOpType, LogicalAgg, LogicalEmptyRelation,
-        LogicalFilter, LogicalJoin, LogicalLimit, LogicalProjection, LogicalScan, LogicalSort,
-        OptRelNode, OptRelNodeRef, OptRelNodeTyp, PlanNode, SortOrderExpr, SortOrderType,
+        FuncExpr, FuncType, JoinType, LikeExpr, LogOpExpr, LogOpType, LogicalAgg,
+        LogicalEmptyRelation, LogicalFilter, LogicalJoin, LogicalLimit, LogicalProjection,
+        LogicalScan, LogicalSort, OptRelNode, OptRelNodeRef, OptRelNodeTyp, PlanNode,
+        SortOrderExpr, SortOrderType,
     },
     Value,
 };
@@ -54,7 +55,9 @@ impl OptdPlanContext<'_> {
                     Operator::Eq => BinOpType::Eq,
                     Operator::NotEq => BinOpType::Neq,
                     Operator::LtEq => BinOpType::Leq,
+                    Operator::Lt => BinOpType::Lt,
                     Operator::GtEq => BinOpType::Geq,
+                    Operator::Gt => BinOpType::Gt,
                     Operator::And => BinOpType::And,
                     Operator::Plus => BinOpType::Add,
                     Operator::Minus => BinOpType::Sub,
@@ -166,11 +169,23 @@ impl OptdPlanContext<'_> {
                 let data_type = x.data_type.clone();
                 let val = match data_type {
                     arrow_schema::DataType::Int8 => Value::Int8(0),
+                    arrow_schema::DataType::Int16 => Value::Int16(0),
+                    arrow_schema::DataType::Int32 => Value::Int32(0),
+                    arrow_schema::DataType::Int64 => Value::Int64(0),
+                    arrow_schema::DataType::UInt8 => Value::UInt8(0),
+                    arrow_schema::DataType::UInt16 => Value::UInt16(0),
+                    arrow_schema::DataType::UInt32 => Value::UInt32(0),
+                    arrow_schema::DataType::UInt64 => Value::UInt64(0),
                     arrow_schema::DataType::Date32 => Value::Date32(0),
                     arrow_schema::DataType::Decimal128(_, _) => Value::Decimal128(0),
                     other => unimplemented!("unimplemented datatype {:?}", other),
                 };
                 Ok(CastExpr::new(expr, val).into_expr())
+            }
+            Expr::Like(x) => {
+                let expr = self.conv_into_optd_expr(x.expr.as_ref(), context)?;
+                let pattern = self.conv_into_optd_expr(x.pattern.as_ref(), context)?;
+                Ok(LikeExpr::new(x.negated, x.case_insensitive, expr, pattern).into_expr())
             }
             _ => bail!("Unsupported expression: {:?}", expr),
         }

--- a/optd-datafusion-repr/src/plan_nodes.rs
+++ b/optd-datafusion-repr/src/plan_nodes.rs
@@ -24,8 +24,8 @@ pub use apply::{ApplyType, LogicalApply};
 pub use empty_relation::{LogicalEmptyRelation, PhysicalEmptyRelation};
 pub use expr::{
     BetweenExpr, BinOpExpr, BinOpType, CastExpr, ColumnRefExpr, ConstantExpr, ConstantType,
-    ExprList, FuncExpr, FuncType, LogOpExpr, LogOpType, SortOrderExpr, SortOrderType, UnOpExpr,
-    UnOpType,
+    ExprList, FuncExpr, FuncType, LikeExpr, LogOpExpr, LogOpType, SortOrderExpr, SortOrderType,
+    UnOpExpr, UnOpType,
 };
 pub use filter::{LogicalFilter, PhysicalFilter};
 pub use join::{JoinType, LogicalJoin, PhysicalHashJoin, PhysicalNestedLoopJoin};
@@ -76,6 +76,7 @@ pub enum OptRelNodeTyp {
     SortOrder(SortOrderType),
     Between,
     Cast,
+    Like,
 }
 
 impl OptRelNodeTyp {
@@ -116,6 +117,7 @@ impl OptRelNodeTyp {
                 | Self::LogOp(_)
                 | Self::Between
                 | Self::Cast
+                | Self::Like
         )
     }
 }
@@ -380,6 +382,9 @@ pub fn explain(rel_node: OptRelNodeRef) -> Pretty<'static> {
             .unwrap()
             .dispatch_explain(),
         OptRelNodeTyp::Cast => CastExpr::from_rel_node(rel_node)
+            .unwrap()
+            .dispatch_explain(),
+        OptRelNodeTyp::Like => LikeExpr::from_rel_node(rel_node)
             .unwrap()
             .dispatch_explain(),
     }

--- a/optd-datafusion-repr/src/plan_nodes/expr.rs
+++ b/optd-datafusion-repr/src/plan_nodes/expr.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::{fmt::Display, sync::Arc};
 
 use itertools::Itertools;
 use pretty_xmlish::Pretty;
@@ -672,6 +672,71 @@ impl OptRelNode for CastExpr {
             vec![
                 ("cast_to", format!("{:?}", self.cast_to()).into()),
                 ("expr", self.child().explain()),
+            ],
+            vec![],
+        )
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct LikeExpr(pub Expr);
+
+impl LikeExpr {
+    pub fn new(negated: bool, case_insensitive: bool, expr: Expr, pattern: Expr) -> Self {
+        // TODO: support multiple values in data.
+        let negated = if negated { 1 } else { 0 };
+        let case_insensitive = if case_insensitive { 1 } else { 0 };
+        LikeExpr(Expr(
+            RelNode {
+                typ: OptRelNodeTyp::Like,
+                children: vec![expr.into_rel_node(), pattern.into_rel_node()],
+                data: Some(Value::Serialized(Arc::new([negated, case_insensitive]))),
+            }
+            .into(),
+        ))
+    }
+
+    pub fn child(&self) -> Expr {
+        Expr(self.0.child(0))
+    }
+
+    pub fn pattern(&self) -> Expr {
+        Expr(self.0.child(1))
+    }
+
+    pub fn negated(&self) -> bool {
+        match self.0 .0.data.as_ref().unwrap() {
+            Value::Serialized(data) => data[0] != 0,
+            _ => panic!("not a serialized value"),
+        }
+    }
+
+    pub fn case_insensitive(&self) -> bool {
+        match self.0 .0.data.as_ref().unwrap() {
+            Value::Serialized(data) => data[1] != 0,
+            _ => panic!("not a serialized value"),
+        }
+    }
+}
+
+impl OptRelNode for LikeExpr {
+    fn into_rel_node(self) -> OptRelNodeRef {
+        self.0.into_rel_node()
+    }
+
+    fn from_rel_node(rel_node: OptRelNodeRef) -> Option<Self> {
+        if !matches!(rel_node.typ, OptRelNodeTyp::Like) {
+            return None;
+        }
+        Expr::from_rel_node(rel_node).map(Self)
+    }
+
+    fn dispatch_explain(&self) -> Pretty<'static> {
+        Pretty::simple_record(
+            "Like",
+            vec![
+                ("expr", self.child().explain()),
+                ("pattern", self.pattern().explain()),
             ],
             vec![],
         )

--- a/optd-datafusion-repr/src/plan_nodes/expr.rs
+++ b/optd-datafusion-repr/src/plan_nodes/expr.rs
@@ -72,6 +72,7 @@ pub enum ConstantType {
     Int16,
     Int32,
     Int64,
+    Float64,
     Date,
     Decimal,
     Any,
@@ -93,7 +94,7 @@ impl ConstantExpr {
             Value::Int16(_) => ConstantType::Int16,
             Value::Int32(_) => ConstantType::Int32,
             Value::Int64(_) => ConstantType::Int64,
-            Value::Float(_) => ConstantType::Decimal,
+            Value::Float(_) => ConstantType::Float64,
             _ => unimplemented!(),
         };
         Self::new_with_type(value, typ)
@@ -151,6 +152,10 @@ impl ConstantExpr {
 
     pub fn int64(value: i64) -> Self {
         Self::new_with_type(Value::Int64(value), ConstantType::Int64)
+    }
+
+    pub fn float64(value: f64) -> Self {
+        Self::new_with_type(Value::Float(value.into()), ConstantType::Float64)
     }
 
     pub fn date(value: i64) -> Self {

--- a/optd-sqlplannertest/tests/tpch.planner.sql
+++ b/optd-sqlplannertest/tests/tpch.planner.sql
@@ -88,7 +88,7 @@ CREATE TABLE LINEITEM (
 
 */
 
--- TPC-H Q5 without top-most limit node
+-- TPC-H Q5
 SELECT
     n_name AS nation,
     SUM(l_extendedprice * (1 - l_discount)) AS revenue
@@ -107,8 +107,8 @@ WHERE
     AND s_nationkey = n_nationkey
     AND n_regionkey = r_regionkey
     AND r_name = 'Asia' -- Specified region
-    AND o_orderdate >= DATE '2023-01-01' -- Start of the specified year
-    AND o_orderdate < DATE '2024-01-01'  -- End of the specified year
+    AND o_orderdate >= DATE '2023-01-01'
+    AND o_orderdate < DATE '2024-01-01'
 GROUP BY
     n_name
 ORDER BY

--- a/optd-sqlplannertest/tests/tpch.planner.sql
+++ b/optd-sqlplannertest/tests/tpch.planner.sql
@@ -88,6 +88,153 @@ CREATE TABLE LINEITEM (
 
 */
 
+-- TPC-H Q5 without top-most limit node
+SELECT
+    n_name AS nation,
+    SUM(l_extendedprice * (1 - l_discount)) AS revenue
+FROM
+    customer,
+    orders,
+    lineitem,
+    supplier,
+    nation,
+    region
+WHERE
+    c_custkey = o_custkey
+    AND l_orderkey = o_orderkey
+    AND l_suppkey = s_suppkey
+    AND c_nationkey = s_nationkey
+    AND s_nationkey = n_nationkey
+    AND n_regionkey = r_regionkey
+    AND r_name = 'Asia' -- Specified region
+    AND o_orderdate >= DATE '2023-01-01' -- Start of the specified year
+    AND o_orderdate < DATE '2024-01-01'  -- End of the specified year
+GROUP BY
+    n_name
+ORDER BY
+    revenue DESC;
+
+/*
+LogicalSort
+├── exprs:SortOrder { order: Desc }
+│   └── #1
+└── LogicalProjection { exprs: [ #0, #1 ] }
+    └── LogicalAgg
+        ├── exprs:Agg(Sum)
+        │   └── Mul
+        │       ├── #22
+        │       └── Sub
+        │           ├── Cast { cast_to: Decimal128(0), expr: 1 }
+        │           └── #23
+        ├── groups: [ #41 ]
+        └── LogicalFilter
+            ├── cond:And
+            │   ├── And
+            │   │   ├── And
+            │   │   │   ├── And
+            │   │   │   │   ├── And
+            │   │   │   │   │   ├── And
+            │   │   │   │   │   │   ├── And
+            │   │   │   │   │   │   │   ├── And
+            │   │   │   │   │   │   │   │   ├── Eq
+            │   │   │   │   │   │   │   │   │   ├── #0
+            │   │   │   │   │   │   │   │   │   └── #9
+            │   │   │   │   │   │   │   │   └── Eq
+            │   │   │   │   │   │   │   │       ├── #17
+            │   │   │   │   │   │   │   │       └── #8
+            │   │   │   │   │   │   │   └── Eq
+            │   │   │   │   │   │   │       ├── #19
+            │   │   │   │   │   │   │       └── #33
+            │   │   │   │   │   │   └── Eq
+            │   │   │   │   │   │       ├── #3
+            │   │   │   │   │   │       └── #36
+            │   │   │   │   │   └── Eq
+            │   │   │   │   │       ├── #36
+            │   │   │   │   │       └── #40
+            │   │   │   │   └── Eq
+            │   │   │   │       ├── #42
+            │   │   │   │       └── #44
+            │   │   │   └── Eq
+            │   │   │       ├── #45
+            │   │   │       └── "Asia"
+            │   │   └── Geq
+            │   │       ├── #12
+            │   │       └── Cast { cast_to: Date32(0), expr: "2023-01-01" }
+            │   └── Lt
+            │       ├── #12
+            │       └── Cast { cast_to: Date32(0), expr: "2024-01-01" }
+            └── LogicalJoin { join_type: Cross, cond: true }
+                ├── LogicalJoin { join_type: Cross, cond: true }
+                │   ├── LogicalJoin { join_type: Cross, cond: true }
+                │   │   ├── LogicalJoin { join_type: Cross, cond: true }
+                │   │   │   ├── LogicalJoin { join_type: Cross, cond: true }
+                │   │   │   │   ├── LogicalScan { table: customer }
+                │   │   │   │   └── LogicalScan { table: orders }
+                │   │   │   └── LogicalScan { table: lineitem }
+                │   │   └── LogicalScan { table: supplier }
+                │   └── LogicalScan { table: nation }
+                └── LogicalScan { table: region }
+PhysicalSort
+├── exprs:SortOrder { order: Desc }
+│   └── #1
+└── PhysicalProjection { exprs: [ #0, #1 ] }
+    └── PhysicalAgg
+        ├── aggrs:Agg(Sum)
+        │   └── Mul
+        │       ├── #22
+        │       └── Sub
+        │           ├── Cast { cast_to: Decimal128(0), expr: 1 }
+        │           └── #23
+        ├── groups: [ #41 ]
+        └── PhysicalFilter
+            ├── cond:And
+            │   ├── And
+            │   │   ├── And
+            │   │   │   ├── And
+            │   │   │   │   ├── And
+            │   │   │   │   │   ├── And
+            │   │   │   │   │   │   ├── And
+            │   │   │   │   │   │   │   ├── And
+            │   │   │   │   │   │   │   │   ├── Eq
+            │   │   │   │   │   │   │   │   │   ├── #0
+            │   │   │   │   │   │   │   │   │   └── #9
+            │   │   │   │   │   │   │   │   └── Eq
+            │   │   │   │   │   │   │   │       ├── #17
+            │   │   │   │   │   │   │   │       └── #8
+            │   │   │   │   │   │   │   └── Eq
+            │   │   │   │   │   │   │       ├── #19
+            │   │   │   │   │   │   │       └── #33
+            │   │   │   │   │   │   └── Eq
+            │   │   │   │   │   │       ├── #3
+            │   │   │   │   │   │       └── #36
+            │   │   │   │   │   └── Eq
+            │   │   │   │   │       ├── #36
+            │   │   │   │   │       └── #40
+            │   │   │   │   └── Eq
+            │   │   │   │       ├── #42
+            │   │   │   │       └── #44
+            │   │   │   └── Eq
+            │   │   │       ├── #45
+            │   │   │       └── "Asia"
+            │   │   └── Geq
+            │   │       ├── #12
+            │   │       └── Cast { cast_to: Date32(0), expr: "2023-01-01" }
+            │   └── Lt
+            │       ├── #12
+            │       └── Cast { cast_to: Date32(0), expr: "2024-01-01" }
+            └── PhysicalNestedLoopJoin { join_type: Cross, cond: true }
+                ├── PhysicalNestedLoopJoin { join_type: Cross, cond: true }
+                │   ├── PhysicalNestedLoopJoin { join_type: Cross, cond: true }
+                │   │   ├── PhysicalNestedLoopJoin { join_type: Cross, cond: true }
+                │   │   │   ├── PhysicalNestedLoopJoin { join_type: Cross, cond: true }
+                │   │   │   │   ├── PhysicalScan { table: customer }
+                │   │   │   │   └── PhysicalScan { table: orders }
+                │   │   │   └── PhysicalScan { table: lineitem }
+                │   │   └── PhysicalScan { table: supplier }
+                │   └── PhysicalScan { table: nation }
+                └── PhysicalScan { table: region }
+*/
+
 -- TPC-H Q8 without top-most limit node
 select
     o_year,

--- a/optd-sqlplannertest/tests/tpch.planner.sql
+++ b/optd-sqlplannertest/tests/tpch.planner.sql
@@ -235,6 +235,64 @@ PhysicalSort
                 └── PhysicalScan { table: region }
 */
 
+-- TPC-H Q6
+SELECT
+    SUM(l_extendedprice * l_discount) AS revenue_loss
+FROM
+    lineitem
+WHERE
+    l_shipdate >= DATE '2023-01-01'
+    AND l_shipdate < DATE '2024-01-01'
+    AND l_discount BETWEEN 0.05 AND 0.07
+    AND l_quantity < 24;
+
+/*
+LogicalProjection { exprs: [ #0 ] }
+└── LogicalAgg
+    ├── exprs:Agg(Sum)
+    │   └── Mul
+    │       ├── #5
+    │       └── #6
+    ├── groups: []
+    └── LogicalFilter
+        ├── cond:And
+        │   ├── And
+        │   │   ├── And
+        │   │   │   ├── Geq
+        │   │   │   │   ├── #10
+        │   │   │   │   └── Cast { cast_to: Date32(0), expr: "2023-01-01" }
+        │   │   │   └── Lt
+        │   │   │       ├── #10
+        │   │   │       └── Cast { cast_to: Date32(0), expr: "2024-01-01" }
+        │   │   └── Between { expr: Cast { cast_to: Decimal128(0), expr: #6 }, lower: Cast { cast_to: Decimal128(0), expr: 0.05 }, upper: Cast { cast_to: Decimal128(0), expr: 0.07 } }
+        │   └── Lt
+        │       ├── Cast { cast_to: Decimal128(0), expr: #4 }
+        │       └── Cast { cast_to: Decimal128(0), expr: 24 }
+        └── LogicalScan { table: lineitem }
+PhysicalProjection { exprs: [ #0 ] }
+└── PhysicalAgg
+    ├── aggrs:Agg(Sum)
+    │   └── Mul
+    │       ├── #5
+    │       └── #6
+    ├── groups: []
+    └── PhysicalFilter
+        ├── cond:And
+        │   ├── And
+        │   │   ├── And
+        │   │   │   ├── Geq
+        │   │   │   │   ├── #10
+        │   │   │   │   └── Cast { cast_to: Date32(0), expr: "2023-01-01" }
+        │   │   │   └── Lt
+        │   │   │       ├── #10
+        │   │   │       └── Cast { cast_to: Date32(0), expr: "2024-01-01" }
+        │   │   └── Between { expr: Cast { cast_to: Decimal128(0), expr: #6 }, lower: Cast { cast_to: Decimal128(0), expr: 0.05 }, upper: Cast { cast_to: Decimal128(0), expr: 0.07 } }
+        │   └── Lt
+        │       ├── Cast { cast_to: Decimal128(0), expr: #4 }
+        │       └── Cast { cast_to: Decimal128(0), expr: 24 }
+        └── PhysicalScan { table: lineitem }
+*/
+
 -- TPC-H Q8 without top-most limit node
 select
     o_year,

--- a/optd-sqlplannertest/tests/tpch.yml
+++ b/optd-sqlplannertest/tests/tpch.yml
@@ -115,6 +115,19 @@
   tasks:
       - explain:logical_optd,physical_optd
 - sql: |
+      SELECT
+          SUM(l_extendedprice * l_discount) AS revenue_loss
+      FROM
+          lineitem
+      WHERE
+          l_shipdate >= DATE '2023-01-01'
+          AND l_shipdate < DATE '2024-01-01'
+          AND l_discount BETWEEN 0.05 AND 0.07
+          AND l_quantity < 24;
+  desc: TPC-H Q6
+  tasks:
+      - explain:logical_optd,physical_optd
+- sql: |
       select
           o_year,
           sum(case

--- a/optd-sqlplannertest/tests/tpch.yml
+++ b/optd-sqlplannertest/tests/tpch.yml
@@ -105,13 +105,13 @@
           AND s_nationkey = n_nationkey
           AND n_regionkey = r_regionkey
           AND r_name = 'Asia' -- Specified region
-          AND o_orderdate >= DATE '2023-01-01' -- Start of the specified year
-          AND o_orderdate < DATE '2024-01-01'  -- End of the specified year
+          AND o_orderdate >= DATE '2023-01-01'
+          AND o_orderdate < DATE '2024-01-01'
       GROUP BY
           n_name
       ORDER BY
           revenue DESC;
-  desc: TPC-H Q5 without top-most limit node
+  desc: TPC-H Q5
   tasks:
       - explain:logical_optd,physical_optd
 - sql: |

--- a/optd-sqlplannertest/tests/tpch.yml
+++ b/optd-sqlplannertest/tests/tpch.yml
@@ -87,6 +87,34 @@
   tasks:
       - execute
 - sql: |
+      SELECT
+          n_name AS nation,
+          SUM(l_extendedprice * (1 - l_discount)) AS revenue
+      FROM
+          customer,
+          orders,
+          lineitem,
+          supplier,
+          nation,
+          region
+      WHERE
+          c_custkey = o_custkey
+          AND l_orderkey = o_orderkey
+          AND l_suppkey = s_suppkey
+          AND c_nationkey = s_nationkey
+          AND s_nationkey = n_nationkey
+          AND n_regionkey = r_regionkey
+          AND r_name = 'Asia' -- Specified region
+          AND o_orderdate >= DATE '2023-01-01' -- Start of the specified year
+          AND o_orderdate < DATE '2024-01-01'  -- End of the specified year
+      GROUP BY
+          n_name
+      ORDER BY
+          revenue DESC;
+  desc: TPC-H Q5 without top-most limit node
+  tasks:
+      - explain:logical_optd,physical_optd
+- sql: |
       select
           o_year,
           sum(case


### PR DESCRIPTION
- Support gt and lt for bin op type
- Support `LikeExpr` (it's for Q2, but it turns out Q2 requires more work)
- Support for cast types 