### PR TITLE
feat: custom "workspaces" for generated data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,3 @@
 /.DS_Store
 /.idea
 .history
-optd-perftest/**/genned_tables
-optd-perftest/**/genned_queries
-optd-perftest/**/tpch-kit
-optd-perftest/**/pgdata
-optd-perftest/**/postgres_log

--- a/optd-perftest/src/main.rs
+++ b/optd-perftest/src/main.rs
@@ -1,3 +1,5 @@
+use std::fs;
+
 use cardtest::{CardtestRunner, CardtestRunnerDBHelper};
 use clap::{Parser, Subcommand};
 use postgres_db::PostgresDb;
@@ -42,6 +44,11 @@ enum Commands {
 async fn main() -> anyhow::Result<()> {
     env_logger::init();
     let cli = Cli::parse();
+
+    let workspace_dpath = shell::parse_pathstr(&cli.workspace)?;
+    if !workspace_dpath.exists() {
+        fs::create_dir(&workspace_dpath)?;
+    }
 
     match &cli.command {
         Commands::Cardtest { scale_factor, seed } => {

--- a/optd-perftest/src/main.rs
+++ b/optd-perftest/src/main.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use std::{fs, path::Path};
 
 use cardtest::{CardtestRunner, CardtestRunnerDBHelper};
 use clap::{Parser, Subcommand};
@@ -57,13 +57,16 @@ async fn main() -> anyhow::Result<()> {
                 scale_factor: *scale_factor,
                 seed: *seed,
             };
-            cardtest(tpch_config).await
+            cardtest(&workspace_dpath, tpch_config).await
         }
     }
 }
 
-async fn cardtest(tpch_config: TpchConfig) -> anyhow::Result<()> {
-    let pg_db = PostgresDb::build().await?;
+async fn cardtest<P: AsRef<Path>>(
+    workspace_dpath: P,
+    tpch_config: TpchConfig,
+) -> anyhow::Result<()> {
+    let pg_db = PostgresDb::build(workspace_dpath).await?;
     let databases: Vec<Box<dyn CardtestRunnerDBHelper>> = vec![Box::new(pg_db)];
 
     let tpch_benchmark = Benchmark::Tpch(tpch_config.clone());

--- a/optd-perftest/src/main.rs
+++ b/optd-perftest/src/main.rs
@@ -16,6 +16,12 @@ mod tpch;
 
 #[derive(Parser)]
 struct Cli {
+    #[arg(long)]
+    #[clap(default_value = "../optd_perftest_workspace")]
+    #[clap(
+        help = "The directory where artifacts required for performance testing (such as pgdata or TPC-H queries) are generated. See comment of parse_pathstr() to see what paths are allowed (TLDR: absolute and relative both ok)."
+    )]
+    workspace: String,
     #[command(subcommand)]
     command: Commands,
 }

--- a/optd-perftest/src/shell.rs
+++ b/optd-perftest/src/shell.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
-use std::{fs, io};
 use std::str;
+use std::{fs, io};
 
 /// Runs a command, exiting the program immediately if the command fails
 pub fn run_command_with_status_check(cmd_str: &str) -> io::Result<Output> {

--- a/optd-perftest/src/shell.rs
+++ b/optd-perftest/src/shell.rs
@@ -1,6 +1,7 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use std::{fs, io};
+use std::str;
 
 /// Runs a command, exiting the program immediately if the command fails
 pub fn run_command_with_status_check(cmd_str: &str) -> io::Result<Output> {
@@ -36,4 +37,23 @@ where
         fs::create_dir(&dpath)?;
     }
     Ok(())
+}
+
+/// Get the path of the root "optd" repo directory
+pub fn get_optd_root() -> io::Result<PathBuf> {
+    let output = run_command_with_status_check("git rev-parse --show-toplevel")?;
+    let path = str::from_utf8(&output.stdout).unwrap().trim();
+    let path = PathBuf::from(path);
+    Ok(path)
+}
+
+/// Can be an absolute path or a relative path. Regardless of where this CLI is run, relative paths are evaluated relative to the optd repo root.
+pub fn parse_pathstr(pathstr: &str) -> io::Result<PathBuf> {
+    let path = PathBuf::from(pathstr);
+    let path = if path.is_relative() {
+        get_optd_root()?.join(path)
+    } else {
+        path
+    };
+    Ok(path)
 }


### PR DESCRIPTION
**Summary**: Instead of generating data (queries, schema, etc.) directly inside the optd repo, we generate them inside a custom "workspace" directory.

**Demo**:

https://github.com/cmu-db/optd/assets/20631215/56931dce-6ac0-499f-a968-dde34f103f70

**Details**:
* The current main use case of this is to run tests locally with a "clean" workspace without needing to delete local files
* Workspaces are a CLI arg
* Relative paths are allowed and are interpreted relative to the root directory of the optd repository using `parse_pathstr()`