### PR TITLE
feat: support IntervalMonthDayNano DF type

### DIFF
--- a/optd-core/src/rel_node.rs
+++ b/optd-core/src/rel_node.rs
@@ -35,6 +35,7 @@ pub enum Value {
     Int16(i16),
     Int32(i32),
     Int64(i64),
+    Int128(i128),
     Float(OrderedFloat<f64>),
     String(Arc<str>),
     Bool(bool),
@@ -54,6 +55,7 @@ impl std::fmt::Display for Value {
             Self::Int16(x) => write!(f, "{x}"),
             Self::Int32(x) => write!(f, "{x}"),
             Self::Int64(x) => write!(f, "{x}"),
+            Self::Int128(x) => write!(f, "{x}"),
             Self::Float(x) => write!(f, "{x}"),
             Self::String(x) => write!(f, "\"{x}\""),
             Self::Bool(x) => write!(f, "{x}"),
@@ -118,6 +120,13 @@ impl Value {
         match self {
             Value::Int64(i) => *i,
             _ => panic!("Value is not an i64"),
+        }
+    }
+
+    pub fn as_i128(&self) -> i128 {
+        match self {
+            Value::Int128(i) => *i,
+            _ => panic!("Value is not an i128"),
         }
     }
 

--- a/optd-datafusion-bridge/src/from_optd.rs
+++ b/optd-datafusion-bridge/src/from_optd.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use anyhow::{bail, Context, Result};
+use arrow_schema::IntervalUnit;
 use async_recursion::async_recursion;
 use datafusion::{
     arrow::datatypes::{DataType, Field, Schema, SchemaRef},
@@ -51,6 +52,7 @@ fn from_optd_schema(optd_schema: OptdSchema) -> Schema {
         ConstantType::Int64 => DataType::Int64,
         ConstantType::Float64 => DataType::Float64,
         ConstantType::Date => DataType::Date32,
+        ConstantType::IntervalMonthDateNano => DataType::Interval(IntervalUnit::MonthDayNano),
         ConstantType::Decimal => DataType::Float64,
         ConstantType::Utf8String => DataType::Utf8,
     };
@@ -152,6 +154,9 @@ impl OptdPlanContext<'_> {
                         // TODO(chi): no hard code decimal
                     }
                     ConstantType::Date => ScalarValue::Date32(Some(value.as_i64() as i32)),
+                    ConstantType::IntervalMonthDateNano => {
+                        ScalarValue::IntervalMonthDayNano(Some(value.as_i128()))
+                    }
                     ConstantType::Utf8String => ScalarValue::Utf8(Some(value.as_str().to_string())),
                     ConstantType::Any => unimplemented!(),
                 };

--- a/optd-datafusion-bridge/src/into_optd.rs
+++ b/optd-datafusion-bridge/src/into_optd.rs
@@ -113,6 +113,10 @@ impl OptdPlanContext<'_> {
                     let x = x.as_ref().unwrap();
                     Ok(ConstantExpr::date(*x as i64).into_expr())
                 }
