### PR TITLE
test: add tpch 3, 15, 17 planner test

### DIFF
--- a/optd-sqlplannertest/tests/tpch.yml
+++ b/optd-sqlplannertest/tests/tpch.yml
@@ -159,6 +159,32 @@
       - explain_with_logical:logical_optd,physical_optd
 - sql: |
       SELECT
+          l_orderkey,
+          SUM(l_extendedprice * (1 - l_discount)) AS revenue,
+          o_orderdate,
+          o_shippriority 
+      FROM
+          customer,
+          orders,
+          lineitem 
+      WHERE
+          c_mktsegment = 'FURNITURE' 
+          AND c_custkey = o_custkey 
+          AND l_orderkey = o_orderkey 
+          AND o_orderdate < DATE '1995-03-29' 
+          AND l_shipdate > DATE '1995-03-29' 
+      GROUP BY
+          l_orderkey,
+          o_orderdate,
+          o_shippriority 
+      ORDER BY
+          revenue DESC,
+          o_orderdate LIMIT 10;
+  desc: TPC-H Q3
+  tasks:
+      - explain_with_logical:logical_optd,physical_optd
+- sql: |
+      SELECT
           n_name AS nation,
           SUM(l_extendedprice * (1 - l_discount)) AS revenue
       FROM
@@ -319,29 +345,39 @@
   tasks:
       - explain:logical_optd,physical_optd
 - sql: |
-       SELECT
-           l_shipmode,
-           sum(case when o_orderpriority = '1-URGENT'
-                    or o_orderpriority = '2-HIGH'
-                    then 1 else 0 end) as high_priority_orders,
-           sum(case when o_orderpriority <> '1-URGENT'
-                    and o_orderpriority <> '2-HIGH'
-                    then 1 else 0 end) as low_priority_orders
-       FROM
-           orders,
-           lineitem
-       WHERE
-           o_orderkey = l_orderkey
-           AND l_shipmode in ('MAIL', 'SHIP')
-           AND l_commitdate < l_receiptdate
-           AND l_shipdate < l_commitdate
-           AND l_receiptdate >= DATE '1994-01-01'
-           AND l_receiptdate < DATE '1995-01-01'
-       GROUP BY
-           l_shipmode
-       ORDER BY
-           l_shipmode;
-  desc: TPC-H Q12
+      SELECT
+          nation,
+          o_year,
+          SUM(amount) AS sum_profit
+      FROM
+          (
+              SELECT
+                  n_name AS nation,
+                  EXTRACT(YEAR FROM o_orderdate) AS o_year,
+                  l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity AS amount
+              FROM
+                  part,
+                  supplier,
+                  lineitem,
+                  partsupp,
+                  orders,
+                  nation
+              WHERE
+                  s_suppkey = l_suppkey
+                  AND ps_suppkey = l_suppkey
+                  AND ps_partkey = l_partkey
+                  AND p_partkey = l_partkey
+                  AND o_orderkey = l_orderkey
+                  AND s_nationkey = n_nationkey
+                  AND p_name LIKE '%green%'
+          ) AS profit
+      GROUP BY
+          nation,
+          o_year
+      ORDER BY
+          nation,
+          o_year DESC;
+  desc: TPC-H Q9
   tasks:
       - explain:logical_optd,physical_optd
 - sql: |
@@ -381,6 +417,32 @@
   tasks:
       - explain:logical_optd,physical_optd
 - sql: |
+       SELECT
+           l_shipmode,
+           sum(case when o_orderpriority = '1-URGENT'
+                    or o_orderpriority = '2-HIGH'
+                    then 1 else 0 end) as high_priority_orders,
+           sum(case when o_orderpriority <> '1-URGENT'
+                    and o_orderpriority <> '2-HIGH'
+                    then 1 else 0 end) as low_priority_orders
+       FROM
+           orders,
+           lineitem
+       WHERE
+           o_orderkey = l_orderkey
+           AND l_shipmode in ('MAIL', 'SHIP')
+           AND l_commitdate < l_receiptdate
+           AND l_shipdate < l_commitdate
+           AND l_receiptdate >= DATE '1994-01-01'
+           AND l_receiptdate < DATE '1995-01-01'
+       GROUP BY
+           l_shipmode
+       ORDER BY
+           l_shipmode;
+  desc: TPC-H Q12
+  tasks:
+      - explain:logical_optd,physical_optd
+- sql: |
       SELECT
           100.00 * sum(case when p_type like 'PROMO%'
                           then l_extendedprice * (1 - l_discount)
@@ -396,34 +458,63 @@
   tasks:
       - explain:logical_optd,physical_optd
 - sql: |
+      WITH revenue0 (supplier_no, total_revenue) AS 
+      (
+          SELECT
+              l_suppkey,
+              SUM(l_extendedprice * (1 - l_discount)) 
+          FROM
+              lineitem 
+          WHERE
+              l_shipdate >= DATE '1993-01-01' 
+              AND l_shipdate < DATE '1993-01-01' + INTERVAL '3' MONTH 
+          GROUP BY
+              l_suppkey 
+      )
       SELECT
-          c_name,
-          c_custkey,
-          o_orderkey,
-          o_orderdate,
-          o_totalprice,
-          sum(l_quantity) as total_quantity
+          s_suppkey,
+          s_name,
+          s_address,
+          s_phone,
+          total_revenue 
       FROM
-          customer,
-          orders,
-          lineitem
+          supplier,
+          revenue0 
       WHERE
-          c_custkey = o_custkey
-          AND o_orderkey = l_orderkey
-      GROUP BY
-          c_name,
-          c_custkey,
-          o_orderkey,
-          o_orderdate,
-          o_totalprice
-      HAVING
-          sum(l_quantity) > 300
+          s_suppkey = supplier_no 
+          AND total_revenue = 
+          (
+              SELECT
+                  MAX(total_revenue) 
+              FROM
+                  revenue0 
+          )
       ORDER BY
-          o_totalprice DESC,
-          o_orderdate;
-  desc: TPC-H Q18
+          s_suppkey;
+  desc: TPC-H Q15
   tasks:
-      - explain:logical_optd,physical_optd
+      - explain_with_logical:logical_optd,physical_optd
+- sql: |
+      SELECT
+          ROUND(SUM(l_extendedprice) / 7.0, 16) AS avg_yearly 
+      FROM
+          lineitem,
+          part 
+      WHERE
+          p_partkey = l_partkey 
+          AND p_brand = 'Brand#13' 
+          AND p_container = 'JUMBO PKG' 
+          AND l_quantity < ( 
+              SELECT
+                  0.2 * AVG(l_quantity) 
+              FROM
+                  lineitem 
+              WHERE
+                  l_partkey = p_partkey 
+          );
+  desc: TPC-H Q17
+  tasks:
+      - explain_with_logical:logical_optd,physical_optd
 - sql: |
       SELECT
           sum(l_extendedprice* (1 - l_discount)) as revenue
@@ -459,4 +550,3 @@
   desc: TPC-H Q19
   tasks:
       - explain:logical_optd,physical_optd
-


### PR DESCRIPTION
After #80, we can test subqueries with DF logical optimizer enabled. The reasons not all queries are working are:

- Multiple join filters, possibly containing non-eq predicate.
- optd panicking with `cannot find best binding for group`. I suspect this is due to the partial explore?

In addition, I realized I pasted the wrong query for q18 🥵 (that made me double-checked whether other queries are correct), so it is removed now.