### PR TITLE
feat: add cost in `RelNodeMeta`

### DIFF
--- a/optd-core/src/cascades/memo.rs
+++ b/optd-core/src/cascades/memo.rs
@@ -518,7 +518,7 @@ impl<T: RelNodeTyp> Memo<T> {
                 if let Some(meta) = meta {
                     meta.insert(
                         node.as_ref() as *const _ as usize,
-                        RelNodeMeta::new(group_id),
+                        RelNodeMeta::new(group_id, winner.cost),
                     );
                 }
                 return Ok(node);

--- a/optd-core/src/rel_node.rs
+++ b/optd-core/src/rel_node.rs
@@ -10,7 +10,7 @@ use std::{
 
 use ordered_float::OrderedFloat;
 
-use crate::cascades::GroupId;
+use crate::{cascades::GroupId, cost::Cost};
 
 pub type RelNodeRef<T> = Arc<RelNode<T>>;
 
@@ -208,11 +208,13 @@ impl<T: RelNodeTyp> RelNode<T> {
 pub struct RelNodeMeta {
     /// The group (id) of the `RelNode`
     pub group_id: GroupId,
+    /// Cost of the `RelNode`
+    pub cost: Cost,
 }
 
 impl RelNodeMeta {
-    pub fn new(group_id: GroupId) -> Self {
-        RelNodeMeta { group_id }
+    pub fn new(group_id: GroupId, cost: Cost) -> Self {
+        RelNodeMeta { group_id, cost }
     }
 }
 


### PR DESCRIPTION
Add the cost in winning `RelNode`s. This potentially enables us to output the cost in `EXPLAIN`, and obtain the estimated cardinality which can be used in q-error computation.