+                ScalarValue::IntervalMonthDayNano(x) => {
+                    let x = x.as_ref().unwrap();
+                    Ok(ConstantExpr::interval_month_day_nano(*x).into_expr())
+                }
                 ScalarValue::Decimal128(x, _, _) => {
                     let x = x.as_ref().unwrap();
                     Ok(ConstantExpr::decimal(*x as f64).into_expr())

--- a/optd-sqlplannertest/tests/tpch.planner.sql
+++ b/optd-sqlplannertest/tests/tpch.planner.sql
@@ -88,6 +88,120 @@ CREATE TABLE LINEITEM (
 
 */
 
+-- TPC-H Q1
+SELECT
+    l_returnflag,
+    l_linestatus,
+    sum(l_quantity) as sum_qty,
+    sum(l_extendedprice) as sum_base_price,
+    sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
+    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
+    avg(l_quantity) as avg_qty,
+    avg(l_extendedprice) as avg_price,
+    avg(l_discount) as avg_disc,
+    count(*) as count_order
+FROM
+    lineitem
+WHERE
+    l_shipdate <= date '1998-12-01' - interval '90' day
+GROUP BY
+    l_returnflag, l_linestatus
+ORDER BY
+    l_returnflag, l_linestatus;
+
+/*
+LogicalSort
+├── exprs:
+│   ┌── SortOrder { order: Asc }
+│   │   └── #0
+│   └── SortOrder { order: Asc }
+│       └── #1
+└── LogicalProjection { exprs: [ #0, #1, #2, #3, #4, #5, #6, #7, #8, #9 ] }
+    └── LogicalAgg
+        ├── exprs:
+        │   ┌── Agg(Sum)
+        │   │   └── [ #4 ]
+        │   ├── Agg(Sum)
+        │   │   └── [ #5 ]
+        │   ├── Agg(Sum)
+        │   │   └── Mul
+        │   │       ├── #5
+        │   │       └── Sub
+        │   │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+        │   │           └── #6
+        │   ├── Agg(Sum)
+        │   │   └── Mul
+        │   │       ├── Mul
+        │   │       │   ├── #5
+        │   │       │   └── Sub
+        │   │       │       ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+        │   │       │       └── #6
+        │   │       └── Add
+        │   │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+        │   │           └── #7
+        │   ├── Agg(Avg)
+        │   │   └── [ #4 ]
+        │   ├── Agg(Avg)
+        │   │   └── [ #5 ]
+        │   ├── Agg(Avg)
+        │   │   └── [ #6 ]
+        │   └── Agg(Count)
+        │       └── [ 1 ]
+        ├── groups: [ #8, #9 ]
+        └── LogicalFilter
+            ├── cond:Leq
+            │   ├── #10
+            │   └── Sub
+            │       ├── Cast { cast_to: Date32, expr: "1998-12-01" }
+            │       └── INTERVAL_MONTH_DAY_NANO (0, 90, 0)
+            └── LogicalScan { table: lineitem }
+PhysicalSort
+├── exprs:
+│   ┌── SortOrder { order: Asc }
+│   │   └── #0
+│   └── SortOrder { order: Asc }
+│       └── #1
+└── PhysicalProjection { exprs: [ #0, #1, #2, #3, #4, #5, #6, #7, #8, #9 ] }
+    └── PhysicalAgg
+        ├── aggrs:
+        │   ┌── Agg(Sum)
+        │   │   └── [ #4 ]
+        │   ├── Agg(Sum)
+        │   │   └── [ #5 ]
+        │   ├── Agg(Sum)
+        │   │   └── Mul
+        │   │       ├── #5
+        │   │       └── Sub
+        │   │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+        │   │           └── #6
+        │   ├── Agg(Sum)
+        │   │   └── Mul
+        │   │       ├── Mul
+        │   │       │   ├── #5
+        │   │       │   └── Sub
+        │   │       │       ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+        │   │       │       └── #6
+        │   │       └── Add
+        │   │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+        │   │           └── #7
+        │   ├── Agg(Avg)
+        │   │   └── [ #4 ]
+        │   ├── Agg(Avg)
+        │   │   └── [ #5 ]
+        │   ├── Agg(Avg)
+        │   │   └── [ #6 ]
+        │   └── Agg(Count)
+        │       └── [ 1 ]
+        ├── groups: [ #8, #9 ]
+        └── PhysicalFilter
+            ├── cond:Leq
+            │   ├── #10
+            │   └── Sub
+            │       ├── Cast { cast_to: Date32, expr: "1998-12-01" }
+            │       └── INTERVAL_MONTH_DAY_NANO (0, 90, 0)
+            └── PhysicalScan { table: lineitem }
+*/
+
 -- TPC-H Q2
 select
         s_acctbal,
@@ -313,120 +427,6 @@ PhysicalLimit { skip: 0, fetch: 100 }
                                     │   └── "AFRICA"
                                     └── PhysicalProjection { exprs: [ #0, #1 ] }
                                         └── PhysicalScan { table: region }
-*/
-
--- TPC-H Q1
-SELECT
-    l_returnflag,
-    l_linestatus,
-    sum(l_quantity) as sum_qty,
-    sum(l_extendedprice) as sum_base_price,
-    sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
-    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
-    avg(l_quantity) as avg_qty,
-    avg(l_extendedprice) as avg_price,
-    avg(l_discount) as avg_disc,
-    count(*) as count_order
-FROM
-    lineitem
-WHERE
-    l_shipdate <= date '1998-12-01' - interval '90' day
-GROUP BY
-    l_returnflag, l_linestatus
-ORDER BY
-    l_returnflag, l_linestatus;
-
-/*
-LogicalSort
-├── exprs:
-│   ┌── SortOrder { order: Asc }
-│   │   └── #0
-│   └── SortOrder { order: Asc }
-│       └── #1
-└── LogicalProjection { exprs: [ #0, #1, #2, #3, #4, #5, #6, #7, #8, #9 ] }
-    └── LogicalAgg
-        ├── exprs:
-        │   ┌── Agg(Sum)
-        │   │   └── [ #4 ]
-        │   ├── Agg(Sum)
-        │   │   └── [ #5 ]
-        │   ├── Agg(Sum)
-        │   │   └── Mul
-        │   │       ├── #5
-        │   │       └── Sub
-        │   │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
-        │   │           └── #6
-        │   ├── Agg(Sum)
-        │   │   └── Mul
-        │   │       ├── Mul
-        │   │       │   ├── #5
-        │   │       │   └── Sub
-        │   │       │       ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
-        │   │       │       └── #6
-        │   │       └── Add
-        │   │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
-        │   │           └── #7
-        │   ├── Agg(Avg)
-        │   │   └── [ #4 ]
-        │   ├── Agg(Avg)
-        │   │   └── [ #5 ]
-        │   ├── Agg(Avg)
-        │   │   └── [ #6 ]
-        │   └── Agg(Count)
-        │       └── [ 1 ]
-        ├── groups: [ #8, #9 ]
-        └── LogicalFilter
-            ├── cond:Leq
-            │   ├── #10
-            │   └── Sub
-            │       ├── Cast { cast_to: Date32, expr: "1998-12-01" }
-            │       └── INTERVAL_MONTH_DAY_NANO (0, 90, 0)
-            └── LogicalScan { table: lineitem }
-PhysicalSort
-├── exprs:
-│   ┌── SortOrder { order: Asc }
-│   │   └── #0
-│   └── SortOrder { order: Asc }
-│       └── #1
-└── PhysicalProjection { exprs: [ #0, #1, #2, #3, #4, #5, #6, #7, #8, #9 ] }
-    └── PhysicalAgg
-        ├── aggrs:
-        │   ┌── Agg(Sum)
-        │   │   └── [ #4 ]
-        │   ├── Agg(Sum)
-        │   │   └── [ #5 ]
-        │   ├── Agg(Sum)
-        │   │   └── Mul
-        │   │       ├── #5
-        │   │       └── Sub
-        │   │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
-        │   │           └── #6
-        │   ├── Agg(Sum)
-        │   │   └── Mul
-        │   │       ├── Mul
-        │   │       │   ├── #5
-        │   │       │   └── Sub
-        │   │       │       ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
-        │   │       │       └── #6
-        │   │       └── Add
-        │   │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
-        │   │           └── #7
-        │   ├── Agg(Avg)
-        │   │   └── [ #4 ]
-        │   ├── Agg(Avg)
-        │   │   └── [ #5 ]
-        │   ├── Agg(Avg)
-        │   │   └── [ #6 ]
-        │   └── Agg(Count)
-        │       └── [ 1 ]
-        ├── groups: [ #8, #9 ]
-        └── PhysicalFilter
-            ├── cond:Leq
-            │   ├── #10
-            │   └── Sub
-            │       ├── Cast { cast_to: Date32, expr: "1998-12-01" }
-            │       └── INTERVAL_MONTH_DAY_NANO (0, 90, 0)
-            └── PhysicalScan { table: lineitem }
 */
 
 -- TPC-H Q5

--- a/optd-sqlplannertest/tests/tpch.planner.sql
+++ b/optd-sqlplannertest/tests/tpch.planner.sql
@@ -88,6 +88,120 @@ CREATE TABLE LINEITEM (
 
 */
 
+-- TPC-H Q1
+SELECT
+    l_returnflag,
+    l_linestatus,
+    sum(l_quantity) as sum_qty,
+    sum(l_extendedprice) as sum_base_price,
+    sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
+    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
+    avg(l_quantity) as avg_qty,
+    avg(l_extendedprice) as avg_price,
+    avg(l_discount) as avg_disc,
+    count(*) as count_order
+FROM
+    lineitem
+WHERE
+    l_shipdate <= date '1998-12-01' - interval '90' day
+GROUP BY
+    l_returnflag, l_linestatus
+ORDER BY
+    l_returnflag, l_linestatus;
+
+/*
+LogicalSort
+├── exprs:
+│   ┌── SortOrder { order: Asc }
+│   │   └── #0
+│   └── SortOrder { order: Asc }
+│       └── #1
+└── LogicalProjection { exprs: [ #0, #1, #2, #3, #4, #5, #6, #7, #8, #9 ] }
+    └── LogicalAgg
+        ├── exprs:
+        │   ┌── Agg(Sum)
+        │   │   └── [ #4 ]
+        │   ├── Agg(Sum)
+        │   │   └── [ #5 ]
+        │   ├── Agg(Sum)
+        │   │   └── Mul
+        │   │       ├── #5
+        │   │       └── Sub
+        │   │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+        │   │           └── #6
+        │   ├── Agg(Sum)
+        │   │   └── Mul
+        │   │       ├── Mul
+        │   │       │   ├── #5
+        │   │       │   └── Sub
+        │   │       │       ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+        │   │       │       └── #6
+        │   │       └── Add
+        │   │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+        │   │           └── #7
+        │   ├── Agg(Avg)
+        │   │   └── [ #4 ]
+        │   ├── Agg(Avg)
+        │   │   └── [ #5 ]
+        │   ├── Agg(Avg)
+        │   │   └── [ #6 ]
+        │   └── Agg(Count)
+        │       └── [ 1 ]
+        ├── groups: [ #8, #9 ]
+        └── LogicalFilter
+            ├── cond:Leq
+            │   ├── #10
+            │   └── Sub
+            │       ├── Cast { cast_to: Date32, expr: "1998-12-01" }
+            │       └── INTERVAL_MONTH_DAY_NANO (0, 90, 0)
+            └── LogicalScan { table: lineitem }
+PhysicalSort
+├── exprs:
+│   ┌── SortOrder { order: Asc }
+│   │   └── #0
+│   └── SortOrder { order: Asc }
+│       └── #1
+└── PhysicalProjection { exprs: [ #0, #1, #2, #3, #4, #5, #6, #7, #8, #9 ] }
+    └── PhysicalAgg
+        ├── aggrs:
+        │   ┌── Agg(Sum)
+        │   │   └── [ #4 ]
+        │   ├── Agg(Sum)
+        │   │   └── [ #5 ]
+        │   ├── Agg(Sum)
+        │   │   └── Mul
+        │   │       ├── #5
+        │   │       └── Sub
+        │   │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+        │   │           └── #6
+        │   ├── Agg(Sum)
+        │   │   └── Mul
+        │   │       ├── Mul
+        │   │       │   ├── #5
+        │   │       │   └── Sub
+        │   │       │       ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+        │   │       │       └── #6
+        │   │       └── Add
+        │   │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+        │   │           └── #7
+        │   ├── Agg(Avg)
+        │   │   └── [ #4 ]
+        │   ├── Agg(Avg)
+        │   │   └── [ #5 ]
+        │   ├── Agg(Avg)
+        │   │   └── [ #6 ]
+        │   └── Agg(Count)
+        │       └── [ 1 ]
+        ├── groups: [ #8, #9 ]
+        └── PhysicalFilter
+            ├── cond:Leq
+            │   ├── #10
+            │   └── Sub
+            │       ├── Cast { cast_to: Date32, expr: "1998-12-01" }
+            │       └── INTERVAL_MONTH_DAY_NANO (0, 90, 0)
+            └── PhysicalScan { table: lineitem }
+*/
+
 -- TPC-H Q5
 SELECT
     n_name AS nation,
@@ -854,6 +968,235 @@ PhysicalSort
                     │   │   └── PhysicalScan { table: partsupp }
                     │   └── PhysicalScan { table: orders }
                     └── PhysicalScan { table: nation }
+*/
+
+-- TPC-H Q10
+SELECT
+    c_custkey,
+    c_name,
+    sum(l_extendedprice * (1 - l_discount)) as revenue,
+    c_acctbal,
+    n_name,
+    c_address,
+    c_phone,
+    c_comment
+FROM
+    customer,
+    orders,
+    lineitem,
+    nation
+WHERE
+    c_custkey = o_custkey
+    AND l_orderkey = o_orderkey
+    AND o_orderdate >= DATE '1993-07-01'
+    AND o_orderdate < DATE '1993-07-01' + INTERVAL '3' MONTH
+    AND l_returnflag = 'R'
+    AND c_nationkey = n_nationkey
+GROUP BY
+    c_custkey,
+    c_name,
+    c_acctbal,
+    c_phone,
+    n_name,
+    c_address,
+    c_comment
+ORDER BY
+    revenue DESC
+LIMIT 20;
+
+/*
+LogicalLimit { skip: 0, fetch: 20 }
+└── LogicalSort
+    ├── exprs:SortOrder { order: Desc }
+    │   └── #2
+    └── LogicalProjection { exprs: [ #0, #1, #7, #2, #4, #5, #3, #6 ] }
+        └── LogicalAgg
+            ├── exprs:Agg(Sum)
+            │   └── Mul
+            │       ├── #22
+            │       └── Sub
+            │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+            │           └── #23
+            ├── groups: [ #0, #1, #5, #4, #34, #2, #7 ]
+            └── LogicalFilter
+                ├── cond:And
+                │   ├── And
+                │   │   ├── And
+                │   │   │   ├── And
+                │   │   │   │   ├── And
+                │   │   │   │   │   ├── Eq
+                │   │   │   │   │   │   ├── #0
+                │   │   │   │   │   │   └── #9
+                │   │   │   │   │   └── Eq
+                │   │   │   │   │       ├── #17
+                │   │   │   │   │       └── #8
+                │   │   │   │   └── Geq
+                │   │   │   │       ├── #12
+                │   │   │   │       └── Cast { cast_to: Date32, expr: "1993-07-01" }
+                │   │   │   └── Lt
+                │   │   │       ├── #12
+                │   │   │       └── Add
+                │   │   │           ├── Cast { cast_to: Date32, expr: "1993-07-01" }
+                │   │   │           └── INTERVAL_MONTH_DAY_NANO (3, 0, 0)
+                │   │   └── Eq
+                │   │       ├── #25
+                │   │       └── "R"
+                │   └── Eq
+                │       ├── #3
+                │       └── #33
+                └── LogicalJoin { join_type: Cross, cond: true }
+                    ├── LogicalJoin { join_type: Cross, cond: true }
+                    │   ├── LogicalJoin { join_type: Cross, cond: true }
+                    │   │   ├── LogicalScan { table: customer }
+                    │   │   └── LogicalScan { table: orders }
+                    │   └── LogicalScan { table: lineitem }
+                    └── LogicalScan { table: nation }
+PhysicalLimit { skip: 0, fetch: 20 }
+└── PhysicalSort
+    ├── exprs:SortOrder { order: Desc }
+    │   └── #2
+    └── PhysicalProjection { exprs: [ #0, #1, #7, #2, #4, #5, #3, #6 ] }
+        └── PhysicalAgg
+            ├── aggrs:Agg(Sum)
+            │   └── Mul
+            │       ├── #22
+            │       └── Sub
+            │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+            │           └── #23
+            ├── groups: [ #0, #1, #5, #4, #34, #2, #7 ]
+            └── PhysicalFilter
+                ├── cond:And
+                │   ├── And
+                │   │   ├── And
+                │   │   │   ├── And
+                │   │   │   │   ├── And
+                │   │   │   │   │   ├── Eq
+                │   │   │   │   │   │   ├── #0
+                │   │   │   │   │   │   └── #9
+                │   │   │   │   │   └── Eq
+                │   │   │   │   │       ├── #17
+                │   │   │   │   │       └── #8
+                │   │   │   │   └── Geq
+                │   │   │   │       ├── #12
+                │   │   │   │       └── Cast { cast_to: Date32, expr: "1993-07-01" }
+                │   │   │   └── Lt
+                │   │   │       ├── #12
+                │   │   │       └── Add
+                │   │   │           ├── Cast { cast_to: Date32, expr: "1993-07-01" }
+                │   │   │           └── INTERVAL_MONTH_DAY_NANO (3, 0, 0)
+                │   │   └── Eq
+                │   │       ├── #25
+                │   │       └── "R"
+                │   └── Eq
+                │       ├── #3
+                │       └── #33
+                └── PhysicalNestedLoopJoin { join_type: Cross, cond: true }
+                    ├── PhysicalNestedLoopJoin { join_type: Cross, cond: true }
+                    │   ├── PhysicalNestedLoopJoin { join_type: Cross, cond: true }
+                    │   │   ├── PhysicalScan { table: customer }
+                    │   │   └── PhysicalScan { table: orders }
+                    │   └── PhysicalScan { table: lineitem }
+                    └── PhysicalScan { table: nation }
+*/
+
+-- TPC-H Q14
+SELECT
+    100.00 * sum(case when p_type like 'PROMO%'
+                    then l_extendedprice * (1 - l_discount)
+                    else 0 end) / sum(l_extendedprice * (1 - l_discount)) as promo_revenue
+FROM
+    lineitem,
+    part
+WHERE
+    l_partkey = p_partkey
+    AND l_shipdate >= DATE '1995-09-01'
+    AND l_shipdate < DATE '1995-09-01' + INTERVAL '1' MONTH;
+
+/*
+LogicalProjection
+├── exprs:Div
+│   ├── Mul
+│   │   ├── 100
+│   │   └── Cast { cast_to: Float64, expr: #0 }
+│   └── Cast { cast_to: Float64, expr: #1 }
+└── LogicalAgg
+    ├── exprs:
+    │   ┌── Agg(Sum)
+    │   │   └── Case
+    │   │       └── 
+    │   │           ┌── Like { expr: #20, pattern: "PROMO%" }
+    │   │           ├── Mul
+    │   │           │   ├── #5
+    │   │           │   └── Sub
+    │   │           │       ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+    │   │           │       └── #6
+    │   │           └── Cast { cast_to: Decimal128(38, 4), expr: 0 }
+    │   └── Agg(Sum)
+    │       └── Mul
+    │           ├── #5
+    │           └── Sub
+    │               ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+    │               └── #6
+    ├── groups: []
+    └── LogicalFilter
+        ├── cond:And
+        │   ├── And
+        │   │   ├── Eq
+        │   │   │   ├── #1
+        │   │   │   └── #16
+        │   │   └── Geq
+        │   │       ├── #10
+        │   │       └── Cast { cast_to: Date32, expr: "1995-09-01" }
+        │   └── Lt
+        │       ├── #10
+        │       └── Add
+        │           ├── Cast { cast_to: Date32, expr: "1995-09-01" }
+        │           └── INTERVAL_MONTH_DAY_NANO (1, 0, 0)
+        └── LogicalJoin { join_type: Cross, cond: true }
+            ├── LogicalScan { table: lineitem }
+            └── LogicalScan { table: part }
+PhysicalProjection
+├── exprs:Div
+│   ├── Mul
+│   │   ├── 100
+│   │   └── Cast { cast_to: Float64, expr: #0 }
+│   └── Cast { cast_to: Float64, expr: #1 }
+└── PhysicalAgg
+    ├── aggrs:
+    │   ┌── Agg(Sum)
+    │   │   └── Case
+    │   │       └── 
+    │   │           ┌── Like { expr: #20, pattern: "PROMO%" }
+    │   │           ├── Mul
+    │   │           │   ├── #5
+    │   │           │   └── Sub
+    │   │           │       ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+    │   │           │       └── #6
+    │   │           └── Cast { cast_to: Decimal128(38, 4), expr: 0 }
+    │   └── Agg(Sum)
+    │       └── Mul
+    │           ├── #5
+    │           └── Sub
+    │               ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+    │               └── #6
+    ├── groups: []
+    └── PhysicalFilter
+        ├── cond:And
+        │   ├── And
+        │   │   ├── Eq
+        │   │   │   ├── #1
+        │   │   │   └── #16
+        │   │   └── Geq
+        │   │       ├── #10
+        │   │       └── Cast { cast_to: Date32, expr: "1995-09-01" }
+        │   └── Lt
+        │       ├── #10
+        │       └── Add
+        │           ├── Cast { cast_to: Date32, expr: "1995-09-01" }
+        │           └── INTERVAL_MONTH_DAY_NANO (1, 0, 0)
+        └── PhysicalNestedLoopJoin { join_type: Cross, cond: true }
+            ├── PhysicalScan { table: lineitem }
+            └── PhysicalScan { table: part }
 */
 
 -- TPC-H Q18

--- a/optd-sqlplannertest/tests/tpch.yml
+++ b/optd-sqlplannertest/tests/tpch.yml
@@ -88,6 +88,29 @@
       - execute
 - sql: |
       SELECT
+          l_returnflag,
+          l_linestatus,
+          sum(l_quantity) as sum_qty,
+          sum(l_extendedprice) as sum_base_price,
+          sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
+          sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
+          avg(l_quantity) as avg_qty,
+          avg(l_extendedprice) as avg_price,
+          avg(l_discount) as avg_disc,
+          count(*) as count_order
+      FROM
+          lineitem
+      WHERE
+          l_shipdate <= date '1998-12-01' - interval '90' day
+      GROUP BY
+          l_returnflag, l_linestatus
+      ORDER BY
+          l_returnflag, l_linestatus;
+  desc: TPC-H Q1
+  tasks:
+      - explain:logical_optd,physical_optd
+- sql: |
+      SELECT
           n_name AS nation,
           SUM(l_extendedprice * (1 - l_discount)) AS revenue
       FROM
@@ -245,6 +268,57 @@
           nation,
           o_year DESC;
   desc: TPC-H Q9
+  tasks:
+      - explain:logical_optd,physical_optd
+- sql: |
+      SELECT
+          c_custkey,
+          c_name,
+          sum(l_extendedprice * (1 - l_discount)) as revenue,
+          c_acctbal,
+          n_name,
+          c_address,
+          c_phone,
+          c_comment
+      FROM
+          customer,
+          orders,
+          lineitem,
+          nation
+      WHERE
+          c_custkey = o_custkey
+          AND l_orderkey = o_orderkey
+          AND o_orderdate >= DATE '1993-07-01'
+          AND o_orderdate < DATE '1993-07-01' + INTERVAL '3' MONTH
+          AND l_returnflag = 'R'
+          AND c_nationkey = n_nationkey
+      GROUP BY
+          c_custkey,
+          c_name,
+          c_acctbal,
+          c_phone,
+          n_name,
+          c_address,
+          c_comment
+      ORDER BY
+          revenue DESC
+      LIMIT 20;
+  desc: TPC-H Q10
+  tasks:
+      - explain:logical_optd,physical_optd
+- sql: |
+      SELECT
+          100.00 * sum(case when p_type like 'PROMO%'
+                          then l_extendedprice * (1 - l_discount)
+                          else 0 end) / sum(l_extendedprice * (1 - l_discount)) as promo_revenue
+      FROM
+          lineitem,
+          part
+      WHERE
+          l_partkey = p_partkey
+          AND l_shipdate >= DATE '1995-09-01'
+          AND l_shipdate < DATE '1995-09-01' + INTERVAL '1' MONTH;
+  desc: TPC-H Q14
   tasks:
       - explain:logical_optd,physical_optd
 - sql: |

--- a/optd-sqlplannertest/tests/tpch.yml
+++ b/optd-sqlplannertest/tests/tpch.yml
@@ -87,6 +87,29 @@
   tasks:
       - execute
 - sql: |
+      SELECT
+          l_returnflag,
+          l_linestatus,
+          sum(l_quantity) as sum_qty,
+          sum(l_extendedprice) as sum_base_price,
+          sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
+          sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
+          avg(l_quantity) as avg_qty,
+          avg(l_extendedprice) as avg_price,
+          avg(l_discount) as avg_disc,
+          count(*) as count_order
+      FROM
+          lineitem
+      WHERE
+          l_shipdate <= date '1998-12-01' - interval '90' day
+      GROUP BY
+          l_returnflag, l_linestatus
+      ORDER BY
+          l_returnflag, l_linestatus;
+  desc: TPC-H Q1
+  tasks:
+      - explain:logical_optd,physical_optd
+- sql: |
       select
               s_acctbal,
               s_name,
@@ -134,29 +157,6 @@
   desc: TPC-H Q2
   tasks:
       - explain_with_logical:logical_optd,physical_optd
-- sql: |
-      SELECT
-          l_returnflag,
-          l_linestatus,
-          sum(l_quantity) as sum_qty,
-          sum(l_extendedprice) as sum_base_price,
-          sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
-          sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
-          avg(l_quantity) as avg_qty,
-          avg(l_extendedprice) as avg_price,
-          avg(l_discount) as avg_disc,
-          count(*) as count_order
-      FROM
-          lineitem
-      WHERE
-          l_shipdate <= date '1998-12-01' - interval '90' day
-      GROUP BY
-          l_returnflag, l_linestatus
-      ORDER BY
-          l_returnflag, l_linestatus;
-  desc: TPC-H Q1
-  tasks:
-      - explain:logical_optd,physical_optd
 - sql: |
       SELECT
           n_name AS nation,


### PR DESCRIPTION
This enables tpch Q1, 10, 14.
During explain, it will be displayed as `INTERVAL_MONTH_DAY(x, x, x)`.