### PR TITLE
feat: CLI for optd-perftest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -981,13 +981,35 @@ checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags 1.3.2",
- "clap_derive",
- "clap_lex",
+ "clap_derive 3.2.25",
+ "clap_lex 0.2.4",
  "indexmap 1.9.3",
  "once_cell",
- "strsim",
+ "strsim 0.10.0",
  "termcolor",
  "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b230ab84b0ffdf890d5a10abdbc8b83ae1c4918275daea1ab8801f71536b2651"
+dependencies = [
+ "clap_builder",
+ "clap_derive 4.5.0",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex 0.7.0",
+ "strsim 0.11.0",
 ]
 
 [[package]]
@@ -1004,6 +1026,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_derive"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
+dependencies = [
+ "heck",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,6 +1045,12 @@ checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "clipboard-win"
@@ -1359,7 +1399,7 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-credential-types",
- "clap",
+ "clap 3.2.25",
  "ctor",
  "datafusion",
  "dirs",
@@ -2291,7 +2331,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79529479c298f5af41375b0c1a77ef670d450b4c9cd7949d2b43af08121b20ec"
 dependencies = [
- "clap",
+ "clap 3.2.25",
  "termcolor",
  "threadpool",
 ]
@@ -2675,6 +2715,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "clap 4.5.2",
  "env_logger 0.11.2",
  "futures",
  "log",
@@ -3685,6 +3726,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "strum"

--- a/mac_kill_postgres.sh
+++ b/mac_kill_postgres.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# a sketchy way to kill "orphaned" postgres processes (i.e. processes whose pgdata dir has already been deleted)
+# I named it mac cuz I have no idea if it'll work on linux
+# use this script to avoid having to manually do "ps aux" and "kill [pid]" every time cardtest_integration (or something similar) fails
+
+# the "main" process has bin/postgres in it
+# we kill it in a loop because sometimes it's required for some reason I don't understand
+while pid=$(ps aux | grep bin/postgres | grep -v grep | head -n1 | awk '{print $2}'); do
+  if [ -z "$pid" ]; then
+    break
+  else
+    # we'll sometimes kill pids that don't exist. don't show the error in these cases
+    kill $pid &>/dev/null
+    sleep 1 # sleep so we don't loop too fast
+  fi
+done
+
+# even after it's gone, wait for it to completely shut down
+sleep 1

--- a/optd-perftest/Cargo.toml
+++ b/optd-perftest/Cargo.toml
@@ -20,5 +20,8 @@ tokio = { version = "1.24", features = [
 shlex = "1.3"
 tokio-postgres = "0.7"
 regex = "1.10"
+clap = { version = "4.5", features = [
+    "derive",
+] }
 log = "0.4"
 env_logger = "0.11"

--- a/optd-perftest/src/cardtest.rs
+++ b/optd-perftest/src/cardtest.rs
@@ -25,12 +25,12 @@ impl CardtestRunner {
     ///   of the entire query, not of a subtree of the query. This detail is specified in Section 7.1 of
     ///   [Yang 2020](https://arxiv.org/pdf/2006.08109.pdf)
     pub async fn eval_benchmark_qerrors_alldbs(
-        &self,
+        &mut self,
         benchmark: &Benchmark,
     ) -> anyhow::Result<HashMap<String, Vec<f64>>> {
         let mut qerrors_alldbs = HashMap::new();
 
-        for database in &self.databases {
+        for database in &mut self.databases {
             let estcards = database.eval_benchmark_estcards(benchmark).await?;
             let truecards = database.eval_benchmark_truecards(benchmark).await?;
             assert!(truecards.len() == estcards.len());
@@ -76,7 +76,10 @@ pub trait CardtestRunnerDBHelper {
     // get_name() has &self so that we're able to do Box<dyn CardtestRunnerDBHelper>
     fn get_name(&self) -> &str;
 
-    // the order of queries has to be the same between these two functions
-    async fn eval_benchmark_estcards(&self, benchmark: &Benchmark) -> anyhow::Result<Vec<usize>>;
-    async fn eval_benchmark_truecards(&self, benchmark: &Benchmark) -> anyhow::Result<Vec<usize>>;
+    // The order of queries has to be the same between these two functions.
+    // They take mutable references because evaluation sometimes involves mutating self.
+    //   One example of this is in PostgresDb where we may need to reconnect to the database,
+    //   which requires modifying the PostgresDb object.
+    async fn eval_benchmark_estcards(&mut self, benchmark: &Benchmark) -> anyhow::Result<Vec<usize>>;
+    async fn eval_benchmark_truecards(&mut self, benchmark: &Benchmark) -> anyhow::Result<Vec<usize>>;
 }

--- a/optd-perftest/src/cardtest.rs
+++ b/optd-perftest/src/cardtest.rs
@@ -80,6 +80,12 @@ pub trait CardtestRunnerDBHelper {
     // They take mutable references because evaluation sometimes involves mutating self.
     //   One example of this is in PostgresDb where we may need to reconnect to the database,
     //   which requires modifying the PostgresDb object.
-    async fn eval_benchmark_estcards(&mut self, benchmark: &Benchmark) -> anyhow::Result<Vec<usize>>;
-    async fn eval_benchmark_truecards(&mut self, benchmark: &Benchmark) -> anyhow::Result<Vec<usize>>;
+    async fn eval_benchmark_estcards(
+        &mut self,
+        benchmark: &Benchmark,
+    ) -> anyhow::Result<Vec<usize>>;
+    async fn eval_benchmark_truecards(
+        &mut self,
+        benchmark: &Benchmark,
+    ) -> anyhow::Result<Vec<usize>>;
 }

--- a/optd-perftest/src/datafusion_db_cardtest.rs
+++ b/optd-perftest/src/datafusion_db_cardtest.rs
@@ -8,11 +8,17 @@ impl CardtestRunnerDBHelper for DatafusionDb {
         "DataFusion"
     }
 
-    async fn eval_benchmark_truecards(&mut self, _benchmark: &Benchmark) -> anyhow::Result<Vec<usize>> {
+    async fn eval_benchmark_truecards(
+        &mut self,
+        _benchmark: &Benchmark,
+    ) -> anyhow::Result<Vec<usize>> {
         Ok(vec![])
     }
 
-    async fn eval_benchmark_estcards(&mut self, _benchmark: &Benchmark) -> anyhow::Result<Vec<usize>> {
+    async fn eval_benchmark_estcards(
+        &mut self,
+        _benchmark: &Benchmark,
+    ) -> anyhow::Result<Vec<usize>> {
         Ok(vec![])
     }
 }

--- a/optd-perftest/src/datafusion_db_cardtest.rs
+++ b/optd-perftest/src/datafusion_db_cardtest.rs
@@ -8,11 +8,11 @@ impl CardtestRunnerDBHelper for DatafusionDb {
         "DataFusion"
     }
 
-    async fn eval_benchmark_truecards(&self, _benchmark: &Benchmark) -> anyhow::Result<Vec<usize>> {
+    async fn eval_benchmark_truecards(&mut self, _benchmark: &Benchmark) -> anyhow::Result<Vec<usize>> {
         Ok(vec![])
     }
 
-    async fn eval_benchmark_estcards(&self, _benchmark: &Benchmark) -> anyhow::Result<Vec<usize>> {
+    async fn eval_benchmark_estcards(&mut self, _benchmark: &Benchmark) -> anyhow::Result<Vec<usize>> {
         Ok(vec![])
     }
 }

--- a/optd-perftest/src/main.rs
+++ b/optd-perftest/src/main.rs
@@ -1,5 +1,5 @@
-use anyhow::Result;
 use cardtest::{CardtestRunner, CardtestRunnerDBHelper};
+use clap::{Parser, Subcommand};
 use postgres_db::PostgresDb;
 
 use crate::{
@@ -14,21 +14,42 @@ mod postgres_db;
 mod shell;
 mod tpch;
 
+#[derive(Parser)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    Cardtest {
+        #[arg(long)]
+        #[clap(default_value = "1")]
+        scale_factor: i32,
+        #[arg(long)]
+        #[clap(default_value = "15721")]
+        seed: i32,
+    },
+}
+
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> anyhow::Result<()> {
     env_logger::init();
-    let pg_db = PostgresDb::build().await?;
-    let databases: Vec<Box<dyn CardtestRunnerDBHelper>> = vec![Box::new(pg_db)];
-    let tpch_config = TpchConfig {
-        database: String::from(TPCH_KIT_POSTGRES),
-        scale_factor: 1,
-        seed: 15721,
-    };
-    let tpch_benchmark = Benchmark::Tpch(tpch_config.clone());
-    let cardtest_runner = CardtestRunner::new(databases).await?;
-    let qerrors = cardtest_runner
-        .eval_benchmark_qerrors_alldbs(&tpch_benchmark)
-        .await?;
-    println!("qerrors: {:?}", qerrors);
+    let cli = Cli::parse();
+
+    match &cli.command {
+        Commands::Cardtest { scale_factor, seed } => {
+            let tpch_config = TpchConfig {
+                database: String::from(TPCH_KIT_POSTGRES),
+                scale_factor: *scale_factor,
+                seed: *seed,
+            };
+            cardtest(tpch_config).await
+        }
+    }
+}
+
+async fn cardtest(tpch_config: TpchConfig) -> anyhow::Result<()> {
+    println!("tpch_config={:?}", tpch_config);
     Ok(())
 }

--- a/optd-perftest/src/main.rs
+++ b/optd-perftest/src/main.rs
@@ -24,8 +24,8 @@ struct Cli {
 enum Commands {
     Cardtest {
         #[arg(long)]
-        #[clap(default_value = "1")]
-        scale_factor: i32,
+        #[clap(default_value = "0.01")]
+        scale_factor: f64,
         #[arg(long)]
         #[clap(default_value = "15721")]
         seed: i32,

--- a/optd-perftest/src/main.rs
+++ b/optd-perftest/src/main.rs
@@ -50,6 +50,14 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn cardtest(tpch_config: TpchConfig) -> anyhow::Result<()> {
-    println!("tpch_config={:?}", tpch_config);
+    let pg_db = PostgresDb::build().await?;
+    let databases: Vec<Box<dyn CardtestRunnerDBHelper>> = vec![Box::new(pg_db)];
+
+    let tpch_benchmark = Benchmark::Tpch(tpch_config.clone());
+    let cardtest_runner = CardtestRunner::new(databases).await?;
+    let qerrors = cardtest_runner
+        .eval_benchmark_qerrors_alldbs(&tpch_benchmark)
+        .await?;
+    println!("qerrors: {:?}", qerrors);
     Ok(())
 }

--- a/optd-perftest/src/main.rs
+++ b/optd-perftest/src/main.rs
@@ -54,7 +54,7 @@ async fn cardtest(tpch_config: TpchConfig) -> anyhow::Result<()> {
     let databases: Vec<Box<dyn CardtestRunnerDBHelper>> = vec![Box::new(pg_db)];
 
     let tpch_benchmark = Benchmark::Tpch(tpch_config.clone());
-    let cardtest_runner = CardtestRunner::new(databases).await?;
+    let mut cardtest_runner = CardtestRunner::new(databases).await?;
     let qerrors = cardtest_runner
         .eval_benchmark_qerrors_alldbs(&tpch_benchmark)
         .await?;

--- a/optd-perftest/src/postgres_db.rs
+++ b/optd-perftest/src/postgres_db.rs
@@ -253,7 +253,10 @@ impl CardtestRunnerDBHelper for PostgresDb {
         "Postgres"
     }
 
-    async fn eval_benchmark_estcards(&mut self, benchmark: &Benchmark) -> anyhow::Result<Vec<usize>> {
+    async fn eval_benchmark_estcards(
+        &mut self,
+        benchmark: &Benchmark,
+    ) -> anyhow::Result<Vec<usize>> {
         self.load_benchmark_data(benchmark).await?;
         match benchmark {
             Benchmark::Test => unimplemented!(),
@@ -261,7 +264,10 @@ impl CardtestRunnerDBHelper for PostgresDb {
         }
     }
 
-    async fn eval_benchmark_truecards(&mut self, benchmark: &Benchmark) -> anyhow::Result<Vec<usize>> {
+    async fn eval_benchmark_truecards(
+        &mut self,
+        benchmark: &Benchmark,
+    ) -> anyhow::Result<Vec<usize>> {
         self.load_benchmark_data(benchmark).await?;
         match benchmark {
             Benchmark::Test => unimplemented!(),

--- a/optd-perftest/src/postgres_db.rs
+++ b/optd-perftest/src/postgres_db.rs
@@ -33,6 +33,8 @@ pub struct PostgresDb {
 ///   - Setup should be done in build() unless it requires more information (like benchmark)
 impl PostgresDb {
     pub async fn build() -> anyhow::Result<Self> {
+        log::debug!("[start] building PostgresDb");
+
         // build paths, sometimes creating them if they don't exist
         let curr_dpath = env::current_dir()?;
         let postgres_db_dpath = Path::new(file!())
@@ -61,6 +63,7 @@ impl PostgresDb {
         db.start_postgres().await?;
         db.connect_to_postgres().await?;
 
+        log::debug!("[end] building PostgresDb");
         Ok(db)
     }
 
@@ -178,7 +181,7 @@ impl PostgresDb {
         Ok(())
     }
 
-    async fn load_benchmark_data(&self, benchmark: &Benchmark) -> anyhow::Result<()> {
+    async fn load_benchmark_data(&mut self, benchmark: &Benchmark) -> anyhow::Result<()> {
         let benchmark_stringid = benchmark.get_stringid();
         if benchmark.is_readonly() {
             let done_fname = format!("{}_done", benchmark_stringid);
@@ -200,7 +203,7 @@ impl PostgresDb {
     }
 
     /// Load the benchmark data without worrying about caching
-    async fn load_benchmark_data_raw(&self, benchmark: &Benchmark) -> anyhow::Result<()> {
+    async fn load_benchmark_data_raw(&mut self, benchmark: &Benchmark) -> anyhow::Result<()> {
         match benchmark {
             Benchmark::Tpch(tpch_config) => self.load_tpch_data_raw(tpch_config).await?,
             _ => unimplemented!(),
@@ -209,13 +212,15 @@ impl PostgresDb {
     }
 
     /// Load the TPC-H data without worrying about caching
-    async fn load_tpch_data_raw(&self, tpch_config: &TpchConfig) -> anyhow::Result<()> {
+    async fn load_tpch_data_raw(&mut self, tpch_config: &TpchConfig) -> anyhow::Result<()> {
         // start from a clean slate
         self.remove_pgdata().await?;
         // since we deleted pgdata we'll need to re-init it
         self.init_pgdata().await?;
         // postgres must be started again since remove_pgdata() stops it
         self.start_postgres().await?;
+        // deleting pgdata would also delete the old connection so we have to reconnect
+        self.connect_to_postgres().await?;
         // load the schema
         let tpch_kit = TpchKit::build()?;
         shell::run_command_with_status_check(&format!(
@@ -248,7 +253,7 @@ impl CardtestRunnerDBHelper for PostgresDb {
         "Postgres"
     }
 
-    async fn eval_benchmark_estcards(&self, benchmark: &Benchmark) -> anyhow::Result<Vec<usize>> {
+    async fn eval_benchmark_estcards(&mut self, benchmark: &Benchmark) -> anyhow::Result<Vec<usize>> {
         self.load_benchmark_data(benchmark).await?;
         match benchmark {
             Benchmark::Test => unimplemented!(),
@@ -256,7 +261,7 @@ impl CardtestRunnerDBHelper for PostgresDb {
         }
     }
 
-    async fn eval_benchmark_truecards(&self, benchmark: &Benchmark) -> anyhow::Result<Vec<usize>> {
+    async fn eval_benchmark_truecards(&mut self, benchmark: &Benchmark) -> anyhow::Result<Vec<usize>> {
         self.load_benchmark_data(benchmark).await?;
         match benchmark {
             Benchmark::Test => unimplemented!(),

--- a/optd-perftest/src/tpch.rs
+++ b/optd-perftest/src/tpch.rs
@@ -14,7 +14,7 @@ const NUM_TPCH_QUERIES: usize = 22;
 #[derive(Clone, Debug)]
 pub struct TpchConfig {
     pub database: String,
-    pub scale_factor: i32,
+    pub scale_factor: f64,
     pub seed: i32,
 }
 

--- a/optd-perftest/src/tpch.rs
+++ b/optd-perftest/src/tpch.rs
@@ -11,7 +11,7 @@ const TPCH_KIT_REPO_URL: &str = "git@github.com:lmwnshn/tpch-kit.git";
 pub const TPCH_KIT_POSTGRES: &str = "POSTGRESQL";
 const NUM_TPCH_QUERIES: usize = 22;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct TpchConfig {
     pub database: String,
     pub scale_factor: i32,

--- a/optd-perftest/src/tpch.rs
+++ b/optd-perftest/src/tpch.rs
@@ -44,6 +44,8 @@ pub struct TpchKit {
 /// I keep the same conventions for these methods as I do for PostgresDb
 impl TpchKit {
     pub fn build() -> io::Result<Self> {
+        log::debug!("[start] building TpchKit");
+
         // build paths, sometimes creating them if they don't exist
         // we assume that this is being run in the base optd repo dir
         let optd_repo_dpath = env::current_dir()?;
@@ -88,6 +90,7 @@ impl TpchKit {
         // do setup after creating kit
         kit.clonepull_tpch_kit_repo()?;
 
+        log::debug!("[end] building TpchKit");
         Ok(kit)
     }
 


### PR DESCRIPTION
**Summary**: An extensible CLI built with `clap` for the `optd-perftest` package

**Demo**:

https://github.com/cmu-db/optd/assets/20631215/05315dcc-6a91-4c4d-a9ea-fdb8d15ba675


**Details**:
* The CLI currently only exposes the `cardtest` option (cardinality testing) but can be extended to support more types of performance tests
* The `cardtest` option takes in scale factor and seed as options, but both have defaults as well
* Fixed a bug where we forgot to reconnect after reinitializing pgdata