### PR TITLE
feat: Extend scan node to support additional fields from DataFusion

### DIFF
--- a/optd-datafusion-bridge/src/from_optd.rs
+++ b/optd-datafusion-bridge/src/from_optd.rs
@@ -73,10 +73,38 @@ impl OptdPlanContext<'_> {
         &mut self,
         node: PhysicalScan,
     ) -> Result<Arc<dyn ExecutionPlan + 'static>> {
-        let table = node.into_rel_node().data.as_ref().unwrap().as_str();
+        let table = node.clone().into_rel_node().data.as_ref().unwrap().as_str();
         let source = self.tables.get(table.as_ref()).unwrap();
         let provider = source_as_provider(source)?;
-        let plan = provider.scan(self.session_state, None, &[], None).await?;
+
+        let proj_expr_list = node
+            .projections()
+            .to_vec()
+            .into_iter()
+            .map(|expr| {
+                ConstantExpr::from_rel_node(expr.into_rel_node())
+                    .unwrap()
+                    .value()
+                    .as_u64() as usize
+            })
+            .collect();
+
+        assert!(node.fetch().typ() == OptRelNodeTyp::Constant(ConstantType::UInt64));
+        let fetch = ConstantExpr::from_rel_node(node.fetch().into_rel_node())
+            .unwrap()
+            .value()
+            .as_u64();
+        let fetch_opt: Option<usize> = if fetch == u64::MAX {
+            None
+        } else {
+            Some(fetch.try_into().unwrap())
+        };
+
+        // TODO: Filter expr can't be converted easily to this Expr type
+
+        let plan = provider
+            .scan(self.session_state, Some(&proj_expr_list), &[], fetch_opt)
+            .await?;
         Ok(plan)
     }
 

--- a/optd-datafusion-bridge/src/from_optd.rs
+++ b/optd-datafusion-bridge/src/from_optd.rs
@@ -74,8 +74,6 @@ impl OptdPlanContext<'_> {
         node: PhysicalScan,
     ) -> Result<Arc<dyn ExecutionPlan + 'static>> {
         let table = node.into_rel_node().data.as_ref().unwrap().as_str();
-        dbg!(table.clone());
-        dbg!(self.tables.clone().keys());
         let source = self.tables.get(table.as_ref()).unwrap();
         let provider = source_as_provider(source)?;
         let plan = provider.scan(self.session_state, None, &[], None).await?;

--- a/optd-datafusion-bridge/src/from_optd.rs
+++ b/optd-datafusion-bridge/src/from_optd.rs
@@ -73,7 +73,11 @@ impl OptdPlanContext<'_> {
         &mut self,
         node: PhysicalScan,
     ) -> Result<Arc<dyn ExecutionPlan + 'static>> {
-        let source = self.tables.get(node.table().as_ref()).unwrap();
+        let table = ConstantExpr::from_rel_node(node.table_name().into_rel_node())
+            .unwrap()
+            .value()
+            .as_str();
+        let source = self.tables.get(table.as_ref()).unwrap();
         let provider = source_as_provider(source)?;
         let plan = provider.scan(self.session_state, None, &[], None).await?;
         Ok(plan)

--- a/optd-datafusion-bridge/src/from_optd.rs
+++ b/optd-datafusion-bridge/src/from_optd.rs
@@ -73,10 +73,7 @@ impl OptdPlanContext<'_> {
         &mut self,
         node: PhysicalScan,
     ) -> Result<Arc<dyn ExecutionPlan + 'static>> {
-        let table = ConstantExpr::from_rel_node(node.table_name().into_rel_node())
-            .unwrap()
-            .value()
-            .as_str();
+        let table = node.into_rel_node().data.as_ref().unwrap().as_str();
         let source = self.tables.get(table.as_ref()).unwrap();
         let provider = source_as_provider(source)?;
         let plan = provider.scan(self.session_state, None, &[], None).await?;

--- a/optd-datafusion-bridge/src/from_optd.rs
+++ b/optd-datafusion-bridge/src/from_optd.rs
@@ -74,6 +74,8 @@ impl OptdPlanContext<'_> {
         node: PhysicalScan,
     ) -> Result<Arc<dyn ExecutionPlan + 'static>> {
         let table = node.into_rel_node().data.as_ref().unwrap().as_str();
