### PR TITLE
Feat: add Q11 and Q13 support

### DIFF
--- a/optd-perftest/src/main.rs
+++ b/optd-perftest/src/main.rs
@@ -32,7 +32,7 @@ enum Commands {
         #[arg(long)]
         #[clap(value_delimiter = ',', num_args = 1..)]
         // this is the current list of all queries that work in perftest
-        #[clap(default_value = "2,3,5,7,8,9,10,12,14,17")]
+        #[clap(default_value = "2,3,5,7,8,9,10,11,12,13,14,17")]
         query_ids: Vec<u32>,
 
         #[arg(long)]


### PR DESCRIPTION
Optd now supports TPC-H Q11 and Q13 after https://github.com/cmu-db/optd/pull/115