### PR TITLE
feat: add RuleWrapper and make the optimizer a hybrid optimizer

### DIFF
--- a/optd-core/src/cascades/optimizer.rs
+++ b/optd-core/src/cascades/optimizer.rs
@@ -283,6 +283,19 @@ impl<T: RelNodeTyp> CascadesOptimizer<T> {
         self.memo.add_new_group_expr(expr, group_id)
     }
 
+    pub(super) fn replace_group_expr(
+        &mut self,
+        expr: RelNodeRef<T>,
+        group_id: GroupId,
+        expr_id: ExprId,
+    ) {
+        // the old expr is replaced, so we clear the fired rules for old expr
+        self.fired_rules
+            .entry(expr_id)
+            .and_modify(|fired_rules| fired_rules.clear());
+        self.memo.replace_group_expr(expr_id, group_id, expr);
+    }
+
     pub(super) fn get_group_info(&self, group_id: GroupId) -> GroupInfo {
         self.memo.get_group_info(group_id)
     }

--- a/optd-core/src/cascades/optimizer.rs
+++ b/optd-core/src/cascades/optimizer.rs
@@ -11,7 +11,7 @@ use crate::{
     optimizer::Optimizer,
     property::{PropertyBuilder, PropertyBuilderAny},
     rel_node::{RelNodeRef, RelNodeTyp},
-    rules::Rule,
+    rules::RuleWrapper,
 };
 
 use super::{
@@ -42,7 +42,7 @@ pub struct CascadesOptimizer<T: RelNodeTyp> {
     pub(super) tasks: VecDeque<Box<dyn Task<T>>>,
     explored_group: HashSet<GroupId>,
     fired_rules: HashMap<ExprId, HashSet<RuleId>>,
-    rules: Arc<[Arc<dyn Rule<T, Self>>]>,
+    rules: Arc<[Arc<RuleWrapper<T, Self>>]>,
     disabled_rules: HashSet<usize>,
     cost: Arc<dyn CostModel<T>>,
     property_builders: Arc<[Box<dyn PropertyBuilderAny<T>>]>,
@@ -79,7 +79,7 @@ impl Display for ExprId {
 
 impl<T: RelNodeTyp> CascadesOptimizer<T> {
     pub fn new(
-        rules: Vec<Arc<dyn Rule<T, Self>>>,
+        rules: Vec<Arc<RuleWrapper<T, Self>>>,
         cost: Box<dyn CostModel<T>>,
         property_builders: Vec<Box<dyn PropertyBuilderAny<T>>>,
     ) -> Self {
@@ -87,7 +87,7 @@ impl<T: RelNodeTyp> CascadesOptimizer<T> {
     }
 
     pub fn new_with_prop(
-        rules: Vec<Arc<dyn Rule<T, Self>>>,
+        rules: Vec<Arc<RuleWrapper<T, Self>>>,
         cost: Box<dyn CostModel<T>>,
         property_builders: Vec<Box<dyn PropertyBuilderAny<T>>>,
         prop: OptimizerProperties,
@@ -113,7 +113,7 @@ impl<T: RelNodeTyp> CascadesOptimizer<T> {
         self.cost.clone()
     }
 
-    pub(super) fn rules(&self) -> Arc<[Arc<dyn Rule<T, Self>>]> {
+    pub(super) fn rules(&self) -> Arc<[Arc<RuleWrapper<T, Self>>]> {
         self.rules.clone()
     }
 
@@ -289,11 +289,20 @@ impl<T: RelNodeTyp> CascadesOptimizer<T> {
         group_id: GroupId,
         expr_id: ExprId,
     ) {
-        // the old expr is replaced, so we clear the fired rules for old expr
-        self.fired_rules
-            .entry(expr_id)
-            .and_modify(|fired_rules| fired_rules.clear());
-        self.memo.replace_group_expr(expr_id, group_id, expr);
+        let replaced = self.memo.replace_group_expr(expr_id, group_id, expr);
+        if replaced {
+            // the old expr is replaced, so we clear the fired rules for old expr
+            self.fired_rules
+                .entry(expr_id)
+                .and_modify(|fired_rules| fired_rules.clear());
+            return;
+        }
+        // new expr merged with old expr, we mark old expr as a dead end
+        self.fired_rules.entry(expr_id).and_modify(|fired_rules| {
+            for i in 0..self.rules.len() {
+                fired_rules.insert(i);
+            }
+        });
     }
 
     pub(super) fn get_group_info(&self, group_id: GroupId) -> GroupInfo {

--- a/optd-core/src/cascades/tasks/apply_rule.rs
+++ b/optd-core/src/cascades/tasks/apply_rule.rs
@@ -12,7 +12,7 @@ use crate::{
         GroupId,
     },
     rel_node::{RelNode, RelNodeTyp},
-    rules::{RuleMatcher, RuleType},
+    rules::{OptimizeType, RuleMatcher},
 };
 
 use super::Task;
@@ -188,25 +188,40 @@ impl<T: RelNodeTyp> Task<T> for ApplyRuleTask {
             return Ok(vec![]);
         }
 
-        let rule = optimizer.rules()[self.rule_id].clone();
-        trace!(event = "task_begin", task = "apply_rule", expr_id = %self.expr_id, rule_id = %self.rule_id, rule = %rule.name(), rule_type = %rule.get_rule_type());
+        let rule_wrapper = optimizer.rules()[self.rule_id].clone();
+        let rule = rule_wrapper.rule();
+
+        trace!(event = "task_begin", task = "apply_rule", expr_id = %self.expr_id, rule_id = %self.rule_id, rule = %rule.name(), optimize_type=%rule_wrapper.optimize_type());
         let group_id = optimizer.get_group_id(self.expr_id);
         let mut tasks = vec![];
         let binding_exprs = match_and_pick_expr(rule.matcher(), self.expr_id, optimizer);
         for expr in binding_exprs {
             let applied = rule.apply(optimizer, expr);
 
-            if rule.get_rule_type() == RuleType::Normalization {
+            if rule_wrapper.optimize_type() == OptimizeType::Heuristics {
                 assert!(
-                    applied.len() == 1,
-                    "normalization rule should always return one expr"
+                    applied.len() <= 1,
+                    "rules registered as heuristics should always return equal or less than one expr"
                 );
+
+                if applied.is_empty() {
+                    continue;
+                }
 
                 let RelNode { typ, .. } = &applied[0];
 
-                // TODO: for normalization rule, can typ be a group?
-                if let Some(_) = typ.extract_group() {
-                    assert!(false, "normalization rule returns a group? 🤔️")
+                assert!(
+                    !rule.is_impl_rule(),
+                    "impl rule registered should not be registered as heuristics"
+                );
+
+                if let Some(group_id_2) = typ.extract_group() {
+                    // If this is a group, merge the groups!
+                    optimizer.merge_group(group_id, group_id_2);
+                    // mark the old expr as a dead end
+                    (0..optimizer.rules().len())
+                        .for_each(|i| optimizer.mark_rule_fired(self.expr_id, i));
+                    continue;
                 }
 
                 for new_expr in applied {
@@ -218,7 +233,7 @@ impl<T: RelNodeTyp> Task<T> for ApplyRuleTask {
 
                     trace!(event = "apply_rule replace", expr_id = %self.expr_id, rule_id = %self.rule_id);
 
-                    // normalization rule are always logical, exploring its children
+                    // rules registed as heuristics are always logical, exploring its children
                     tasks.push(
                         Box::new(OptimizeExpressionTask::new(self.expr_id, self.exploring))
                             as Box<dyn Task<T>>,

--- a/optd-core/src/rules.rs
+++ b/optd-core/src/rules.rs
@@ -1,6 +1,7 @@
 mod ir;
 
 use std::collections::HashMap;
+use std::fmt;
 
 use crate::{
     optimizer::Optimizer,
@@ -9,11 +10,43 @@ use crate::{
 
 pub use ir::RuleMatcher;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuleType {
+    /// Implementation rules are used to convert logical plan to physical plan
+    Implementation,
+
+    /// transformation rules are used to generate new logical plan, default type
+    Transformation,
+
+    /// normalization rules are like heuristics rules, which always apply when matched
+    /// , are used to simplify the plan and new generated plan will replace original ones
+    Normalization,
+}
+
+impl fmt::Display for RuleType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            RuleType::Implementation => write!(f, "Implementation"),
+            RuleType::Transformation => write!(f, "Transformation"),
+            RuleType::Normalization => write!(f, "Normalization"),
+        }
+    }
+}
+
 pub trait Rule<T: RelNodeTyp, O: Optimizer<T>>: 'static + Send + Sync {
     fn matcher(&self) -> &RuleMatcher<T>;
     fn apply(&self, optimizer: &O, input: HashMap<usize, RelNode<T>>) -> Vec<RelNode<T>>;
     fn name(&self) -> &'static str;
     fn is_impl_rule(&self) -> bool {
-        false
+        self.get_rule_type() == RuleType::Implementation
+    }
+    fn is_xform_rule(&self) -> bool {
+        self.get_rule_type() == RuleType::Transformation
+    }
+    fn is_norm_rule(&self) -> bool {
+        self.get_rule_type() == RuleType::Normalization
+    }
+    fn get_rule_type(&self) -> RuleType {
+        RuleType::Transformation
     }
 }

--- a/optd-core/src/rules.rs
+++ b/optd-core/src/rules.rs
@@ -38,6 +38,18 @@ impl<T: RelNodeTyp, O: Optimizer<T>> RuleWrapper<T, O> {
             optimize_type: optimizer_type,
         }
     }
+    pub fn new_cascades(rule: Arc<dyn Rule<T, O>>) -> Arc<Self> {
+        Arc::new(Self {
+            rule,
+            optimize_type: OptimizeType::Cascades,
+        })
+    }
+    pub fn new_heuristic(rule: Arc<dyn Rule<T, O>>) -> Arc<Self> {
+        Arc::new(Self {
+            rule,
+            optimize_type: OptimizeType::Heuristics,
+        })
+    }
     pub fn rule(&self) -> Arc<dyn Rule<T, O>> {
         self.rule.clone()
     }

--- a/optd-datafusion-repr/src/bin/test_optimize.rs
+++ b/optd-datafusion-repr/src/bin/test_optimize.rs
@@ -1,8 +1,11 @@
 use std::sync::Arc;
 
 use optd_core::{
-    cascades::CascadesOptimizer, heuristics::HeuristicsOptimizer, optimizer::Optimizer,
+    cascades::CascadesOptimizer,
+    heuristics::HeuristicsOptimizer,
+    optimizer::Optimizer,
     rel_node::Value,
+    rules::{OptimizeType, Rule, RuleWrapper},
 };
 use optd_datafusion_repr::{
     cost::{OptCostModel, PerTableStats},
@@ -22,17 +25,23 @@ pub fn main() {
         .with_target(false)
         .init();
 
+    let rules: Vec<Arc<dyn Rule<OptRelNodeTyp, CascadesOptimizer<OptRelNodeTyp>>>> = vec![
+        Arc::new(JoinCommuteRule::new()),
+        Arc::new(JoinAssocRule::new()),
+        Arc::new(PhysicalConversionRule::new(OptRelNodeTyp::Scan)),
+        Arc::new(PhysicalConversionRule::new(OptRelNodeTyp::Join(
+            JoinType::Inner,
+        ))),
+        Arc::new(PhysicalConversionRule::new(OptRelNodeTyp::Filter)),
+        Arc::new(HashJoinRule::new()),
+    ];
+    let mut rule_wrappers = Vec::new();
+    for rule in rules {
+        rule_wrappers.push(Arc::new(RuleWrapper::new(rule, OptimizeType::Cascades)));
+    }
+
     let mut optimizer = CascadesOptimizer::new(
-        vec![
-            Arc::new(JoinCommuteRule::new()),
-            Arc::new(JoinAssocRule::new()),
-            Arc::new(PhysicalConversionRule::new(OptRelNodeTyp::Scan)),
-            Arc::new(PhysicalConversionRule::new(OptRelNodeTyp::Join(
-                JoinType::Inner,
-            ))),
-            Arc::new(PhysicalConversionRule::new(OptRelNodeTyp::Filter)),
-            Arc::new(HashJoinRule::new()),
-        ],
+        rule_wrappers,
         Box::new(OptCostModel::new(
             [("t1", 1000), ("t2", 100), ("t3", 10000)]
                 .into_iter()

--- a/optd-datafusion-repr/src/bin/test_optimize.rs
+++ b/optd-datafusion-repr/src/bin/test_optimize.rs
@@ -5,7 +5,7 @@ use optd_core::{
     heuristics::HeuristicsOptimizer,
     optimizer::Optimizer,
     rel_node::Value,
-    rules::{OptimizeType, Rule, RuleWrapper},
+    rules::{Rule, RuleWrapper},
 };
 use optd_datafusion_repr::{
     cost::{OptCostModel, PerTableStats},
@@ -37,7 +37,7 @@ pub fn main() {
     ];
     let mut rule_wrappers = Vec::new();
     for rule in rules {
-        rule_wrappers.push(Arc::new(RuleWrapper::new(rule, OptimizeType::Cascades)));
+        rule_wrappers.push(RuleWrapper::new_cascades(rule));
     }
 
     let mut optimizer = CascadesOptimizer::new(

--- a/optd-datafusion-repr/src/rules/macros.rs
+++ b/optd-datafusion-repr/src/rules/macros.rs
@@ -196,7 +196,7 @@ macro_rules! define_rule_inner {
                 }
             }
 
-            fn get_rule_type(&self) -> optd_core::rules::RuleType {
+            fn is_impl_rule(&self) -> bool {
                 $rule_type
             }
         }
@@ -205,19 +205,13 @@ macro_rules! define_rule_inner {
 
 macro_rules! define_rule {
     ($name:ident, $apply:ident, $($matcher:tt)+) => {
-        crate::rules::macros::define_rule_inner! { optd_core::rules::RuleType::Transformation, $name, $apply, $($matcher)+ }
+        crate::rules::macros::define_rule_inner! { false, $name, $apply, $($matcher)+ }
     };
 }
 
 macro_rules! define_impl_rule {
     ($name:ident, $apply:ident, $($matcher:tt)+) => {
-        crate::rules::macros::define_rule_inner! { optd_core::rules::RuleType::Implementation, $name, $apply, $($matcher)+ }
-    };
-}
-
-macro_rules! define_norm_rule {
-    ($name:ident, $apply:ident, $($matcher:tt)+) => {
-        crate::rules::macros::define_rule_inner! { optd_core::rules::RuleType::Normalization, $name, $apply, $($matcher)+ }
+        crate::rules::macros::define_rule_inner! { true, $name, $apply, $($matcher)+ }
     };
 }
 
@@ -225,7 +219,6 @@ pub(crate) use apply_matcher;
 pub(crate) use collect_picks;
 pub(crate) use define_impl_rule;
 pub(crate) use define_matcher;
-pub(crate) use define_norm_rule;
 pub(crate) use define_picks;
 pub(crate) use define_picks_struct;
 pub(crate) use define_rule;

--- a/optd-datafusion-repr/src/rules/macros.rs
+++ b/optd-datafusion-repr/src/rules/macros.rs
@@ -145,7 +145,7 @@ macro_rules! apply_matcher {
 }
 
 macro_rules! define_rule_inner {
-    ($is_impl_rule:expr, $name:ident, $apply:ident, $($matcher:tt)+) => {
+    ($rule_type:expr, $name:ident, $apply:ident, $($matcher:tt)+) => {
         pub struct $name {
             matcher: RuleMatcher<OptRelNodeTyp>,
         }
@@ -196,8 +196,8 @@ macro_rules! define_rule_inner {
                 }
             }
 
-            fn is_impl_rule(&self) -> bool {
-                $is_impl_rule
+            fn get_rule_type(&self) -> optd_core::rules::RuleType {
+                $rule_type
             }
         }
     };
@@ -205,13 +205,19 @@ macro_rules! define_rule_inner {
 
 macro_rules! define_rule {
     ($name:ident, $apply:ident, $($matcher:tt)+) => {
-        crate::rules::macros::define_rule_inner! { false, $name, $apply, $($matcher)+ }
+        crate::rules::macros::define_rule_inner! { optd_core::rules::RuleType::Transformation, $name, $apply, $($matcher)+ }
     };
 }
 
 macro_rules! define_impl_rule {
     ($name:ident, $apply:ident, $($matcher:tt)+) => {
-        crate::rules::macros::define_rule_inner! { true, $name, $apply, $($matcher)+ }
+        crate::rules::macros::define_rule_inner! { optd_core::rules::RuleType::Implementation, $name, $apply, $($matcher)+ }
+    };
+}
+
+macro_rules! define_norm_rule {
+    ($name:ident, $apply:ident, $($matcher:tt)+) => {
+        crate::rules::macros::define_rule_inner! { optd_core::rules::RuleType::Normalization, $name, $apply, $($matcher)+ }
     };
 }
 
@@ -219,6 +225,7 @@ pub(crate) use apply_matcher;
 pub(crate) use collect_picks;
 pub(crate) use define_impl_rule;
 pub(crate) use define_matcher;
+pub(crate) use define_norm_rule;
 pub(crate) use define_picks;
 pub(crate) use define_picks_struct;
 pub(crate) use define_rule;

--- a/optd-datafusion-repr/src/rules/physical.rs
+++ b/optd-datafusion-repr/src/rules/physical.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use optd_core::optimizer::Optimizer;
 use optd_core::rel_node::RelNode;
-use optd_core::rules::{Rule, RuleMatcher, RuleType};
+use optd_core::rules::{Rule, RuleMatcher};
 
 use crate::plan_nodes::{JoinType, OptRelNodeTyp};
 
@@ -140,8 +140,8 @@ impl<O: Optimizer<OptRelNodeTyp>> Rule<OptRelNodeTyp, O> for PhysicalConversionR
         }
     }
 
-    fn get_rule_type(&self) -> RuleType {
-        RuleType::Implementation
+    fn is_impl_rule(&self) -> bool {
+        true
     }
 
     fn name(&self) -> &'static str {

--- a/optd-datafusion-repr/src/rules/physical.rs
+++ b/optd-datafusion-repr/src/rules/physical.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use optd_core::optimizer::Optimizer;
 use optd_core::rel_node::RelNode;
-use optd_core::rules::{Rule, RuleMatcher};
+use optd_core::rules::{Rule, RuleMatcher, RuleType};
 
 use crate::plan_nodes::{JoinType, OptRelNodeTyp};
 
@@ -142,6 +142,10 @@ impl<O: Optimizer<OptRelNodeTyp>> Rule<OptRelNodeTyp, O> for PhysicalConversionR
 
     fn is_impl_rule(&self) -> bool {
         true
+    }
+
+    fn get_rule_type(&self) -> RuleType {
+        RuleType::Implementation
     }
 
     fn name(&self) -> &'static str {

--- a/optd-datafusion-repr/src/rules/physical.rs
+++ b/optd-datafusion-repr/src/rules/physical.rs
@@ -140,10 +140,6 @@ impl<O: Optimizer<OptRelNodeTyp>> Rule<OptRelNodeTyp, O> for PhysicalConversionR
         }
     }
 
-    fn is_impl_rule(&self) -> bool {
-        true
-    }
-
     fn get_rule_type(&self) -> RuleType {
         RuleType::Implementation
     }


### PR DESCRIPTION
# Design
This pr is for adding a rule wrapper and hybrid logic to make cascades optimizer support two types of logic rules: rules registered as heuristics and rules registered as cascades.
- heuristic rule, which should always replace the old expr using the new expr if rule is applied
- heuristic rule should only return 1 or 0 expr, if not match, return the 0 expr
- heuristic rule's newly generated expr would be an expr not explored yet, only marks the heuristic rule which generates it as fired
- heuristic rule's newly generated expr might have been existed in memo, in that case two groups should be merged and old expr should be marked as a dead end (all rules fired for it)

# Major Changes
- Add RuleWrapper and optimizeType
- Change OptimizeExpression Task and ApplyRuleTask logic
- Add replace_group_expr for memo and optimizer

# why we are using a hybrid optimizer instead of two stage optimizers including heuristics and cascades?
Currently the columnRef property define emptyRelation derive rules as derive instead of a real column ref. However, this is not true for a two-stage optimizer. For instance, if we have a query like this select * from t1 join t2 on false, the original plan tree is Projection(columnRef 0,1,2,3) -> InnerJoin -> TableScan, after heuristic rules it becomes Projection(columnRef 0,1,2,3) -> EmptyRelation. But the emptyRelation has no connected table name or properties containing its schema(even if we create infer properties rules in heuristics, CascadesOptimizer cannot get the properties generated by heuristicOptimizers), but the projection node require columnref 0,1,2,3, so the columnRef derive rule will panic as it cannot infer from the children of emptyRelation. If we put heuristic rules in cascades optimizer, it works fine as the original table scan is stored in original plan and can be fetched from catalog, after transformation, the same group share the same properties, so it works fine.

If we're going to create a two-stage optimizer, it is hard to share properties/schema across two optimizers. No matter we're modifying current heuristic implementations with infer properties or creating a heuristic optimizer from cascades framework with customized task. (because the schema are either stored in memo or from catalog with table name, it cannot be easily shared with outside calls)

# future tasks
the lack of maintaining properties in remembered state might break the adaptive design as the emptyRelation is record and no connected schema without inferred properties.