+        dbg!(table.clone());
+        dbg!(self.tables.clone().keys());
         let source = self.tables.get(table.as_ref()).unwrap();
         let provider = source_as_provider(source)?;
         let plan = provider.scan(self.session_state, None, &[], None).await?;

--- a/optd-datafusion-bridge/src/into_optd.rs
+++ b/optd-datafusion-bridge/src/into_optd.rs
@@ -70,7 +70,7 @@ impl OptdPlanContext<'_> {
         .into_expr();
 
         self.tables
-            .insert(table_name.to_string(), node.source.clone());
+            .insert(table_name.as_str().to_string(), node.source.clone());
         let scan = LogicalScan::new(
             converted_filters,
             converted_projections,

--- a/optd-datafusion-bridge/src/lib.rs
+++ b/optd-datafusion-bridge/src/lib.rs
@@ -137,11 +137,7 @@ fn get_join_order(rel_node: OptRelNodeRef) -> Option<JoinOrder> {
             let scan =
                 optd_datafusion_repr::plan_nodes::PhysicalScan::from_rel_node(rel_node).unwrap();
             Some(JoinOrder::Table(
-                ConstantExpr::from_rel_node(scan.table_name().into_rel_node())
-                    .unwrap()
-                    .value()
-                    .as_str()
-                    .to_string(),
+                scan.into_rel_node().data.as_ref().unwrap().to_string(),
             ))
         }
         _ => {

--- a/optd-datafusion-bridge/src/lib.rs
+++ b/optd-datafusion-bridge/src/lib.rs
@@ -19,7 +19,7 @@ use datafusion::{
 use itertools::Itertools;
 use optd_datafusion_repr::{
     plan_nodes::{
-        ConstantType, OptRelNode, OptRelNodeRef, OptRelNodeTyp, PhysicalHashJoin,
+        ConstantExpr, ConstantType, OptRelNode, OptRelNodeRef, OptRelNodeTyp, PhysicalHashJoin,
         PhysicalNestedLoopJoin, PlanNode,
     },
     properties::schema::Catalog,
@@ -136,7 +136,13 @@ fn get_join_order(rel_node: OptRelNodeRef) -> Option<JoinOrder> {
         OptRelNodeTyp::PhysicalScan => {
             let scan =
                 optd_datafusion_repr::plan_nodes::PhysicalScan::from_rel_node(rel_node).unwrap();
-            Some(JoinOrder::Table(scan.table().to_string()))
+            Some(JoinOrder::Table(
+                ConstantExpr::from_rel_node(scan.table_name().into_rel_node())
+                    .unwrap()
+                    .value()
+                    .as_str()
+                    .to_string(),
+            ))
         }
         _ => {
             for child in &rel_node.children {

--- a/optd-datafusion-bridge/src/lib.rs
+++ b/optd-datafusion-bridge/src/lib.rs
@@ -19,7 +19,7 @@ use datafusion::{
 use itertools::Itertools;
 use optd_datafusion_repr::{
     plan_nodes::{
-        ConstantExpr, ConstantType, OptRelNode, OptRelNodeRef, OptRelNodeTyp, PhysicalHashJoin,
+        ConstantType, OptRelNode, OptRelNodeRef, OptRelNodeTyp, PhysicalHashJoin,
         PhysicalNestedLoopJoin, PlanNode,
     },
     properties::schema::Catalog,

--- a/optd-datafusion-repr/src/bin/test_optimize.rs
+++ b/optd-datafusion-repr/src/bin/test_optimize.rs
@@ -53,10 +53,10 @@ pub fn main() {
 
     // The plan: (filter (scan t1) #1=2) join (scan t2) join (scan t3)
     let scan1 = LogicalScan::new(
-        ConstantExpr::new(Value::String("t1".into())).into_expr(),
         ConstantExpr::new(Value::Bool(true)).into_expr(),
         ExprList::new(vec![]),
         ConstantExpr::new(Value::UInt64(u64::MAX)).into_expr(),
+        Value::String("t1".into()),
     );
     let filter_cond = BinOpExpr::new(
         ColumnRefExpr::new(1).0,
@@ -65,17 +65,17 @@ pub fn main() {
     );
     let filter1 = LogicalFilter::new(scan1.0, filter_cond.0);
     let scan2 = LogicalScan::new(
-        ConstantExpr::new(Value::String("t2".into())).into_expr(),
         ConstantExpr::new(Value::Bool(true)).into_expr(),
         ExprList::new(vec![]),
         ConstantExpr::new(Value::UInt64(u64::MAX)).into_expr(),
+        Value::String("t2".into()),
     );
     let join_cond = ConstantExpr::new(Value::Bool(true));
     let scan3 = LogicalScan::new(
-        ConstantExpr::new(Value::String("t3".into())).into_expr(),
         ConstantExpr::new(Value::Bool(true)).into_expr(),
         ExprList::new(vec![]),
         ConstantExpr::new(Value::UInt64(u64::MAX)).into_expr(),
+        Value::String("t3".into()),
     );
     let join_filter = LogicalJoin::new(filter1.0, scan2.0, join_cond.clone().0, JoinType::Inner);
     let fnal = LogicalJoin::new(scan3.0, join_filter.0, join_cond.0, JoinType::Inner);

--- a/optd-datafusion-repr/src/bin/test_optimize.rs
+++ b/optd-datafusion-repr/src/bin/test_optimize.rs
@@ -10,8 +10,8 @@ use optd_core::{
 use optd_datafusion_repr::{
     cost::{OptCostModel, PerTableStats},
     plan_nodes::{
-        BinOpExpr, BinOpType, ColumnRefExpr, ConstantExpr, JoinType, LogicalFilter, LogicalJoin,
-        LogicalScan, OptRelNode, OptRelNodeTyp, PlanNode,
+        BinOpExpr, BinOpType, ColumnRefExpr, ConstantExpr, ExprList, JoinType, LogicalFilter,
+        LogicalJoin, LogicalScan, OptRelNode, OptRelNodeTyp, PlanNode,
     },
     rules::{HashJoinRule, JoinAssocRule, JoinCommuteRule, PhysicalConversionRule},
 };
@@ -52,16 +52,31 @@ pub fn main() {
     );
 
     // The plan: (filter (scan t1) #1=2) join (scan t2) join (scan t3)
-    let scan1 = LogicalScan::new("t1".into());
+    let scan1 = LogicalScan::new(
+        ConstantExpr::new(Value::String("t1".into())).into_expr(),
+        ConstantExpr::new(Value::Bool(true)).into_expr(),
+        ExprList::new(vec![]),
+        ConstantExpr::new(Value::UInt64(u64::MAX)).into_expr(),
+    );
     let filter_cond = BinOpExpr::new(
         ColumnRefExpr::new(1).0,
         ConstantExpr::new(Value::Int64(2)).0,
         BinOpType::Eq,
     );
     let filter1 = LogicalFilter::new(scan1.0, filter_cond.0);
-    let scan2 = LogicalScan::new("t2".into());
+    let scan2 = LogicalScan::new(
+        ConstantExpr::new(Value::String("t2".into())).into_expr(),
+        ConstantExpr::new(Value::Bool(true)).into_expr(),
+        ExprList::new(vec![]),
+        ConstantExpr::new(Value::UInt64(u64::MAX)).into_expr(),
+    );
     let join_cond = ConstantExpr::new(Value::Bool(true));
-    let scan3 = LogicalScan::new("t3".into());
+    let scan3 = LogicalScan::new(
+        ConstantExpr::new(Value::String("t3".into())).into_expr(),
+        ConstantExpr::new(Value::Bool(true)).into_expr(),
+        ExprList::new(vec![]),
+        ConstantExpr::new(Value::UInt64(u64::MAX)).into_expr(),
+    );
     let join_filter = LogicalJoin::new(filter1.0, scan2.0, join_cond.clone().0, JoinType::Inner);
     let fnal = LogicalJoin::new(scan3.0, join_filter.0, join_cond.0, JoinType::Inner);
     let node = optimizer.optimize(fnal.0.clone().into_rel_node());

--- a/optd-datafusion-repr/src/plan_nodes/macros.rs
+++ b/optd-datafusion-repr/src/plan_nodes/macros.rs
@@ -48,6 +48,7 @@ macro_rules! define_plan_node {
                 $(, $data_name : Value)?
                 $(, $inner_name : $inner_typ)?
             ) -> $struct_name {
+                #[allow(unused_mut, unused)]
                 let mut data = None;
                 $(
                     data = Some($data_name);

--- a/optd-datafusion-repr/src/plan_nodes/macros.rs
+++ b/optd-datafusion-repr/src/plan_nodes/macros.rs
@@ -5,6 +5,7 @@ macro_rules! define_plan_node {
         [ $({ $child_id:literal, $child_name:ident : $child_meta_typ:ty }),* ] ,
         [ $({ $attr_id:literal, $attr_name:ident : $attr_meta_typ:ty }),* ]
         $(, { $inner_name:ident : $inner_typ:ty })?
+        $(, $data_name:ident)?
     ) => {
         impl OptRelNode for $struct_name {
             fn into_rel_node(self) -> OptRelNodeRef {
@@ -44,8 +45,15 @@ macro_rules! define_plan_node {
             pub fn new(
                 $($child_name : $child_meta_typ,)*
                 $($attr_name : $attr_meta_typ),*
+                $(, $data_name : Value)?
                 $(, $inner_name : $inner_typ)?
             ) -> $struct_name {
+                let mut data = None;
+                $(
+                    data = Some($data_name);
+                )?
+
+
                 $struct_name($meta_typ(
                     optd_core::rel_node::RelNode {
                         typ: OptRelNodeTyp::$variant $( ($inner_name) )?,
@@ -53,7 +61,7 @@ macro_rules! define_plan_node {
                             $($child_name.into_rel_node(),)*
                             $($attr_name.into_rel_node()),*
                         ],
-                        data: None,
+                        data
                     }
                     .into(),
                 ))

--- a/optd-datafusion-repr/src/plan_nodes/scan.rs
+++ b/optd-datafusion-repr/src/plan_nodes/scan.rs
@@ -21,7 +21,7 @@ pub struct PhysicalScan(pub PlanNode);
 
 define_plan_node!(
     PhysicalScan : PlanNode,
-    Scan, [], [
+    PhysicalScan, [], [
         { 0, filter: Expr },
         { 1, projections: ExprList },
         { 2, fetch: Expr }

--- a/optd-datafusion-repr/src/plan_nodes/scan.rs
+++ b/optd-datafusion-repr/src/plan_nodes/scan.rs
@@ -1,82 +1,102 @@
-use std::sync::Arc;
-
-use pretty_xmlish::Pretty;
-
 use crate::explain::Insertable;
-use optd_core::rel_node::{RelNode, RelNodeMetaMap, Value};
 
-use super::{replace_typ, OptRelNode, OptRelNodeRef, OptRelNodeTyp, PlanNode};
+use super::{
+    macros::define_plan_node, Expr, ExprList, OptRelNode, OptRelNodeRef, OptRelNodeTyp, PlanNode,
+};
 
 #[derive(Clone, Debug)]
 pub struct LogicalScan(pub PlanNode);
 
-impl OptRelNode for LogicalScan {
-    fn into_rel_node(self) -> OptRelNodeRef {
-        self.0.into_rel_node()
-    }
-
-    fn from_rel_node(rel_node: OptRelNodeRef) -> Option<Self> {
-        if rel_node.typ != OptRelNodeTyp::Scan {
-            return None;
-        }
-        PlanNode::from_rel_node(rel_node).map(Self)
-    }
-
-    fn dispatch_explain(&self, _meta_map: Option<&RelNodeMetaMap>) -> Pretty<'static> {
-        Pretty::childless_record(
-            "LogicalScan",
-            vec![("table", self.table().to_string().into())],
-        )
-    }
-}
-
-impl LogicalScan {
-    pub fn new(table: String) -> LogicalScan {
-        LogicalScan(PlanNode(
-            RelNode {
-                typ: OptRelNodeTyp::Scan,
-                children: vec![],
-                data: Some(Value::String(table.into())),
-            }
-            .into(),
-        ))
-    }
-
-    pub fn table(&self) -> Arc<str> {
-        self.clone().into_rel_node().data.as_ref().unwrap().as_str()
-    }
-}
+define_plan_node!(
+    LogicalScan : PlanNode,
+    Scan, [], [
+        { 0, table_name: Expr },
+        { 1, filter: Expr },
+        { 2, projections: ExprList },
+        { 3, fetch: Expr }
+    ]
+);
 
 #[derive(Clone, Debug)]
 pub struct PhysicalScan(pub PlanNode);
 
-impl OptRelNode for PhysicalScan {
-    fn into_rel_node(self) -> OptRelNodeRef {
-        replace_typ(self.0.into_rel_node(), OptRelNodeTyp::PhysicalScan)
-    }
+define_plan_node!(
+    PhysicalScan : PlanNode,
+    Scan, [], [
+        { 0, table_name: Expr },
+        { 1, filter: Expr },
+        { 2, projections: ExprList },
+        { 3, fetch: Expr }
+    ]
+);
 
-    fn from_rel_node(rel_node: OptRelNodeRef) -> Option<Self> {
-        if rel_node.typ != OptRelNodeTyp::PhysicalScan {
-            return None;
-        }
-        PlanNode::from_rel_node(rel_node).map(Self)
-    }
+// impl OptRelNode for LogicalScan {
+//     fn into_rel_node(self) -> OptRelNodeRef {
+//         self.0.into_rel_node()
+//     }
 
-    fn dispatch_explain(&self, meta_map: Option<&RelNodeMetaMap>) -> Pretty<'static> {
-        let mut fields = vec![("table", self.table().to_string().into())];
-        if let Some(meta_map) = meta_map {
-            fields = fields.with_meta(self.0.get_meta(meta_map));
-        }
-        Pretty::childless_record("PhysicalScan", fields)
-    }
-}
+//     fn from_rel_node(rel_node: OptRelNodeRef) -> Option<Self> {
+//         if rel_node.typ != OptRelNodeTyp::Scan {
+//             return None;
+//         }
+//         PlanNode::from_rel_node(rel_node).map(Self)
+//     }
 
-impl PhysicalScan {
-    pub fn new(node: PlanNode) -> PhysicalScan {
-        Self(node)
-    }
+//     fn dispatch_explain(&self, _meta_map: Option<&RelNodeMetaMap>) -> Pretty<'static> {
+//         Pretty::childless_record(
+//             "LogicalScan",
+//             vec![("table", self.table().to_string().into())],
+//         )
+//     }
+// }
 
-    pub fn table(&self) -> Arc<str> {
-        self.clone().into_rel_node().data.as_ref().unwrap().as_str()
-    }
-}
+// impl LogicalScan {
+//     pub fn new(table: String, filter: Expr, projections: ExprList) -> LogicalScan {
+//         LogicalScan(PlanNode(
+//             RelNode {
+//                 typ: OptRelNodeTyp::Scan,
+//                 children: vec![filter, projections],
+//                 data: Some(Value::String(table.into())),
+//             }
+//             .into(),
+//         ))
+//     }
+
+//     pub fn table(&self) -> Arc<str> {
+//         self.clone().into_rel_node().data.as_ref().unwrap().as_str()
+//     }
+// }
+
+// #[derive(Clone, Debug)]
+// pub struct PhysicalScan(pub PlanNode);
+
+// impl OptRelNode for PhysicalScan {
+//     fn into_rel_node(self) -> OptRelNodeRef {
+//         replace_typ(self.0.into_rel_node(), OptRelNodeTyp::PhysicalScan)
+//     }
+
+//     fn from_rel_node(rel_node: OptRelNodeRef) -> Option<Self> {
+//         if rel_node.typ != OptRelNodeTyp::PhysicalScan {
+//             return None;
+//         }
+//         PlanNode::from_rel_node(rel_node).map(Self)
+//     }
+
+//     fn dispatch_explain(&self, meta_map: Option<&RelNodeMetaMap>) -> Pretty<'static> {
+//         let mut fields = vec![("table", self.table().to_string().into())];
+//         if let Some(meta_map) = meta_map {
+//             fields = fields.with_meta(self.0.get_meta(meta_map));
+//         }
+//         Pretty::simple_record("PhysicalScan", fields, self.0.into_rel_node().children())
+//     }
+// }
+
+// impl PhysicalScan {
+//     pub fn new(node: PlanNode) -> PhysicalScan {
+//         Self(node)
+//     }
+
+//     pub fn table(&self) -> Arc<str> {
+//         self.clone().into_rel_node().data.as_ref().unwrap().as_str()
+//     }
+// }

--- a/optd-datafusion-repr/src/plan_nodes/scan.rs
+++ b/optd-datafusion-repr/src/plan_nodes/scan.rs
@@ -1,4 +1,4 @@
-use crate::explain::Insertable;
+use optd_core::rel_node::Value;
 
 use super::{
     macros::define_plan_node, Expr, ExprList, OptRelNode, OptRelNodeRef, OptRelNodeTyp, PlanNode,
@@ -10,11 +10,10 @@ pub struct LogicalScan(pub PlanNode);
 define_plan_node!(
     LogicalScan : PlanNode,
     Scan, [], [
-        { 0, table_name: Expr },
-        { 1, filter: Expr },
-        { 2, projections: ExprList },
-        { 3, fetch: Expr }
-    ]
+        { 0, filter: Expr },
+        { 1, projections: ExprList },
+        { 2, fetch: Expr }
+    ], table_name
 );
 
 #[derive(Clone, Debug)]
@@ -23,80 +22,8 @@ pub struct PhysicalScan(pub PlanNode);
 define_plan_node!(
     PhysicalScan : PlanNode,
     Scan, [], [
-        { 0, table_name: Expr },
-        { 1, filter: Expr },
-        { 2, projections: ExprList },
-        { 3, fetch: Expr }
-    ]
+        { 0, filter: Expr },
+        { 1, projections: ExprList },
+        { 2, fetch: Expr }
+    ], table_name
 );
-
-// impl OptRelNode for LogicalScan {
-//     fn into_rel_node(self) -> OptRelNodeRef {
-//         self.0.into_rel_node()
-//     }
-
-//     fn from_rel_node(rel_node: OptRelNodeRef) -> Option<Self> {
-//         if rel_node.typ != OptRelNodeTyp::Scan {
-//             return None;
-//         }
-//         PlanNode::from_rel_node(rel_node).map(Self)
-//     }
-
-//     fn dispatch_explain(&self, _meta_map: Option<&RelNodeMetaMap>) -> Pretty<'static> {
-//         Pretty::childless_record(
-//             "LogicalScan",
-//             vec![("table", self.table().to_string().into())],
-//         )
-//     }
-// }
-
-// impl LogicalScan {
-//     pub fn new(table: String, filter: Expr, projections: ExprList) -> LogicalScan {
-//         LogicalScan(PlanNode(
-//             RelNode {
-//                 typ: OptRelNodeTyp::Scan,
-//                 children: vec![filter, projections],
-//                 data: Some(Value::String(table.into())),
-//             }
-//             .into(),
-//         ))
-//     }
-
-//     pub fn table(&self) -> Arc<str> {
-//         self.clone().into_rel_node().data.as_ref().unwrap().as_str()
-//     }
-// }
-
-// #[derive(Clone, Debug)]
-// pub struct PhysicalScan(pub PlanNode);
-
-// impl OptRelNode for PhysicalScan {
-//     fn into_rel_node(self) -> OptRelNodeRef {
-//         replace_typ(self.0.into_rel_node(), OptRelNodeTyp::PhysicalScan)
-//     }
-
-//     fn from_rel_node(rel_node: OptRelNodeRef) -> Option<Self> {
-//         if rel_node.typ != OptRelNodeTyp::PhysicalScan {
-//             return None;
-//         }
-//         PlanNode::from_rel_node(rel_node).map(Self)
-//     }
-
-//     fn dispatch_explain(&self, meta_map: Option<&RelNodeMetaMap>) -> Pretty<'static> {
-//         let mut fields = vec![("table", self.table().to_string().into())];
-//         if let Some(meta_map) = meta_map {
-//             fields = fields.with_meta(self.0.get_meta(meta_map));
-//         }
-//         Pretty::simple_record("PhysicalScan", fields, self.0.into_rel_node().children())
-//     }
-// }
-
-// impl PhysicalScan {
-//     pub fn new(node: PlanNode) -> PhysicalScan {
-//         Self(node)
-//     }
-
-//     pub fn table(&self) -> Arc<str> {
-//         self.clone().into_rel_node().data.as_ref().unwrap().as_str()
-//     }
-// }


### PR DESCRIPTION
Moves limits, filtering, and projection into the scan node representation. In the process, I moved the scan node to use macros, which required modifying the macros to support an optional data field.