### PR TITLE
Fix: fix empty relation schema maintainence across passes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,6 +793,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2686,6 +2695,7 @@ dependencies = [
  "arrow-schema",
  "assert_approx_eq",
  "async-trait",
+ "bincode",
  "camelpaste",
  "datafusion",
  "datafusion-expr",
@@ -2696,6 +2706,7 @@ dependencies = [
  "optd-gungnir",
  "ordered-float 4.2.0",
  "pretty-xmlish",
+ "serde",
  "tracing",
  "tracing-subscriber",
 ]

--- a/optd-core/src/rel_node.rs
+++ b/optd-core/src/rel_node.rs
@@ -151,6 +151,13 @@ impl Value {
             _ => panic!("Value is not a string"),
         }
     }
+
+    pub fn as_slice(&self) -> Arc<[u8]> {
+        match self {
+            Value::Serialized(i) => i.clone(),
+            _ => panic!("Value is not a serialized"),
+        }
+    }
 }
 
 /// A RelNode is consisted of a plan node type and some children.

--- a/optd-datafusion-bridge/src/from_optd.rs
+++ b/optd-datafusion-bridge/src/from_optd.rs
@@ -548,10 +548,6 @@ impl OptdPlanContext<'_> {
         node: PlanNode,
         meta: &RelNodeMetaMap,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let mut schema = OptdSchema { fields: vec![] };
-        if node.typ() == OptRelNodeTyp::PhysicalEmptyRelation {
-            schema = node.schema(self.optimizer.unwrap().optd_optimizer());
-        }
         let rel_node = node.into_rel_node();
 
         let group_id = meta
@@ -599,6 +595,7 @@ impl OptdPlanContext<'_> {
             }
             OptRelNodeTyp::PhysicalEmptyRelation => {
                 let physical_node = PhysicalEmptyRelation::from_rel_node(rel_node).unwrap();
+                let schema = physical_node.empty_relation_schema();
                 let datafusion_schema: Schema = from_optd_schema(schema);
                 Arc::new(datafusion::physical_plan::empty::EmptyExec::new(
                     physical_node.produce_one_row(),

--- a/optd-datafusion-bridge/src/into_optd.rs
+++ b/optd-datafusion-bridge/src/into_optd.rs
@@ -12,6 +12,7 @@ use optd_datafusion_repr::plan_nodes::{
     LogicalEmptyRelation, LogicalFilter, LogicalJoin, LogicalLimit, LogicalProjection, LogicalScan,
     LogicalSort, OptRelNode, OptRelNodeRef, OptRelNodeTyp, PlanNode, SortOrderExpr, SortOrderType,
 };
+use optd_datafusion_repr::properties::schema::Schema as OPTDSchema;
 
 use crate::OptdPlanContext;
 
@@ -366,7 +367,12 @@ impl OptdPlanContext<'_> {
         &mut self,
         node: &logical_plan::EmptyRelation,
     ) -> Result<LogicalEmptyRelation> {
-        Ok(LogicalEmptyRelation::new(node.produce_one_row))
+        // empty_relation from datafusion always have an empty schema
+        let empty_schema = OPTDSchema { fields: vec![] };
+        Ok(LogicalEmptyRelation::new(
+            node.produce_one_row,
+            empty_schema,
+        ))
     }
 
     fn conv_into_optd_limit(&mut self, node: &logical_plan::Limit) -> Result<LogicalLimit> {

--- a/optd-datafusion-repr/Cargo.toml
+++ b/optd-datafusion-repr/Cargo.toml
@@ -22,3 +22,5 @@ datafusion-expr = "32.0.0"
 async-trait = "0.1"
 datafusion = "32.0.0"
 assert_approx_eq = "1.1.0"
+serde = { version = "1.0", features = ["derive"] }
+bincode = "1.3.3"

--- a/optd-datafusion-repr/src/plan_nodes.rs
+++ b/optd-datafusion-repr/src/plan_nodes.rs
@@ -23,7 +23,7 @@ use optd_core::{
 
 pub use agg::{LogicalAgg, PhysicalAgg};
 pub use apply::{ApplyType, LogicalApply};
-pub use empty_relation::{LogicalEmptyRelation, PhysicalEmptyRelation};
+pub use empty_relation::{EmptyRelationData, LogicalEmptyRelation, PhysicalEmptyRelation};
 pub use expr::{
     BetweenExpr, BinOpExpr, BinOpType, CastExpr, ColumnRefExpr, ConstantExpr, ConstantType,
     DataTypeExpr, ExprList, FuncExpr, FuncType, InListExpr, LikeExpr, LogOpExpr, LogOpType,

--- a/optd-datafusion-repr/src/plan_nodes/expr.rs
+++ b/optd-datafusion-repr/src/plan_nodes/expr.rs
@@ -3,6 +3,7 @@ use std::{fmt::Display, sync::Arc};
 use arrow_schema::DataType;
 use itertools::Itertools;
 use pretty_xmlish::Pretty;
+use serde::{Deserialize, Serialize};
 
 use optd_core::rel_node::{RelNode, RelNodeMetaMap, Value};
 
@@ -65,7 +66,7 @@ impl OptRelNode for ExprList {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
 pub enum ConstantType {
     Bool,
     Utf8String,
@@ -84,12 +85,9 @@ pub enum ConstantType {
     Any,
 }
 
-#[derive(Clone, Debug)]
-pub struct ConstantExpr(pub Expr);
-
-impl ConstantExpr {
-    pub fn new(value: Value) -> Self {
-        let typ = match &value {
+impl ConstantType {
+    pub fn get_data_type_from_value(value: &Value) -> Self {
+        match value {
             Value::Bool(_) => ConstantType::Bool,
             Value::String(_) => ConstantType::Utf8String,
             Value::UInt8(_) => ConstantType::UInt8,
@@ -102,7 +100,16 @@ impl ConstantExpr {
             Value::Int64(_) => ConstantType::Int64,
             Value::Float(_) => ConstantType::Float64,
             _ => unimplemented!(),
-        };
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ConstantExpr(pub Expr);
+
+impl ConstantExpr {
+    pub fn new(value: Value) -> Self {
+        let typ = ConstantType::get_data_type_from_value(&value);
         Self::new_with_type(value, typ)
     }
 

--- a/optd-datafusion-repr/src/properties.rs
+++ b/optd-datafusion-repr/src/properties.rs
@@ -1,2 +1,4 @@
 pub mod column_ref;
 pub mod schema;
+
+const DEFAULT_NAME: &str = "unnamed";

--- a/optd-datafusion-repr/src/properties/column_ref.rs
+++ b/optd-datafusion-repr/src/properties/column_ref.rs
@@ -7,7 +7,6 @@ use crate::plan_nodes::{EmptyRelationData, OptRelNodeTyp};
 use super::schema::Catalog;
 use super::DEFAULT_NAME;
 
-
 #[derive(Clone, Debug)]
 pub enum ColumnRef {
     BaseTableColumnRef { table: String, col_idx: usize },

--- a/optd-datafusion-repr/src/properties/column_ref.rs
+++ b/optd-datafusion-repr/src/properties/column_ref.rs
@@ -5,6 +5,8 @@ use optd_core::property::PropertyBuilder;
 use crate::plan_nodes::{EmptyRelationData, OptRelNodeTyp};
 
 use super::schema::Catalog;
+use super::DEFAULT_NAME;
+
 
 #[derive(Clone, Debug)]
 pub enum ColumnRef {
@@ -63,7 +65,7 @@ impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
                 let column_cnt = schema.fields.len();
                 (0..column_cnt)
                     .map(|i| ColumnRef::BaseTableColumnRef {
-                        table: "unnamed".to_string(),
+                        table: DEFAULT_NAME.to_string(),
                         col_idx: i,
                     })
                     .collect()

--- a/optd-datafusion-repr/src/properties/schema.rs
+++ b/optd-datafusion-repr/src/properties/schema.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 
 use optd_core::property::PropertyBuilder;
 
-use crate::plan_nodes::{ConstantType, EmptyRelationData, OptRelNodeTyp};
 use super::DEFAULT_NAME;
+use crate::plan_nodes::{ConstantType, EmptyRelationData, OptRelNodeTyp};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Field {

--- a/optd-datafusion-repr/src/properties/schema.rs
+++ b/optd-datafusion-repr/src/properties/schema.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use optd_core::property::PropertyBuilder;
 
 use crate::plan_nodes::{ConstantType, EmptyRelationData, OptRelNodeTyp};
+use super::DEFAULT_NAME;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Field {
@@ -72,7 +73,7 @@ impl PropertyBuilder<OptRelNodeTyp> for SchemaPropertyBuilder {
                 let data_typ = ConstantType::get_data_type_from_value(&data.unwrap());
                 Schema {
                     fields: vec![Field {
-                        name: "unnamed".to_string(),
+                        name: DEFAULT_NAME.to_string(),
                         typ: data_typ,
                         nullable: true,
                     }],
@@ -88,7 +89,7 @@ impl PropertyBuilder<OptRelNodeTyp> for SchemaPropertyBuilder {
             OptRelNodeTyp::LogOp(_) => Schema {
                 fields: vec![
                     Field {
-                        name: "unnamed".to_string(),
+                        name: DEFAULT_NAME.to_string(),
                         typ: ConstantType::Any,
                         nullable: true
                     };

--- a/optd-datafusion-repr/src/properties/schema.rs
+++ b/optd-datafusion-repr/src/properties/schema.rs
@@ -1,16 +1,17 @@
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use optd_core::property::PropertyBuilder;
 
-use crate::plan_nodes::{ConstantType, OptRelNodeTyp};
+use crate::plan_nodes::{ConstantType, EmptyRelationData, OptRelNodeTyp};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Field {
     pub name: String,
     pub typ: ConstantType,
     pub nullable: bool,
 }
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Schema {
     pub fields: Vec<Field>,
 }
@@ -61,18 +62,28 @@ impl PropertyBuilder<OptRelNodeTyp> for SchemaPropertyBuilder {
                 schema.fields.extend(schema2.fields);
                 schema
             }
-            OptRelNodeTyp::List => {
-                // TODO: calculate real is_nullable for aggregations
+            OptRelNodeTyp::EmptyRelation => {
+                let data = data.unwrap().as_slice();
+                let empty_relation_data: EmptyRelationData =
+                    bincode::deserialize(data.as_ref()).unwrap();
+                empty_relation_data.schema
+            }
+            OptRelNodeTyp::ColumnRef => {
+                let data_typ = ConstantType::get_data_type_from_value(&data.unwrap());
                 Schema {
-                    fields: vec![
-                        Field {
-                            name: "unnamed".to_string(),
-                            typ: ConstantType::Any,
-                            nullable: true
-                        };
-                        children.len()
-                    ],
+                    fields: vec![Field {
+                        name: "unnamed".to_string(),
+                        typ: data_typ,
+                        nullable: true,
+                    }],
                 }
+            }
+            OptRelNodeTyp::List => {
+                let mut fields = vec![];
+                for child in children {
+                    fields.extend(child.fields.clone());
+                }
+                Schema { fields }
             }
             OptRelNodeTyp::LogOp(_) => Schema {
                 fields: vec![

--- a/optd-datafusion-repr/src/rules/eliminate_limit.rs
+++ b/optd-datafusion-repr/src/rules/eliminate_limit.rs
@@ -1,13 +1,14 @@
-use std::collections::HashMap;
-
 use optd_core::rules::{Rule, RuleMatcher};
 use optd_core::{optimizer::Optimizer, rel_node::RelNode};
+use std::collections::HashMap;
+use std::sync::Arc;
 
 use crate::plan_nodes::{
     ConstantExpr, ConstantType, LogicalEmptyRelation, OptRelNode, OptRelNodeTyp,
 };
 
 use super::macros::define_rule;
+use crate::properties::schema::SchemaPropertyBuilder;
 
 define_rule!(
     EliminateLimitRule,
@@ -19,7 +20,7 @@ define_rule!(
 ///     - Limit with skip 0 and no fetch -> Eliminate from the tree
 ///     - Limit with limit 0 -> EmptyRelation
 fn apply_eliminate_limit(
-    _optimizer: &impl Optimizer<OptRelNodeTyp>,
+    optimizer: &impl Optimizer<OptRelNodeTyp>,
     EliminateLimitRulePicks { child, skip, fetch }: EliminateLimitRulePicks,
 ) -> Vec<RelNode<OptRelNodeTyp>> {
     if let OptRelNodeTyp::Constant(ConstantType::UInt64) = skip.typ {
@@ -37,10 +38,13 @@ fn apply_eliminate_limit(
             // Bad convention to have u64 max represent None
             let fetch_is_none = fetch_val == u64::MAX;
 
+            let schema =
+                optimizer.get_property::<SchemaPropertyBuilder>(Arc::new(child.clone()), 0);
+
             if fetch_is_none && skip_val == 0 {
                 return vec![child];
             } else if fetch_val == 0 {
-                let node = LogicalEmptyRelation::new(false);
+                let node = LogicalEmptyRelation::new(false, schema);
                 return vec![node.into_rel_node().as_ref().clone()];
             }
         }


### PR DESCRIPTION
# Why we need this pr?
Previously. EmptyRelation's schema is derived from its logically equivalent peer exprs. For example, the schema for `select * from empty_relation` is deducted from `select * from t1 inner join t2 on false`.  And the empty relation expression will replace the original inner join.

It works fine in the first pass as empty relation is always transformed from expressions having proper schema(except for queries like `select 64;`, it is directly converted from datafusion and has empty schema).

But it will break adaptive design as the next time query is executed, there's only empty relation left in the optimization tree and there's no way to deduct schema properties from pure empty relation.

# Design
we serialize schema as emptyRelation's data value and it is stored in its relnode, once we need the schema we fetch it from empty relation's data.

# Major Changes
- schema prop maintains the type for ColumnRef typ and List typ
- adds convertion from Value to ConstantType to convert data to schema field
- adds serialized data to EmptyRelation data so schema is keeped
- change EmptyRelation initialization method
- change columnExpr derivation rules for emptyRelation