### PR TITLE
feat: caching optd stats, 12x speedup on TPC-H SF1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2807,6 +2807,7 @@ dependencies = [
  "crossbeam",
  "itertools",
  "rand 0.8.5",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2753,6 +2753,7 @@ dependencies = [
  "num-traits",
  "ordered-float 4.2.0",
  "pretty-xmlish",
+ "serde",
  "tracing",
  "tracing-subscriber",
 ]

--- a/optd-core/Cargo.toml
+++ b/optd-core/Cargo.toml
@@ -14,4 +14,4 @@ ordered-float = "4"
 tracing-subscriber = "0.3"
 pretty-xmlish = "0.1"
 itertools = "0.11"
-serde = {version = "1.0", features = ["derive"]}
+serde = {version = "1.0", features = ["derive", "rc"]}

--- a/optd-core/Cargo.toml
+++ b/optd-core/Cargo.toml
@@ -14,3 +14,4 @@ ordered-float = "4"
 tracing-subscriber = "0.3"
 pretty-xmlish = "0.1"
 itertools = "0.11"
+serde = {version = "1.0", features = ["derive"]}

--- a/optd-core/src/rel_node.rs
+++ b/optd-core/src/rel_node.rs
@@ -51,7 +51,7 @@ impl<'de> Deserialize<'de> for SerializableOrderedF64 {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Value {
     UInt8(u8),
     UInt16(u16),

--- a/optd-core/src/rel_node.rs
+++ b/optd-core/src/rel_node.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use ordered_float::OrderedFloat;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{cascades::GroupId, cost::Cost};
 
@@ -27,6 +28,30 @@ pub trait RelNodeTyp:
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct SerializableOrderedF64(pub OrderedFloat<f64>);
+
+impl Serialize for SerializableOrderedF64 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // Directly serialize the inner f64 value of the OrderedFloat
+        self.0 .0.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for SerializableOrderedF64 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Deserialize an f64 and wrap it in an OrderedFloat
+        let float = f64::deserialize(deserializer)?;
+        Ok(SerializableOrderedF64(OrderedFloat(float)))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Value {
     UInt8(u8),
     UInt16(u16),
@@ -37,7 +62,7 @@ pub enum Value {
     Int32(i32),
     Int64(i64),
     Int128(i128),
-    Float(OrderedFloat<f64>),
+    Float(SerializableOrderedF64),
     String(Arc<str>),
     Bool(bool),
     Date32(i32),
@@ -57,7 +82,7 @@ impl std::fmt::Display for Value {
             Self::Int32(x) => write!(f, "{x}"),
             Self::Int64(x) => write!(f, "{x}"),
             Self::Int128(x) => write!(f, "{x}"),
-            Self::Float(x) => write!(f, "{x}"),
+            Self::Float(x) => write!(f, "{}", x.0),
             Self::String(x) => write!(f, "\"{x}\""),
             Self::Bool(x) => write!(f, "{x}"),
             Self::Date32(x) => write!(f, "{x}"),
@@ -133,7 +158,7 @@ impl Value {
 
     pub fn as_f64(&self) -> f64 {
         match self {
-            Value::Float(i) => **i,
+            Value::Float(i) => *i.0,
             _ => panic!("Value is not an f64"),
         }
     }

--- a/optd-datafusion-repr/src/bin/test_optimize.rs
+++ b/optd-datafusion-repr/src/bin/test_optimize.rs
@@ -8,7 +8,7 @@ use optd_core::{
     rules::{Rule, RuleWrapper},
 };
 use optd_datafusion_repr::{
-    cost::{base_cost::StandardPerTableStats, OptCostModel},
+    cost::{base_cost::DataFusionPerTableStats, OptCostModel},
     plan_nodes::{
         BinOpExpr, BinOpType, ColumnRefExpr, ConstantExpr, JoinType, LogicalFilter, LogicalJoin,
         LogicalScan, OptRelNode, OptRelNodeTyp, PlanNode,
@@ -45,7 +45,7 @@ pub fn main() {
         Box::new(OptCostModel::new(
             [("t1", 1000), ("t2", 100), ("t3", 10000)]
                 .into_iter()
-                .map(|(x, y)| (x.to_string(), StandardPerTableStats::new(y, vec![])))
+                .map(|(x, y)| (x.to_string(), DataFusionPerTableStats::new(y, vec![])))
                 .collect(),
         )),
         vec![],

--- a/optd-datafusion-repr/src/bin/test_optimize.rs
+++ b/optd-datafusion-repr/src/bin/test_optimize.rs
@@ -8,7 +8,7 @@ use optd_core::{
     rules::{Rule, RuleWrapper},
 };
 use optd_datafusion_repr::{
-    cost::{OptCostModel, PerTableStats},
+    cost::{base_cost::StandardPerTableStats, OptCostModel},
     plan_nodes::{
         BinOpExpr, BinOpType, ColumnRefExpr, ConstantExpr, JoinType, LogicalFilter, LogicalJoin,
         LogicalScan, OptRelNode, OptRelNodeTyp, PlanNode,
@@ -45,7 +45,7 @@ pub fn main() {
         Box::new(OptCostModel::new(
             [("t1", 1000), ("t2", 100), ("t3", 10000)]
                 .into_iter()
-                .map(|(x, y)| (x.to_string(), PerTableStats::new(y, vec![])))
+                .map(|(x, y)| (x.to_string(), StandardPerTableStats::new(y, vec![])))
                 .collect(),
         )),
         vec![],

--- a/optd-datafusion-repr/src/cost.rs
+++ b/optd-datafusion-repr/src/cost.rs
@@ -1,5 +1,5 @@
-mod adaptive_cost;
-mod base_cost;
+pub mod adaptive_cost;
+pub mod base_cost;
 mod stats;
 
 pub use adaptive_cost::{AdaptiveCostModel, RuntimeAdaptionStorage, DEFAULT_DECAY};

--- a/optd-datafusion-repr/src/cost/adaptive_cost.rs
+++ b/optd-datafusion-repr/src/cost/adaptive_cost.rs
@@ -10,9 +10,10 @@ use optd_core::{
     rel_node::{RelNode, Value},
 };
 
-use super::base_cost::BaseTableStats;
+use super::base_cost::{BaseTableStats, Distribution, MostCommonValues, StandardDistribution, StandardMostCommonValues};
 
 pub type RuntimeAdaptionStorage = Arc<Mutex<RuntimeAdaptionStorageInner>>;
+pub type StandardAdaptiveCostModel = AdaptiveCostModel<StandardMostCommonValues, StandardDistribution>;
 
 #[derive(Default, Debug)]
 pub struct RuntimeAdaptionStorageInner {
@@ -22,13 +23,13 @@ pub struct RuntimeAdaptionStorageInner {
 
 pub const DEFAULT_DECAY: usize = 50;
 
-pub struct AdaptiveCostModel {
+pub struct AdaptiveCostModel<M: MostCommonValues, D: Distribution> {
     runtime_row_cnt: RuntimeAdaptionStorage,
-    base_model: OptCostModel,
+    base_model: OptCostModel<M, D>,
     decay: usize,
 }
 
-impl CostModel<OptRelNodeTyp> for AdaptiveCostModel {
+impl<M: MostCommonValues, D: Distribution> CostModel<OptRelNodeTyp> for AdaptiveCostModel<M, D> {
     fn explain(&self, cost: &Cost) -> String {
         self.base_model.explain(cost)
     }
@@ -56,11 +57,11 @@ impl CostModel<OptRelNodeTyp> for AdaptiveCostModel {
             {
                 if *iter + self.decay >= guard.iter_cnt {
                     let runtime_row_cnt = (*runtime_row_cnt).max(1) as f64;
-                    return OptCostModel::cost(runtime_row_cnt, 0.0, runtime_row_cnt);
+                    return OptCostModel::<M, D>::cost(runtime_row_cnt, 0.0, runtime_row_cnt);
                 }
             }
         }
-        let (mut row_cnt, compute_cost, io_cost) = OptCostModel::cost_tuple(
+        let (mut row_cnt, compute_cost, io_cost) = OptCostModel::<M, D>::cost_tuple(
             &self
                 .base_model
                 .compute_cost(node, data, children, context.clone(), optimizer),
@@ -74,7 +75,7 @@ impl CostModel<OptRelNodeTyp> for AdaptiveCostModel {
                 }
             }
         }
-        OptCostModel::cost(row_cnt, compute_cost, io_cost)
+        OptCostModel::<M, D>::cost(row_cnt, compute_cost, io_cost)
     }
 
     fn compute_plan_node_cost(&self, node: &RelNode<OptRelNodeTyp>) -> Cost {
@@ -82,8 +83,8 @@ impl CostModel<OptRelNodeTyp> for AdaptiveCostModel {
     }
 }
 
-impl AdaptiveCostModel {
-    pub fn new(decay: usize, stats: BaseTableStats) -> Self {
+impl<M: MostCommonValues, D: Distribution> AdaptiveCostModel<M, D> {
+    pub fn new(decay: usize, stats: BaseTableStats<M, D>) -> Self {
         Self {
             runtime_row_cnt: RuntimeAdaptionStorage::default(),
             base_model: OptCostModel::new(stats),

--- a/optd-datafusion-repr/src/cost/adaptive_cost.rs
+++ b/optd-datafusion-repr/src/cost/adaptive_cost.rs
@@ -10,10 +10,13 @@ use optd_core::{
     rel_node::{RelNode, Value},
 };
 
-use super::base_cost::{BaseTableStats, Distribution, MostCommonValues, StandardDistribution, StandardMostCommonValues};
+use super::base_cost::{
+    BaseTableStats, Distribution, MostCommonValues, StandardDistribution, StandardMostCommonValues,
+};
 
 pub type RuntimeAdaptionStorage = Arc<Mutex<RuntimeAdaptionStorageInner>>;
-pub type StandardAdaptiveCostModel = AdaptiveCostModel<StandardMostCommonValues, StandardDistribution>;
+pub type StandardAdaptiveCostModel =
+    AdaptiveCostModel<StandardMostCommonValues, StandardDistribution>;
 
 #[derive(Default, Debug)]
 pub struct RuntimeAdaptionStorageInner {

--- a/optd-datafusion-repr/src/cost/adaptive_cost.rs
+++ b/optd-datafusion-repr/src/cost/adaptive_cost.rs
@@ -11,12 +11,13 @@ use optd_core::{
 };
 
 use super::base_cost::{
-    BaseTableStats, Distribution, MostCommonValues, StandardDistribution, StandardMostCommonValues,
+    BaseTableStats, DataFusionDistribution, DataFusionMostCommonValues, Distribution,
+    MostCommonValues,
 };
 
 pub type RuntimeAdaptionStorage = Arc<Mutex<RuntimeAdaptionStorageInner>>;
-pub type StandardAdaptiveCostModel =
-    AdaptiveCostModel<StandardMostCommonValues, StandardDistribution>;
+pub type DataFusionAdaptiveCostModel =
+    AdaptiveCostModel<DataFusionMostCommonValues, DataFusionDistribution>;
 
 #[derive(Default, Debug)]
 pub struct RuntimeAdaptionStorageInner {

--- a/optd-datafusion-repr/src/cost/base_cost.rs
+++ b/optd-datafusion-repr/src/cost/base_cost.rs
@@ -36,13 +36,21 @@ fn compute_plan_node_cost<T: RelNodeTyp, C: CostModel<T>>(
     cost
 }
 
-pub type BaseTableStats = HashMap<String, PerTableStats>;
+pub type BaseTableStats<M, D> = HashMap<String, PerTableStats<M, D>>;
 
-pub struct OptCostModel {
-    per_table_stats_map: BaseTableStats,
+// The "standard" concrete types that optd currently uses
+// All of optd (except unit tests) must use the same types
+pub type StandardMostCommonValues = MockMostCommonValues;
+pub type StandardDistribution = TDigest;
+pub type StandardBaseTableStats = BaseTableStats<StandardMostCommonValues, StandardDistribution>;
+pub type StandardPerTableStats = PerTableStats<StandardMostCommonValues, StandardDistribution>;
+pub type StandardPerColumnStats = PerColumnStats<StandardMostCommonValues, StandardDistribution>;
+
+pub struct OptCostModel<M: MostCommonValues, D: Distribution> {
+    per_table_stats_map: BaseTableStats<M, D>,
 }
 
-struct MockMostCommonValues {
+pub struct MockMostCommonValues {
     mcvs: HashMap<Value, f64>,
 }
 
@@ -76,12 +84,12 @@ impl MostCommonValues for MockMostCommonValues {
     }
 }
 
-pub struct PerTableStats {
+pub struct PerTableStats<M: MostCommonValues, D: Distribution> {
     row_cnt: usize,
-    per_column_stats_vec: Vec<Option<PerColumnStats>>,
+    per_column_stats_vec: Vec<Option<PerColumnStats<M, D>>>,
 }
 
-impl PerTableStats {
+impl StandardPerTableStats {
     pub fn from_record_batches<I: IntoIterator<Item = Result<RecordBatch, ArrowError>>>(
         batch_iter: RecordBatchIterator<I>,
     ) -> anyhow::Result<Self> {
@@ -137,12 +145,12 @@ impl PerTableStats {
         let mut per_column_stats_vec = Vec::with_capacity(col_cnt);
         for i in 0..col_cnt {
             per_column_stats_vec.push(if Self::is_type_supported(&col_types[i]) {
-                Some(PerColumnStats {
-                    mcvs: Box::new(mcvs[i].take().unwrap()) as Box<dyn MostCommonValues>,
-                    ndistinct: hlls[i].n_distinct(),
-                    null_frac: null_cnt[i] as f64 / row_cnt as f64,
-                    distr: Box::new(distr[i].take().unwrap()) as Box<dyn Distribution>,
-                })
+                Some(PerColumnStats::new(
+                    mcvs[i].take().unwrap(),
+                    hlls[i].n_distinct(),
+                    null_cnt[i] as f64 / row_cnt as f64,
+                    distr[i].take().unwrap(),
+                ))
             } else {
                 None
             });
@@ -245,9 +253,9 @@ impl PerTableStats {
     }
 }
 
-pub struct PerColumnStats {
+pub struct PerColumnStats<M: MostCommonValues, D: Distribution> {
     // even if nulls are the most common, they cannot appear in mcvs
-    mcvs: Box<dyn MostCommonValues>,
+    mcvs: M,
 
     // ndistinct _does_ include the values in mcvs
     // ndistinct _does not_ include nulls
@@ -259,7 +267,18 @@ pub struct PerColumnStats {
 
     // distribution _does not_ include the values in mcvs
     // distribution _does not_ include nulls
-    distr: Box<dyn Distribution>,
+    distr: D,
+}
+
+impl<M: MostCommonValues, D: Distribution> PerColumnStats<M, D> {
+    pub fn new(mcvs: M, ndistinct: u64, null_frac: f64, distr: D) -> Self {
+        Self {
+            mcvs,
+            ndistinct,
+            null_frac,
+            distr,
+        }
+    }
 }
 
 pub trait MostCommonValues: 'static + Send + Sync {
@@ -291,7 +310,7 @@ pub const IO_COST: usize = 3;
 // TODO: a future PR will remove this and get the code working for all of TPC-H
 const INVALID_SELECTIVITY: f64 = 0.001;
 
-impl OptCostModel {
+impl<M: MostCommonValues, D: Distribution> OptCostModel<M, D> {
     pub fn row_cnt(Cost(cost): &Cost) -> f64 {
         cost[ROW_COUNT]
     }
@@ -323,7 +342,7 @@ impl OptCostModel {
     }
 }
 
-impl CostModel<OptRelNodeTyp> for OptCostModel {
+impl<M: MostCommonValues, D: Distribution> CostModel<OptRelNodeTyp> for OptCostModel<M, D> {
     fn explain(&self, cost: &Cost) -> String {
         format!(
             "weighted={},row_cnt={},compute={},io={}",
@@ -471,8 +490,8 @@ impl CostModel<OptRelNodeTyp> for OptCostModel {
     }
 }
 
-impl OptCostModel {
-    pub fn new(per_table_stats_map: BaseTableStats) -> Self {
+impl<M: MostCommonValues, D: Distribution> OptCostModel<M, D> {
+    pub fn new(per_table_stats_map: BaseTableStats<M, D>) -> Self {
         Self {
             per_table_stats_map,
         }
@@ -762,27 +781,11 @@ impl OptCostModel {
     }
 }
 
-impl PerTableStats {
-    pub fn new(row_cnt: usize, per_column_stats_vec: Vec<Option<PerColumnStats>>) -> Self {
+impl<M: MostCommonValues, D: Distribution> PerTableStats<M, D> {
+    pub fn new(row_cnt: usize, per_column_stats_vec: Vec<Option<PerColumnStats<M, D>>>) -> Self {
         Self {
             row_cnt,
             per_column_stats_vec,
-        }
-    }
-}
-
-impl PerColumnStats {
-    pub fn new(
-        mcvs: Box<dyn MostCommonValues>,
-        ndistinct: u64,
-        null_frac: f64,
-        distr: Box<dyn Distribution>,
-    ) -> Self {
-        Self {
-            mcvs,
-            ndistinct,
-            null_frac,
-            distr,
         }
     }
 }
@@ -804,16 +807,17 @@ mod tests {
     };
 
     use super::{Distribution, MostCommonValues, OptCostModel, PerColumnStats, PerTableStats};
+    type TestPerColumnStats = PerColumnStats<TestMostCommonValues, TestDistribution>;
 
-    struct MockMostCommonValues {
+    struct TestMostCommonValues {
         mcvs: HashMap<Value, f64>,
     }
 
-    struct MockDistribution {
+    struct TestDistribution {
         cdfs: HashMap<Value, f64>,
     }
 
-    impl MockMostCommonValues {
+    impl TestMostCommonValues {
         fn new(mcvs_vec: Vec<(Value, f64)>) -> Self {
             Self {
                 mcvs: mcvs_vec.into_iter().collect(),
@@ -821,11 +825,11 @@ mod tests {
         }
 
         pub fn empty() -> Self {
-            MockMostCommonValues::new(vec![])
+            TestMostCommonValues::new(vec![])
         }
     }
 
-    impl MostCommonValues for MockMostCommonValues {
+    impl MostCommonValues for TestMostCommonValues {
         fn freq(&self, value: &Value) -> Option<f64> {
             self.mcvs.get(value).copied()
         }
@@ -847,7 +851,7 @@ mod tests {
         }
     }
 
-    impl MockDistribution {
+    impl TestDistribution {
         fn new(cdfs_vec: Vec<(Value, f64)>) -> Self {
             Self {
                 cdfs: cdfs_vec.into_iter().collect(),
@@ -855,11 +859,11 @@ mod tests {
         }
 
         fn empty() -> Self {
-            MockDistribution::new(vec![])
+            TestDistribution::new(vec![])
         }
     }
 
-    impl Distribution for MockDistribution {
+    impl Distribution for TestDistribution {
         fn cdf(&self, value: &Value) -> f64 {
             *self.cdfs.get(value).unwrap_or(&0.0)
         }
@@ -868,7 +872,9 @@ mod tests {
     const TABLE1_NAME: &str = "t1";
 
     // one column is sufficient for all filter selectivity predicates
-    fn create_one_column_cost_model(per_column_stats: PerColumnStats) -> OptCostModel {
+    fn create_one_column_cost_model(
+        per_column_stats: TestPerColumnStats,
+    ) -> OptCostModel<TestMostCommonValues, TestDistribution> {
         OptCostModel::new(
             vec![(
                 String::from(TABLE1_NAME),
@@ -923,11 +929,11 @@ mod tests {
 
     #[test]
     fn test_colref_eq_constint_in_mcv() {
-        let cost_model = create_one_column_cost_model(PerColumnStats::new(
-            Box::new(MockMostCommonValues::new(vec![(Value::Int32(1), 0.3)])),
+        let cost_model = create_one_column_cost_model(TestPerColumnStats::new(
+            TestMostCommonValues::new(vec![(Value::Int32(1), 0.3)]),
             0,
             0.0,
-            Box::new(MockDistribution::empty()),
+            TestDistribution::empty(),
         ));
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), cnst(Value::Int32(1)));
         let expr_tree_rev = bin_op(BinOpType::Eq, cnst(Value::Int32(1)), col_ref(0));
@@ -947,14 +953,11 @@ mod tests {
 
     #[test]
     fn test_colref_eq_constint_not_in_mcv_no_nulls() {
-        let cost_model = create_one_column_cost_model(PerColumnStats::new(
-            Box::new(MockMostCommonValues::new(vec![
-                (Value::Int32(1), 0.2),
-                (Value::Int32(3), 0.44),
-            ])),
+        let cost_model = create_one_column_cost_model(TestPerColumnStats::new(
+            TestMostCommonValues::new(vec![(Value::Int32(1), 0.2), (Value::Int32(3), 0.44)]),
             5,
             0.0,
-            Box::new(MockDistribution::empty()),
+            TestDistribution::empty(),
         ));
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), cnst(Value::Int32(2)));
         let expr_tree_rev = bin_op(BinOpType::Eq, cnst(Value::Int32(2)), col_ref(0));
@@ -974,14 +977,11 @@ mod tests {
 
     #[test]
     fn test_colref_eq_constint_not_in_mcv_with_nulls() {
-        let cost_model = create_one_column_cost_model(PerColumnStats::new(
-            Box::new(MockMostCommonValues::new(vec![
-                (Value::Int32(1), 0.2),
-                (Value::Int32(3), 0.44),
-            ])),
+        let cost_model = create_one_column_cost_model(TestPerColumnStats::new(
+            TestMostCommonValues::new(vec![(Value::Int32(1), 0.2), (Value::Int32(3), 0.44)]),
             5,
             0.03,
-            Box::new(MockDistribution::empty()),
+            TestDistribution::empty(),
         ));
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), cnst(Value::Int32(2)));
         let expr_tree_rev = bin_op(BinOpType::Eq, cnst(Value::Int32(2)), col_ref(0));
@@ -1002,11 +1002,11 @@ mod tests {
     /// I only have one test for NEQ since I'll assume that it uses the same underlying logic as EQ
     #[test]
     fn test_colref_neq_constint_in_mcv() {
-        let cost_model = create_one_column_cost_model(PerColumnStats::new(
-            Box::new(MockMostCommonValues::new(vec![(Value::Int32(1), 0.3)])),
+        let cost_model = create_one_column_cost_model(TestPerColumnStats::new(
+            TestMostCommonValues::new(vec![(Value::Int32(1), 0.3)]),
             0,
             0.0,
-            Box::new(MockDistribution::empty()),
+            TestDistribution::empty(),
         ));
         let expr_tree = bin_op(BinOpType::Neq, col_ref(0), cnst(Value::Int32(1)));
         let expr_tree_rev = bin_op(BinOpType::Neq, cnst(Value::Int32(1)), col_ref(0));
@@ -1026,11 +1026,11 @@ mod tests {
 
     #[test]
     fn test_colref_leq_constint_no_mcvs_in_range() {
-        let cost_model = create_one_column_cost_model(PerColumnStats::new(
-            Box::new(MockMostCommonValues::empty()),
+        let cost_model = create_one_column_cost_model(TestPerColumnStats::new(
+            TestMostCommonValues::empty(),
             10,
             0.0,
-            Box::new(MockDistribution::new(vec![(Value::Int32(15), 0.7)])),
+            TestDistribution::new(vec![(Value::Int32(15), 0.7)]),
         ));
         let expr_tree = bin_op(BinOpType::Leq, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Geq, cnst(Value::Int32(15)), col_ref(0));
@@ -1050,11 +1050,11 @@ mod tests {
 
     #[test]
     fn test_colref_leq_constint_no_mcvs_in_range_with_nulls() {
-        let cost_model = create_one_column_cost_model(PerColumnStats::new(
-            Box::new(MockMostCommonValues::empty()),
+        let cost_model = create_one_column_cost_model(TestPerColumnStats::new(
+            TestMostCommonValues::empty(),
             10,
             0.1,
-            Box::new(MockDistribution::new(vec![(Value::Int32(15), 0.7)])),
+            TestDistribution::new(vec![(Value::Int32(15), 0.7)]),
         ));
         let expr_tree = bin_op(BinOpType::Leq, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Geq, cnst(Value::Int32(15)), col_ref(0));
@@ -1074,8 +1074,8 @@ mod tests {
 
     #[test]
     fn test_colref_leq_constint_with_mcvs_in_range_not_at_border() {
-        let cost_model = create_one_column_cost_model(PerColumnStats::new(
-            Box::new(MockMostCommonValues {
+        let cost_model = create_one_column_cost_model(TestPerColumnStats::new(
+            TestMostCommonValues {
                 mcvs: vec![
                     (Value::Int32(6), 0.05),
                     (Value::Int32(10), 0.1),
@@ -1084,10 +1084,10 @@ mod tests {
                 ]
                 .into_iter()
                 .collect(),
-            }),
+            },
             10,
             0.0,
-            Box::new(MockDistribution::new(vec![(Value::Int32(15), 0.7)])),
+            TestDistribution::new(vec![(Value::Int32(15), 0.7)]),
         ));
         let expr_tree = bin_op(BinOpType::Leq, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Geq, cnst(Value::Int32(15)), col_ref(0));
@@ -1107,16 +1107,16 @@ mod tests {
 
     #[test]
     fn test_colref_leq_constint_with_mcv_at_border() {
-        let cost_model = create_one_column_cost_model(PerColumnStats::new(
-            Box::new(MockMostCommonValues::new(vec![
+        let cost_model = create_one_column_cost_model(TestPerColumnStats::new(
+            TestMostCommonValues::new(vec![
                 (Value::Int32(6), 0.05),
                 (Value::Int32(10), 0.1),
                 (Value::Int32(15), 0.08),
                 (Value::Int32(25), 0.07),
-            ])),
+            ]),
             10,
             0.0,
-            Box::new(MockDistribution::new(vec![(Value::Int32(15), 0.7)])),
+            TestDistribution::new(vec![(Value::Int32(15), 0.7)]),
         ));
         let expr_tree = bin_op(BinOpType::Leq, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Geq, cnst(Value::Int32(15)), col_ref(0));
@@ -1136,11 +1136,11 @@ mod tests {
 
     #[test]
     fn test_colref_lt_constint_no_mcvs_in_range() {
-        let cost_model = create_one_column_cost_model(PerColumnStats::new(
-            Box::new(MockMostCommonValues::empty()),
+        let cost_model = create_one_column_cost_model(TestPerColumnStats::new(
+            TestMostCommonValues::empty(),
             10,
             0.0,
-            Box::new(MockDistribution::new(vec![(Value::Int32(15), 0.7)])),
+            TestDistribution::new(vec![(Value::Int32(15), 0.7)]),
         ));
         let expr_tree = bin_op(BinOpType::Lt, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Gt, cnst(Value::Int32(15)), col_ref(0));
@@ -1160,11 +1160,11 @@ mod tests {
 
     #[test]
     fn test_colref_lt_constint_no_mcvs_in_range_with_nulls() {
-        let cost_model = create_one_column_cost_model(PerColumnStats::new(
-            Box::new(MockMostCommonValues::empty()),
+        let cost_model = create_one_column_cost_model(TestPerColumnStats::new(
+            TestMostCommonValues::empty(),
             9, // 90% of the values aren't nulls since null_frac = 0.1. if there are 9 distinct non-null values, each will have 0.1 frequency
             0.1,
-            Box::new(MockDistribution::new(vec![(Value::Int32(15), 0.7)])),
+            TestDistribution::new(vec![(Value::Int32(15), 0.7)]),
         ));
         let expr_tree = bin_op(BinOpType::Lt, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Gt, cnst(Value::Int32(15)), col_ref(0));
@@ -1184,8 +1184,8 @@ mod tests {
 
     #[test]
     fn test_colref_lt_constint_with_mcvs_in_range_not_at_border() {
-        let cost_model = create_one_column_cost_model(PerColumnStats::new(
-            Box::new(MockMostCommonValues {
+        let cost_model = create_one_column_cost_model(TestPerColumnStats::new(
+            TestMostCommonValues {
                 mcvs: vec![
                     (Value::Int32(6), 0.05),
                     (Value::Int32(10), 0.1),
@@ -1194,10 +1194,10 @@ mod tests {
                 ]
                 .into_iter()
                 .collect(),
-            }),
+            },
             11, // there are 4 MCVs which together add up to 0.3. With 11 total ndistinct, each remaining value has freq 0.1
             0.0,
-            Box::new(MockDistribution::new(vec![(Value::Int32(15), 0.7)])),
+            TestDistribution::new(vec![(Value::Int32(15), 0.7)]),
         ));
         let expr_tree = bin_op(BinOpType::Lt, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Gt, cnst(Value::Int32(15)), col_ref(0));
@@ -1217,8 +1217,8 @@ mod tests {
 
     #[test]
     fn test_colref_lt_constint_with_mcv_at_border() {
-        let cost_model = create_one_column_cost_model(PerColumnStats::new(
-            Box::new(MockMostCommonValues {
+        let cost_model = create_one_column_cost_model(TestPerColumnStats::new(
+            TestMostCommonValues {
                 mcvs: vec![
                     (Value::Int32(6), 0.05),
                     (Value::Int32(10), 0.1),
@@ -1227,10 +1227,10 @@ mod tests {
                 ]
                 .into_iter()
                 .collect(),
-            }),
+            },
             11, // there are 4 MCVs which together add up to 0.3. With 11 total ndistinct, each remaining value has freq 0.1
             0.0,
-            Box::new(MockDistribution::new(vec![(Value::Int32(15), 0.7)])),
+            TestDistribution::new(vec![(Value::Int32(15), 0.7)]),
         ));
         let expr_tree = bin_op(BinOpType::Lt, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Gt, cnst(Value::Int32(15)), col_ref(0));
@@ -1252,11 +1252,11 @@ mod tests {
     /// The only interesting thing to test is that if there are nulls, those aren't included in GT
     #[test]
     fn test_colref_gt_constint_no_nulls() {
-        let cost_model = create_one_column_cost_model(PerColumnStats::new(
-            Box::new(MockMostCommonValues::empty()),
+        let cost_model = create_one_column_cost_model(TestPerColumnStats::new(
+            TestMostCommonValues::empty(),
             10,
             0.0,
-            Box::new(MockDistribution::new(vec![(Value::Int32(15), 0.7)])),
+            TestDistribution::new(vec![(Value::Int32(15), 0.7)]),
         ));
         let expr_tree = bin_op(BinOpType::Gt, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Lt, cnst(Value::Int32(15)), col_ref(0));
@@ -1276,11 +1276,11 @@ mod tests {
 
     #[test]
     fn test_colref_gt_constint_with_nulls() {
-        let cost_model = create_one_column_cost_model(PerColumnStats::new(
-            Box::new(MockMostCommonValues::empty()),
+        let cost_model = create_one_column_cost_model(TestPerColumnStats::new(
+            TestMostCommonValues::empty(),
             10,
             0.1,
-            Box::new(MockDistribution::new(vec![(Value::Int32(15), 0.7)])),
+            TestDistribution::new(vec![(Value::Int32(15), 0.7)]),
         ));
         let expr_tree = bin_op(BinOpType::Gt, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Lt, cnst(Value::Int32(15)), col_ref(0));
@@ -1302,11 +1302,11 @@ mod tests {
     /// As with above, I have one test without nulls and one test with nulls
     #[test]
     fn test_colref_geq_constint_no_nulls() {
-        let cost_model = create_one_column_cost_model(PerColumnStats::new(
-            Box::new(MockMostCommonValues::empty()),
+        let cost_model = create_one_column_cost_model(TestPerColumnStats::new(
+            TestMostCommonValues::empty(),
             10,
             0.0,
-            Box::new(MockDistribution::new(vec![(Value::Int32(15), 0.7)])),
+            TestDistribution::new(vec![(Value::Int32(15), 0.7)]),
         ));
         let expr_tree = bin_op(BinOpType::Geq, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Leq, cnst(Value::Int32(15)), col_ref(0));
@@ -1326,11 +1326,11 @@ mod tests {
 
     #[test]
     fn test_colref_geq_constint_with_nulls() {
-        let cost_model = create_one_column_cost_model(PerColumnStats::new(
-            Box::new(MockMostCommonValues::empty()),
+        let cost_model = create_one_column_cost_model(TestPerColumnStats::new(
+            TestMostCommonValues::empty(),
             9, // 90% of the values aren't nulls since null_frac = 0.1. if there are 9 distinct non-null values, each will have 0.1 frequency
             0.1,
-            Box::new(MockDistribution::new(vec![(Value::Int32(15), 0.7)])),
+            TestDistribution::new(vec![(Value::Int32(15), 0.7)]),
         ));
         let expr_tree = bin_op(BinOpType::Geq, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Leq, cnst(Value::Int32(15)), col_ref(0));
@@ -1351,8 +1351,8 @@ mod tests {
 
     #[test]
     fn test_and() {
-        let cost_model = create_one_column_cost_model(PerColumnStats::new(
-            Box::new(MockMostCommonValues {
+        let cost_model = create_one_column_cost_model(TestPerColumnStats::new(
+            TestMostCommonValues {
                 mcvs: vec![
                     (Value::Int32(1), 0.3),
                     (Value::Int32(5), 0.5),
@@ -1360,10 +1360,10 @@ mod tests {
                 ]
                 .into_iter()
                 .collect(),
-            }),
+            },
             0,
             0.0,
-            Box::new(MockDistribution::empty()),
+            TestDistribution::empty(),
         ));
         let eq1 = bin_op(BinOpType::Eq, col_ref(0), cnst(Value::Int32(1)));
         let eq5 = bin_op(BinOpType::Eq, col_ref(0), cnst(Value::Int32(5)));
@@ -1391,8 +1391,8 @@ mod tests {
 
     #[test]
     fn test_or() {
-        let cost_model = create_one_column_cost_model(PerColumnStats::new(
-            Box::new(MockMostCommonValues {
+        let cost_model = create_one_column_cost_model(TestPerColumnStats::new(
+            TestMostCommonValues {
                 mcvs: vec![
                     (Value::Int32(1), 0.3),
                     (Value::Int32(5), 0.5),
@@ -1400,10 +1400,10 @@ mod tests {
                 ]
                 .into_iter()
                 .collect(),
-            }),
+            },
             0,
             0.0,
-            Box::new(MockDistribution::empty()),
+            TestDistribution::empty(),
         ));
         let eq1 = bin_op(BinOpType::Eq, col_ref(0), cnst(Value::Int32(1)));
         let eq5 = bin_op(BinOpType::Eq, col_ref(0), cnst(Value::Int32(5)));
@@ -1431,11 +1431,11 @@ mod tests {
 
     #[test]
     fn test_not_no_nulls() {
-        let cost_model = create_one_column_cost_model(PerColumnStats::new(
-            Box::new(MockMostCommonValues::new(vec![(Value::Int32(1), 0.3)])),
+        let cost_model = create_one_column_cost_model(TestPerColumnStats::new(
+            TestMostCommonValues::new(vec![(Value::Int32(1), 0.3)]),
             0,
             0.0,
-            Box::new(MockDistribution::empty()),
+            TestDistribution::empty(),
         ));
         let expr_tree = un_op(
             UnOpType::Not,
@@ -1453,11 +1453,11 @@ mod tests {
 
     #[test]
     fn test_not_with_nulls() {
-        let cost_model = create_one_column_cost_model(PerColumnStats::new(
-            Box::new(MockMostCommonValues::new(vec![(Value::Int32(1), 0.3)])),
+        let cost_model = create_one_column_cost_model(TestPerColumnStats::new(
+            TestMostCommonValues::new(vec![(Value::Int32(1), 0.3)]),
             0,
             0.1,
-            Box::new(MockDistribution::empty()),
+            TestDistribution::empty(),
         ));
         let expr_tree = un_op(
             UnOpType::Not,

--- a/optd-datafusion-repr/src/cost/base_cost.rs
+++ b/optd-datafusion-repr/src/cost/base_cost.rs
@@ -20,6 +20,7 @@ use optd_core::{
 };
 use optd_gungnir::stats::hyperloglog::{self, HyperLogLog};
 use optd_gungnir::stats::tdigest::{self, TDigest};
+use serde::{Deserialize, Serialize};
 
 fn compute_plan_node_cost<T: RelNodeTyp, C: CostModel<T>>(
     model: &C,
@@ -50,6 +51,7 @@ pub struct OptCostModel<M: MostCommonValues, D: Distribution> {
     per_table_stats_map: BaseTableStats<M, D>,
 }
 
+#[derive(Serialize, Deserialize)]
 pub struct MockMostCommonValues {
     mcvs: HashMap<Value, f64>,
 }
@@ -84,6 +86,7 @@ impl MostCommonValues for MockMostCommonValues {
     }
 }
 
+#[derive(Serialize, Deserialize)]
 pub struct PerTableStats<M: MostCommonValues, D: Distribution> {
     row_cnt: usize,
     per_column_stats_vec: Vec<Option<PerColumnStats<M, D>>>,
@@ -253,6 +256,7 @@ impl StandardPerTableStats {
     }
 }
 
+#[derive(Serialize, Deserialize)]
 pub struct PerColumnStats<M: MostCommonValues, D: Distribution> {
     // even if nulls are the most common, they cannot appear in mcvs
     mcvs: M,

--- a/optd-datafusion-repr/src/cost/base_cost.rs
+++ b/optd-datafusion-repr/src/cost/base_cost.rs
@@ -41,11 +41,14 @@ pub type BaseTableStats<M, D> = HashMap<String, PerTableStats<M, D>>;
 
 // The "standard" concrete types that optd currently uses
 // All of optd (except unit tests) must use the same types
-pub type StandardMostCommonValues = MockMostCommonValues;
-pub type StandardDistribution = TDigest;
-pub type StandardBaseTableStats = BaseTableStats<StandardMostCommonValues, StandardDistribution>;
-pub type StandardPerTableStats = PerTableStats<StandardMostCommonValues, StandardDistribution>;
-pub type StandardPerColumnStats = PerColumnStats<StandardMostCommonValues, StandardDistribution>;
+pub type DataFusionMostCommonValues = MockMostCommonValues;
+pub type DataFusionDistribution = TDigest;
+pub type DataFusionBaseTableStats =
+    BaseTableStats<DataFusionMostCommonValues, DataFusionDistribution>;
+pub type DataFusionPerTableStats =
+    PerTableStats<DataFusionMostCommonValues, DataFusionDistribution>;
+pub type DataFusionPerColumnStats =
+    PerColumnStats<DataFusionMostCommonValues, DataFusionDistribution>;
 
 pub struct OptCostModel<M: MostCommonValues, D: Distribution> {
     per_table_stats_map: BaseTableStats<M, D>,
@@ -92,7 +95,7 @@ pub struct PerTableStats<M: MostCommonValues, D: Distribution> {
     per_column_stats_vec: Vec<Option<PerColumnStats<M, D>>>,
 }
 
-impl StandardPerTableStats {
+impl DataFusionPerTableStats {
     pub fn from_record_batches<I: IntoIterator<Item = Result<RecordBatch, ArrowError>>>(
         batch_iter: RecordBatchIterator<I>,
     ) -> anyhow::Result<Self> {

--- a/optd-datafusion-repr/src/cost/stats.rs
+++ b/optd-datafusion-repr/src/cost/stats.rs
@@ -11,7 +11,7 @@ impl Distribution for TDigest {
             Value::Int32(i) => self.cdf(*i as f64),
             Value::Int64(i) => self.cdf(*i as f64),
             Value::Int128(i) => self.cdf(*i as f64),
-            Value::Float(i) => self.cdf(**i),
+            Value::Float(i) => self.cdf(*i.0),
             _ => panic!("Value is not a number"),
         }
     }

--- a/optd-datafusion-repr/src/lib.rs
+++ b/optd-datafusion-repr/src/lib.rs
@@ -4,8 +4,8 @@ use std::{collections::HashMap, sync::Arc};
 
 use anyhow::Result;
 use cost::{
-    adaptive_cost::StandardAdaptiveCostModel, base_cost::StandardBaseTableStats, AdaptiveCostModel,
-    BaseTableStats, RuntimeAdaptionStorage, DEFAULT_DECAY,
+    adaptive_cost::DataFusionAdaptiveCostModel, base_cost::DataFusionBaseTableStats,
+    AdaptiveCostModel, BaseTableStats, RuntimeAdaptionStorage, DEFAULT_DECAY,
 };
 use optd_core::{
     cascades::{CascadesOptimizer, GroupId, OptimizerProperties},
@@ -83,7 +83,7 @@ impl DatafusionOptimizer {
     /// Create an optimizer with partial explore (otherwise it's too slow).
     pub fn new_physical(
         catalog: Arc<dyn Catalog>,
-        stats: StandardBaseTableStats,
+        stats: DataFusionBaseTableStats,
         enable_adaptive: bool,
     ) -> Self {
         let rules = Self::default_rules();
@@ -128,7 +128,7 @@ impl DatafusionOptimizer {
             RuleWrapper::new_heuristic(Arc::new(EliminateFilterRule::new())),
         );
 
-        let cost_model = StandardAdaptiveCostModel::new(1000, BaseTableStats::default()); // very large decay
+        let cost_model = DataFusionAdaptiveCostModel::new(1000, BaseTableStats::default()); // very large decay
         let runtime_statistics = cost_model.get_runtime_map();
         let optimizer = CascadesOptimizer::new(
             rule_wrappers,

--- a/optd-datafusion-repr/src/lib.rs
+++ b/optd-datafusion-repr/src/lib.rs
@@ -4,7 +4,8 @@ use std::{collections::HashMap, sync::Arc};
 
 use anyhow::Result;
 use cost::{
-    adaptive_cost::StandardAdaptiveCostModel, base_cost::{MockMostCommonValues, StandardBaseTableStats}, AdaptiveCostModel, BaseTableStats, RuntimeAdaptionStorage, DEFAULT_DECAY
+    adaptive_cost::StandardAdaptiveCostModel, base_cost::StandardBaseTableStats, AdaptiveCostModel,
+    BaseTableStats, RuntimeAdaptionStorage, DEFAULT_DECAY,
 };
 use optd_core::{
     cascades::{CascadesOptimizer, GroupId, OptimizerProperties},
@@ -12,7 +13,6 @@ use optd_core::{
     rules::RuleWrapper,
 };
 
-use optd_gungnir::stats::tdigest::TDigest;
 use plan_nodes::{OptRelNodeRef, OptRelNodeTyp};
 use properties::{
     column_ref::ColumnRefPropertyBuilder,
@@ -128,10 +128,7 @@ impl DatafusionOptimizer {
             RuleWrapper::new_heuristic(Arc::new(EliminateFilterRule::new())),
         );
 
-        let cost_model = StandardAdaptiveCostModel::new(
-            1000,
-            BaseTableStats::default(),
-        ); // very large decay
+        let cost_model = StandardAdaptiveCostModel::new(1000, BaseTableStats::default()); // very large decay
         let runtime_statistics = cost_model.get_runtime_map();
         let optimizer = CascadesOptimizer::new(
             rule_wrappers,

--- a/optd-datafusion-repr/src/lib.rs
+++ b/optd-datafusion-repr/src/lib.rs
@@ -3,13 +3,16 @@
 use std::{collections::HashMap, sync::Arc};
 
 use anyhow::Result;
-use cost::{AdaptiveCostModel, BaseTableStats, RuntimeAdaptionStorage, DEFAULT_DECAY};
+use cost::{
+    adaptive_cost::StandardAdaptiveCostModel, base_cost::{MockMostCommonValues, StandardBaseTableStats}, AdaptiveCostModel, BaseTableStats, RuntimeAdaptionStorage, DEFAULT_DECAY
+};
 use optd_core::{
     cascades::{CascadesOptimizer, GroupId, OptimizerProperties},
     rel_node::RelNodeMetaMap,
     rules::RuleWrapper,
 };
 
+use optd_gungnir::stats::tdigest::TDigest;
 use plan_nodes::{OptRelNodeRef, OptRelNodeTyp};
 use properties::{
     column_ref::ColumnRefPropertyBuilder,
@@ -80,7 +83,7 @@ impl DatafusionOptimizer {
     /// Create an optimizer with partial explore (otherwise it's too slow).
     pub fn new_physical(
         catalog: Arc<dyn Catalog>,
-        stats: BaseTableStats,
+        stats: StandardBaseTableStats,
         enable_adaptive: bool,
     ) -> Self {
         let rules = Self::default_rules();
@@ -125,7 +128,10 @@ impl DatafusionOptimizer {
             RuleWrapper::new_heuristic(Arc::new(EliminateFilterRule::new())),
         );
 
-        let cost_model = AdaptiveCostModel::new(1000, BaseTableStats::default()); // very large decay
+        let cost_model = StandardAdaptiveCostModel::new(
+            1000,
+            BaseTableStats::default(),
+        ); // very large decay
         let runtime_statistics = cost_model.get_runtime_map();
         let optimizer = CascadesOptimizer::new(
             rule_wrappers,

--- a/optd-datafusion-repr/src/plan_nodes/expr.rs
+++ b/optd-datafusion-repr/src/plan_nodes/expr.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use pretty_xmlish::Pretty;
 use serde::{Deserialize, Serialize};
 
-use optd_core::rel_node::{RelNode, RelNodeMetaMap, Value};
+use optd_core::rel_node::{RelNode, RelNodeMetaMap, SerializableOrderedF64, Value};
 
 use super::{Expr, OptRelNode, OptRelNodeRef, OptRelNodeTyp};
 
@@ -172,7 +172,10 @@ impl ConstantExpr {
     }
 
     pub fn float64(value: f64) -> Self {
-        Self::new_with_type(Value::Float(value.into()), ConstantType::Float64)
+        Self::new_with_type(
+            Value::Float(SerializableOrderedF64(value.into())),
+            ConstantType::Float64,
+        )
     }
 
     pub fn date(value: i64) -> Self {
@@ -180,7 +183,10 @@ impl ConstantExpr {
     }
 
     pub fn decimal(value: f64) -> Self {
-        Self::new_with_type(Value::Float(value.into()), ConstantType::Decimal)
+        Self::new_with_type(
+            Value::Float(SerializableOrderedF64(value.into())),
+            ConstantType::Decimal,
+        )
     }
 
     /// Gets the constant value.

--- a/optd-gungnir/Cargo.toml
+++ b/optd-gungnir/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2021"
 itertools = "0.11"
 rand = "0.8"
 crossbeam = "0.8"
+serde = {version = "1.0", features = ["derive"]}

--- a/optd-gungnir/src/stats/tdigest.rs
+++ b/optd-gungnir/src/stats/tdigest.rs
@@ -4,12 +4,13 @@
 //! For more details, refer to: https://arxiv.org/pdf/1902.04023.pdf
 
 use itertools::Itertools;
+use serde::{Deserialize, Serialize};
 use std::f64::consts::PI;
 
 pub const DEFAULT_COMPRESSION: f64 = 200.0;
 
 /// The TDigest structure for the statistical aggregator to query quantiles.
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct TDigest {
     /// A sorted array of Centroids, according to their mean.
     centroids: Vec<Centroid>,
@@ -20,7 +21,7 @@ pub struct TDigest {
 }
 
 /// A Centroid is a cluster of aggregated data points.
-#[derive(PartialEq, PartialOrd, Clone)]
+#[derive(PartialEq, PartialOrd, Clone, Serialize, Deserialize)]
 struct Centroid {
     /// Mean of all aggregated points in this cluster.
     mean: f64,

--- a/optd-perftest/src/benchmark.rs
+++ b/optd-perftest/src/benchmark.rs
@@ -37,6 +37,17 @@ impl Benchmark {
         dbname.to_lowercase()
     }
 
+    /// Use this when you need a file name. The rules for file names are different from the rules
+    ///   for database names, so this is a different function
+    pub fn get_fname(&self) -> String {
+        match self {
+            Self::Test => String::from("test"),
+            Self::Tpch(tpch_config) => {
+                format!("tpch_sf{}", tpch_config.scale_factor)
+            }
+        }
+    }
+
     /// An ID is just a unique string identifying the benchmark
     /// It's not always used in the same situations as get_dbname(), so it's a separate function
     pub fn get_id(&self) -> String {

--- a/optd-perftest/src/benchmark.rs
+++ b/optd-perftest/src/benchmark.rs
@@ -37,8 +37,8 @@ impl Benchmark {
         dbname.to_lowercase()
     }
 
-    /// Use this when you need a file name. The rules for file names are different from the rules
-    ///   for database names, so this is a different function
+    /// Use this when you need a unique file name. The rules for file names are different from the
+    ///   rules for database names, so this is a different function
     pub fn get_fname(&self) -> String {
         match self {
             Self::Test => String::from("test"),

--- a/optd-perftest/src/cardtest.rs
+++ b/optd-perftest/src/cardtest.rs
@@ -103,13 +103,14 @@ pub trait CardtestRunnerDBMSHelper {
 
 pub async fn cardtest<P: AsRef<Path>>(
     workspace_dpath: P,
+    use_optd_stats_cache: bool,
     pguser: &str,
     pgpassword: &str,
     tpch_config: TpchConfig,
 ) -> anyhow::Result<HashMap<String, Vec<Cardinfo>>> {
     let pg_dbms = Box::new(PostgresDBMS::build(&workspace_dpath, pguser, pgpassword)?);
     let truecard_getter = pg_dbms.clone();
-    let df_dbms = Box::new(DatafusionDBMS::new(&workspace_dpath).await?);
+    let df_dbms = Box::new(DatafusionDBMS::new(&workspace_dpath, use_optd_stats_cache).await?);
     let dbmss: Vec<Box<dyn CardtestRunnerDBMSHelper>> = vec![pg_dbms, df_dbms];
 
     let tpch_benchmark = Benchmark::Tpch(tpch_config.clone());

--- a/optd-perftest/src/cardtest.rs
+++ b/optd-perftest/src/cardtest.rs
@@ -103,14 +103,14 @@ pub trait CardtestRunnerDBMSHelper {
 
 pub async fn cardtest<P: AsRef<Path>>(
     workspace_dpath: P,
-    use_optd_stats_cache: bool,
+    use_optd_cached_stats: bool,
     pguser: &str,
     pgpassword: &str,
     tpch_config: TpchConfig,
 ) -> anyhow::Result<HashMap<String, Vec<Cardinfo>>> {
     let pg_dbms = Box::new(PostgresDBMS::build(&workspace_dpath, pguser, pgpassword)?);
     let truecard_getter = pg_dbms.clone();
-    let df_dbms = Box::new(DatafusionDBMS::new(&workspace_dpath, use_optd_stats_cache).await?);
+    let df_dbms = Box::new(DatafusionDBMS::new(&workspace_dpath, use_optd_cached_stats).await?);
     let dbmss: Vec<Box<dyn CardtestRunnerDBMSHelper>> = vec![pg_dbms, df_dbms];
 
     let tpch_benchmark = Benchmark::Tpch(tpch_config.clone());

--- a/optd-perftest/src/cardtest.rs
+++ b/optd-perftest/src/cardtest.rs
@@ -103,14 +103,14 @@ pub trait CardtestRunnerDBMSHelper {
 
 pub async fn cardtest<P: AsRef<Path>>(
     workspace_dpath: P,
-    use_optd_cached_stats: bool,
+    use_cached_optd_stats: bool,
     pguser: &str,
     pgpassword: &str,
     tpch_config: TpchConfig,
 ) -> anyhow::Result<HashMap<String, Vec<Cardinfo>>> {
     let pg_dbms = Box::new(PostgresDBMS::build(&workspace_dpath, pguser, pgpassword)?);
     let truecard_getter = pg_dbms.clone();
-    let df_dbms = Box::new(DatafusionDBMS::new(&workspace_dpath, use_optd_cached_stats).await?);
+    let df_dbms = Box::new(DatafusionDBMS::new(&workspace_dpath, use_cached_optd_stats).await?);
     let dbmss: Vec<Box<dyn CardtestRunnerDBMSHelper>> = vec![pg_dbms, df_dbms];
 
     let tpch_benchmark = Benchmark::Tpch(tpch_config.clone());

--- a/optd-perftest/src/datafusion_dbms.rs
+++ b/optd-perftest/src/datafusion_dbms.rs
@@ -35,6 +35,7 @@ use regex::Regex;
 
 pub struct DatafusionDBMS {
     workspace_dpath: PathBuf,
+    use_stats_cache: bool,
     ctx: SessionContext,
 }
 
@@ -61,9 +62,13 @@ impl CardtestRunnerDBMSHelper for DatafusionDBMS {
 }
 
 impl DatafusionDBMS {
-    pub async fn new<P: AsRef<Path>>(workspace_dpath: P) -> anyhow::Result<Self> {
+    pub async fn new<P: AsRef<Path>>(
+        workspace_dpath: P,
+        use_stats_cache: bool,
+    ) -> anyhow::Result<Self> {
         Ok(DatafusionDBMS {
             workspace_dpath: workspace_dpath.as_ref().to_path_buf(),
+            use_stats_cache,
             ctx: Self::new_session_ctx(None).await?,
         })
     }
@@ -292,7 +297,7 @@ impl DatafusionDBMS {
             .workspace_dpath
             .join("datafusion_stats_caches")
             .join(format!("{}.json", benchmark_fname));
-        if stats_cache_fpath.exists() {
+        if self.use_stats_cache && stats_cache_fpath.exists() {
             let file = File::open(&stats_cache_fpath)?;
             Ok(serde_json::from_reader(file)?)
         } else {
@@ -340,9 +345,11 @@ impl DatafusionDBMS {
                 log::debug!("statistics generated for table: {}", tbl_name);
             }
 
-            fs::create_dir_all(stats_cache_fpath.parent().unwrap())?;
-            let file = File::create(&stats_cache_fpath)?;
-            serde_json::to_writer(file, &base_table_stats)?;
+            if self.use_stats_cache {
+                fs::create_dir_all(stats_cache_fpath.parent().unwrap())?;
+                let file = File::create(&stats_cache_fpath)?;
+                serde_json::to_writer(file, &base_table_stats)?;
+            }
 
             let duration = start.elapsed();
             println!("datafusion load_tpch_stats duration: {:?}", duration);

--- a/optd-perftest/src/datafusion_dbms.rs
+++ b/optd-perftest/src/datafusion_dbms.rs
@@ -1,5 +1,5 @@
 use std::{
-    fs::{self, File},
+    fs,
     path::{Path, PathBuf},
     sync::Arc,
     time::Instant,
@@ -27,7 +27,10 @@ use datafusion::{
 use datafusion_optd_cli::helper::unescape_input;
 use lazy_static::lazy_static;
 use optd_datafusion_bridge::{DatafusionCatalog, OptdQueryPlanner};
-use optd_datafusion_repr::{cost::{base_cost::StandardBaseTableStats, BaseTableStats, PerTableStats}, DatafusionOptimizer};
+use optd_datafusion_repr::{
+    cost::{base_cost::StandardBaseTableStats, BaseTableStats, PerTableStats},
+    DatafusionOptimizer,
+};
 use regex::Regex;
 
 pub struct DatafusionDBMS {
@@ -75,7 +78,9 @@ impl DatafusionDBMS {
         Ok(())
     }
 
-    async fn new_session_ctx(stats: Option<StandardBaseTableStats>) -> anyhow::Result<SessionContext> {
+    async fn new_session_ctx(
+        stats: Option<StandardBaseTableStats>,
+    ) -> anyhow::Result<SessionContext> {
         let session_config = SessionConfig::from_env()?.with_information_schema(true);
         let rn_config = RuntimeConfig::new();
         let runtime_env = RuntimeEnv::new(rn_config.clone())?;
@@ -288,8 +293,9 @@ impl DatafusionDBMS {
             .join("datafusion_stats_caches")
             .join(format!("{}.json", benchmark_fname));
         if stats_cache_fpath.exists() {
-            let file = File::open(&stats_cache_fpath)?;
-            Ok(serde_json::from_reader(file)?)
+            unimplemented!()
+            // let file = File::open(&stats_cache_fpath)?;
+            // Ok(serde_json::from_reader(file)?)
         } else {
             let start = Instant::now();
 
@@ -335,9 +341,9 @@ impl DatafusionDBMS {
                 log::debug!("statistics generated for table: {}", tbl_name);
             }
 
-            fs::create_dir_all(stats_cache_fpath.parent().unwrap())?;
-            let file = File::create(&stats_cache_fpath)?;
-            serde_json::to_writer(file, &base_table_stats)?;
+            // fs::create_dir_all(stats_cache_fpath.parent().unwrap())?;
+            // let file = File::create(&stats_cache_fpath)?;
+            // serde_json::to_writer(file, &base_table_stats)?;
 
             let duration = start.elapsed();
             println!("datafusion load_tpch_stats duration: {:?}", duration);

--- a/optd-perftest/src/datafusion_dbms.rs
+++ b/optd-perftest/src/datafusion_dbms.rs
@@ -28,14 +28,14 @@ use datafusion_optd_cli::helper::unescape_input;
 use lazy_static::lazy_static;
 use optd_datafusion_bridge::{DatafusionCatalog, OptdQueryPlanner};
 use optd_datafusion_repr::{
-    cost::{base_cost::StandardBaseTableStats, BaseTableStats, PerTableStats},
+    cost::{base_cost::DataFusionBaseTableStats, BaseTableStats, PerTableStats},
     DatafusionOptimizer,
 };
 use regex::Regex;
 
 pub struct DatafusionDBMS {
     workspace_dpath: PathBuf,
-    use_stats_cache: bool,
+    use_cached_stats: bool,
     ctx: SessionContext,
 }
 
@@ -64,11 +64,11 @@ impl CardtestRunnerDBMSHelper for DatafusionDBMS {
 impl DatafusionDBMS {
     pub async fn new<P: AsRef<Path>>(
         workspace_dpath: P,
-        use_stats_cache: bool,
+        use_cached_stats: bool,
     ) -> anyhow::Result<Self> {
         Ok(DatafusionDBMS {
             workspace_dpath: workspace_dpath.as_ref().to_path_buf(),
-            use_stats_cache,
+            use_cached_stats,
             ctx: Self::new_session_ctx(None).await?,
         })
     }
@@ -78,13 +78,13 @@ impl DatafusionDBMS {
     ///
     /// A more ideal way to generate statistics would be to use the `ANALYZE`
     /// command in SQL, but DataFusion does not support that yet.
-    async fn clear_state(&mut self, stats: Option<StandardBaseTableStats>) -> anyhow::Result<()> {
+    async fn clear_state(&mut self, stats: Option<DataFusionBaseTableStats>) -> anyhow::Result<()> {
         self.ctx = Self::new_session_ctx(stats).await?;
         Ok(())
     }
 
     async fn new_session_ctx(
-        stats: Option<StandardBaseTableStats>,
+        stats: Option<DataFusionBaseTableStats>,
     ) -> anyhow::Result<SessionContext> {
         let session_config = SessionConfig::from_env()?.with_information_schema(true);
         let rn_config = RuntimeConfig::new();
@@ -209,13 +209,29 @@ impl DatafusionDBMS {
     async fn get_benchmark_stats(
         &mut self,
         benchmark: &Benchmark,
-    ) -> anyhow::Result<StandardBaseTableStats> {
-        match benchmark {
-            Benchmark::Tpch(tpch_config) => {
-                let benchmark_fname = benchmark.get_fname();
-                self.get_tpch_stats(tpch_config, benchmark_fname).await
-            }
-            _ => unimplemented!(),
+    ) -> anyhow::Result<DataFusionBaseTableStats> {
+        let benchmark_fname = benchmark.get_fname();
+        let stats_cache_fpath = self
+            .workspace_dpath
+            .join("datafusion_stats_caches")
+            .join(format!("{}.json", benchmark_fname));
+        if self.use_cached_stats && stats_cache_fpath.exists() {
+            let file = File::open(&stats_cache_fpath)?;
+            Ok(serde_json::from_reader(file)?)
+        } else {
+            let base_table_stats = match benchmark {
+                Benchmark::Tpch(tpch_config) => self.get_tpch_stats(tpch_config).await?,
+                _ => unimplemented!(),
+            };
+
+            // regardless of whether self.use_cached_stats is true or false, we want to update the cache
+            // this way, even if we choose not to read from the cache, the cache still always has the
+            // most up to date version of the stats
+            fs::create_dir_all(stats_cache_fpath.parent().unwrap())?;
+            let file = File::create(&stats_cache_fpath)?;
+            serde_json::to_writer(file, &base_table_stats)?;
+
+            Ok(base_table_stats)
         }
     }
 
@@ -291,70 +307,53 @@ impl DatafusionDBMS {
     async fn get_tpch_stats(
         &mut self,
         tpch_config: &TpchConfig,
-        benchmark_fname: String,
-    ) -> anyhow::Result<StandardBaseTableStats> {
-        let stats_cache_fpath = self
-            .workspace_dpath
-            .join("datafusion_stats_caches")
-            .join(format!("{}.json", benchmark_fname));
-        if self.use_stats_cache && stats_cache_fpath.exists() {
-            let file = File::open(&stats_cache_fpath)?;
-            Ok(serde_json::from_reader(file)?)
-        } else {
-            let start = Instant::now();
+    ) -> anyhow::Result<DataFusionBaseTableStats> {
+        let start = Instant::now();
 
-            // Generate the tables
-            let tpch_kit = TpchKit::build(&self.workspace_dpath)?;
-            tpch_kit.gen_tables(tpch_config)?;
+        // Generate the tables
+        let tpch_kit = TpchKit::build(&self.workspace_dpath)?;
+        tpch_kit.gen_tables(tpch_config)?;
 
-            // To get the schema of each table.
-            let ctx = Self::new_session_ctx(None).await?;
-            let ddls = fs::read_to_string(&tpch_kit.schema_fpath)?;
-            let ddls = ddls
-                .split(';')
-                .map(|s| s.trim())
-                .filter(|s| !s.is_empty())
-                .collect::<Vec<_>>();
-            for ddl in ddls {
-                Self::execute(&ctx, ddl).await?;
-            }
-            let mut base_table_stats = BaseTableStats::default();
-            for tbl_fpath in tpch_kit.get_tbl_fpath_iter(tpch_config).unwrap() {
-                let tbl_name = tbl_fpath.file_stem().unwrap().to_str().unwrap();
-                let schema = ctx
-                    .catalog("datafusion")
-                    .unwrap()
-                    .schema("public")
-                    .unwrap()
-                    .table(tbl_name)
-                    .await
-                    .unwrap()
-                    .schema();
-                // Load the .tbl file into record batches using arrow.
-                let tbl_file = fs::File::open(&tbl_fpath)?;
-                let csv_reader = ReaderBuilder::new(schema.clone())
-                    .has_header(false)
-                    .with_delimiter(b'|')
-                    .build(tbl_file)
-                    .unwrap();
-                let batch_iter = RecordBatchIterator::new(csv_reader, schema);
-                base_table_stats.insert(
-                    tbl_name.to_string(),
-                    PerTableStats::from_record_batches(batch_iter)?,
-                );
-                log::debug!("statistics generated for table: {}", tbl_name);
-            }
-
-            if self.use_stats_cache {
-                fs::create_dir_all(stats_cache_fpath.parent().unwrap())?;
-                let file = File::create(&stats_cache_fpath)?;
-                serde_json::to_writer(file, &base_table_stats)?;
-            }
-
-            let duration = start.elapsed();
-            println!("datafusion load_tpch_stats duration: {:?}", duration);
-            Ok(base_table_stats)
+        // To get the schema of each table.
+        let ctx = Self::new_session_ctx(None).await?;
+        let ddls = fs::read_to_string(&tpch_kit.schema_fpath)?;
+        let ddls = ddls
+            .split(';')
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<_>>();
+        for ddl in ddls {
+            Self::execute(&ctx, ddl).await?;
         }
+        let mut base_table_stats = BaseTableStats::default();
+        for tbl_fpath in tpch_kit.get_tbl_fpath_iter(tpch_config).unwrap() {
+            let tbl_name = tbl_fpath.file_stem().unwrap().to_str().unwrap();
+            let schema = ctx
+                .catalog("datafusion")
+                .unwrap()
+                .schema("public")
+                .unwrap()
+                .table(tbl_name)
+                .await
+                .unwrap()
+                .schema();
+            // Load the .tbl file into record batches using arrow.
+            let tbl_file = fs::File::open(&tbl_fpath)?;
+            let csv_reader = ReaderBuilder::new(schema.clone())
+                .has_header(false)
+                .with_delimiter(b'|')
+                .build(tbl_file)
+                .unwrap();
+            let batch_iter = RecordBatchIterator::new(csv_reader, schema);
+            base_table_stats.insert(
+                tbl_name.to_string(),
+                PerTableStats::from_record_batches(batch_iter)?,
+            );
+        }
+
+        let duration = start.elapsed();
+        println!("datafusion load_tpch_stats duration: {:?}", duration);
+        Ok(base_table_stats)
     }
 }
 

--- a/optd-perftest/src/datafusion_dbms.rs
+++ b/optd-perftest/src/datafusion_dbms.rs
@@ -1,5 +1,5 @@
 use std::{
-    fs,
+    fs::{self, File},
     path::{Path, PathBuf},
     sync::Arc,
     time::Instant,
@@ -201,7 +201,10 @@ impl DatafusionDBMS {
         benchmark: &Benchmark,
     ) -> anyhow::Result<BaseTableStats> {
         match benchmark {
-            Benchmark::Tpch(tpch_config) => self.get_tpch_stats(tpch_config).await,
+            Benchmark::Tpch(tpch_config) => {
+                let benchmark_fname = benchmark.get_fname();
+                self.get_tpch_stats(tpch_config, benchmark_fname).await
+            },
             _ => unimplemented!(),
         }
     }
@@ -275,53 +278,66 @@ impl DatafusionDBMS {
         Ok(())
     }
 
-    async fn get_tpch_stats(&mut self, tpch_config: &TpchConfig) -> anyhow::Result<BaseTableStats> {
-        let start = Instant::now();
+    async fn get_tpch_stats(&mut self, tpch_config: &TpchConfig, benchmark_fname: String) -> anyhow::Result<BaseTableStats> {
+        let stats_cache_fpath = self.workspace_dpath.join("datafusion_stats_caches").join(format!("{}.json", benchmark_fname));
+        if stats_cache_fpath.exists() {
+            let file = File::open(&stats_cache_fpath)?;
+            Ok(serde_json::from_reader(file)?)
+        } else {
+            let start = Instant::now();
 
-        // Generate the tables
-        let tpch_kit = TpchKit::build(&self.workspace_dpath)?;
-        tpch_kit.gen_tables(tpch_config)?;
+            // Generate the tables
+            let tpch_kit = TpchKit::build(&self.workspace_dpath)?;
+            tpch_kit.gen_tables(tpch_config)?;
 
-        // To get the schema of each table.
-        let ctx = Self::new_session_ctx(None).await?;
-        let ddls = fs::read_to_string(&tpch_kit.schema_fpath)?;
-        let ddls = ddls
-            .split(';')
-            .map(|s| s.trim())
-            .filter(|s| !s.is_empty())
-            .collect::<Vec<_>>();
-        for ddl in ddls {
-            Self::execute(&ctx, ddl).await?;
+            // To get the schema of each table.
+            let ctx = Self::new_session_ctx(None).await?;
+            let ddls = fs::read_to_string(&tpch_kit.schema_fpath)?;
+            let ddls = ddls
+                .split(';')
+                .map(|s| s.trim())
+                .filter(|s| !s.is_empty())
+                .collect::<Vec<_>>();
+            for ddl in ddls {
+                Self::execute(&ctx, ddl).await?;
+            }
+            let mut base_table_stats = BaseTableStats::default();
+            for tbl_fpath in tpch_kit.get_tbl_fpath_iter(tpch_config).unwrap() {
+                let tbl_name = tbl_fpath.file_stem().unwrap().to_str().unwrap();
+                let schema = ctx
+                    .catalog("datafusion")
+                    .unwrap()
+                    .schema("public")
+                    .unwrap()
+                    .table(tbl_name)
+                    .await
+                    .unwrap()
+                    .schema();
+                // Load the .tbl file into record batches using arrow.
+                let tbl_file = fs::File::open(&tbl_fpath)?;
+                let csv_reader = ReaderBuilder::new(schema.clone())
+                    .has_header(false)
+                    .with_delimiter(b'|')
+                    .build(tbl_file)
+                    .unwrap();
+                let batch_iter = RecordBatchIterator::new(csv_reader, schema);
+                base_table_stats.insert(
+                    tbl_name.to_string(),
+                    PerTableStats::from_record_batches(batch_iter)?,
+                );
+                log::debug!("statistics generated for table: {}", tbl_name);
+            }
+
+            fs::create_dir_all(stats_cache_fpath.parent().unwrap())?;
+            let file = File::create(&stats_cache_fpath)?;
+            serde_json::to_writer(file, &base_table_stats)?;
+
+            let duration = start.elapsed();
+            println!("datafusion load_tpch_stats duration: {:?}", duration);
+            Ok(base_table_stats)
         }
-        let mut base_table_stats = BaseTableStats::default();
-        for tbl_fpath in tpch_kit.get_tbl_fpath_iter(tpch_config).unwrap() {
-            let tbl_name = tbl_fpath.file_stem().unwrap().to_str().unwrap();
-            let schema = ctx
-                .catalog("datafusion")
-                .unwrap()
-                .schema("public")
-                .unwrap()
-                .table(tbl_name)
-                .await
-                .unwrap()
-                .schema();
-            // Load the .tbl file into record batches using arrow.
-            let tbl_file = fs::File::open(&tbl_fpath)?;
-            let csv_reader = ReaderBuilder::new(schema.clone())
-                .has_header(false)
-                .with_delimiter(b'|')
-                .build(tbl_file)
-                .unwrap();
-            let batch_iter = RecordBatchIterator::new(csv_reader, schema);
-            base_table_stats.insert(
-                tbl_name.to_string(),
-                PerTableStats::from_record_batches(batch_iter)?,
-            );
-            log::debug!("statistics generated for table: {}", tbl_name);
-        }
-        let duration = start.elapsed();
-        println!("datafusion load_tpch_stats duration: {:?}", duration);
-        Ok(base_table_stats)
+
+        
     }
 }
 

--- a/optd-perftest/src/datafusion_dbms.rs
+++ b/optd-perftest/src/datafusion_dbms.rs
@@ -27,7 +27,7 @@ use datafusion::{
 use datafusion_optd_cli::helper::unescape_input;
 use lazy_static::lazy_static;
 use optd_datafusion_bridge::{DatafusionCatalog, OptdQueryPlanner};
-use optd_datafusion_repr::{cost::BaseTableStats, cost::PerTableStats, DatafusionOptimizer};
+use optd_datafusion_repr::{cost::{base_cost::StandardBaseTableStats, BaseTableStats, PerTableStats}, DatafusionOptimizer};
 use regex::Regex;
 
 pub struct DatafusionDBMS {
@@ -70,12 +70,12 @@ impl DatafusionDBMS {
     ///
     /// A more ideal way to generate statistics would be to use the `ANALYZE`
     /// command in SQL, but DataFusion does not support that yet.
-    async fn clear_state(&mut self, stats: Option<BaseTableStats>) -> anyhow::Result<()> {
+    async fn clear_state(&mut self, stats: Option<StandardBaseTableStats>) -> anyhow::Result<()> {
         self.ctx = Self::new_session_ctx(stats).await?;
         Ok(())
     }
 
-    async fn new_session_ctx(stats: Option<BaseTableStats>) -> anyhow::Result<SessionContext> {
+    async fn new_session_ctx(stats: Option<StandardBaseTableStats>) -> anyhow::Result<SessionContext> {
         let session_config = SessionConfig::from_env()?.with_information_schema(true);
         let rn_config = RuntimeConfig::new();
         let runtime_env = RuntimeEnv::new(rn_config.clone())?;
@@ -199,12 +199,12 @@ impl DatafusionDBMS {
     async fn get_benchmark_stats(
         &mut self,
         benchmark: &Benchmark,
-    ) -> anyhow::Result<BaseTableStats> {
+    ) -> anyhow::Result<StandardBaseTableStats> {
         match benchmark {
             Benchmark::Tpch(tpch_config) => {
                 let benchmark_fname = benchmark.get_fname();
                 self.get_tpch_stats(tpch_config, benchmark_fname).await
-            },
+            }
             _ => unimplemented!(),
         }
     }
@@ -278,8 +278,15 @@ impl DatafusionDBMS {
         Ok(())
     }
 
-    async fn get_tpch_stats(&mut self, tpch_config: &TpchConfig, benchmark_fname: String) -> anyhow::Result<BaseTableStats> {
-        let stats_cache_fpath = self.workspace_dpath.join("datafusion_stats_caches").join(format!("{}.json", benchmark_fname));
+    async fn get_tpch_stats(
+        &mut self,
+        tpch_config: &TpchConfig,
+        benchmark_fname: String,
+    ) -> anyhow::Result<StandardBaseTableStats> {
+        let stats_cache_fpath = self
+            .workspace_dpath
+            .join("datafusion_stats_caches")
+            .join(format!("{}.json", benchmark_fname));
         if stats_cache_fpath.exists() {
             let file = File::open(&stats_cache_fpath)?;
             Ok(serde_json::from_reader(file)?)
@@ -336,8 +343,6 @@ impl DatafusionDBMS {
             println!("datafusion load_tpch_stats duration: {:?}", duration);
             Ok(base_table_stats)
         }
-
-        
     }
 }
 

--- a/optd-perftest/src/datafusion_dbms.rs
+++ b/optd-perftest/src/datafusion_dbms.rs
@@ -141,8 +141,6 @@ impl DatafusionDBMS {
     }
 
     async fn eval_tpch_estcards(&self, tpch_config: &TpchConfig) -> anyhow::Result<Vec<usize>> {
-        let start = Instant::now();
-
         let tpch_kit = TpchKit::build(&self.workspace_dpath)?;
         tpch_kit.gen_queries(tpch_config)?;
 
@@ -152,9 +150,6 @@ impl DatafusionDBMS {
             let estcard = self.eval_query_estcard(&sql).await?;
             estcards.push(estcard);
         }
-
-        let duration = start.elapsed();
-        println!("datafusion eval_tpch_estcards duration: {:?}", duration);
 
         Ok(estcards)
     }
@@ -250,8 +245,6 @@ impl DatafusionDBMS {
 
     #[allow(dead_code)]
     async fn load_tpch_data_no_stats(&mut self, tpch_config: &TpchConfig) -> anyhow::Result<()> {
-        let start = Instant::now();
-
         // Generate the tables.
         let tpch_kit = TpchKit::build(&self.workspace_dpath)?;
         tpch_kit.gen_tables(tpch_config)?;
@@ -298,9 +291,6 @@ impl DatafusionDBMS {
             .await?;
         }
 
-        let duration = start.elapsed();
-        println!("datafusion load_tpch_data duration: {:?}", duration);
-
         Ok(())
     }
 
@@ -308,8 +298,6 @@ impl DatafusionDBMS {
         &mut self,
         tpch_config: &TpchConfig,
     ) -> anyhow::Result<DataFusionBaseTableStats> {
-        let start = Instant::now();
-
         // Generate the tables
         let tpch_kit = TpchKit::build(&self.workspace_dpath)?;
         tpch_kit.gen_tables(tpch_config)?;
@@ -351,8 +339,6 @@ impl DatafusionDBMS {
             );
         }
 
-        let duration = start.elapsed();
-        println!("datafusion load_tpch_stats duration: {:?}", duration);
         Ok(base_table_stats)
     }
 }

--- a/optd-perftest/src/datafusion_dbms.rs
+++ b/optd-perftest/src/datafusion_dbms.rs
@@ -2,7 +2,6 @@ use std::{
     fs::{self, File},
     path::{Path, PathBuf},
     sync::Arc,
-    time::Instant,
 };
 
 use crate::{

--- a/optd-perftest/src/datafusion_dbms.rs
+++ b/optd-perftest/src/datafusion_dbms.rs
@@ -1,5 +1,5 @@
 use std::{
-    fs,
+    fs::{self, File},
     path::{Path, PathBuf},
     sync::Arc,
     time::Instant,
@@ -293,9 +293,8 @@ impl DatafusionDBMS {
             .join("datafusion_stats_caches")
             .join(format!("{}.json", benchmark_fname));
         if stats_cache_fpath.exists() {
-            unimplemented!()
-            // let file = File::open(&stats_cache_fpath)?;
-            // Ok(serde_json::from_reader(file)?)
+            let file = File::open(&stats_cache_fpath)?;
+            Ok(serde_json::from_reader(file)?)
         } else {
             let start = Instant::now();
 
@@ -341,9 +340,9 @@ impl DatafusionDBMS {
                 log::debug!("statistics generated for table: {}", tbl_name);
             }
 
-            // fs::create_dir_all(stats_cache_fpath.parent().unwrap())?;
-            // let file = File::create(&stats_cache_fpath)?;
-            // serde_json::to_writer(file, &base_table_stats)?;
+            fs::create_dir_all(stats_cache_fpath.parent().unwrap())?;
+            let file = File::create(&stats_cache_fpath)?;
+            serde_json::to_writer(file, &base_table_stats)?;
 
             let duration = start.elapsed();
             println!("datafusion load_tpch_stats duration: {:?}", duration);

--- a/optd-perftest/src/main.rs
+++ b/optd-perftest/src/main.rs
@@ -43,7 +43,7 @@ enum Commands {
         //   accidentally use a stale version of the stats
         // regardless of whether this is true or false, we still _write_ to the cache
         //   so that the cache always has the latest version of the stats
-        use_optd_cached_stats: bool,
+        use_cached_optd_stats: bool,
 
         #[clap(long)]
         #[clap(default_value = "default_user")]
@@ -77,7 +77,7 @@ async fn main() -> anyhow::Result<()> {
             scale_factor,
             seed,
             query_ids,
-            use_optd_cached_stats,
+            use_cached_optd_stats,
             pguser,
             pgpassword,
         } => {
@@ -89,7 +89,7 @@ async fn main() -> anyhow::Result<()> {
             };
             let cardinfo_alldbs = cardtest::cardtest(
                 &workspace_dpath,
-                use_optd_cached_stats,
+                use_cached_optd_stats,
                 &pguser,
                 &pgpassword,
                 tpch_config,

--- a/optd-perftest/src/main.rs
+++ b/optd-perftest/src/main.rs
@@ -7,7 +7,7 @@ use std::fs;
 
 #[derive(Parser)]
 struct Cli {
-    #[arg(long)]
+    #[clap(long)]
     #[clap(default_value = "optd_perftest_workspace")]
     #[clap(
         help = "The directory where artifacts required for performance testing (such as pgdata or TPC-H queries) are generated. See comment of parse_pathstr() to see what paths are allowed (TLDR: absolute and relative both ok)."
@@ -21,26 +21,32 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     Cardtest {
-        #[arg(long)]
+        #[clap(long)]
         #[clap(default_value = "0.01")]
         scale_factor: f64,
 
-        #[arg(long)]
+        #[clap(long)]
         #[clap(default_value = "15721")]
         seed: i32,
 
-        #[arg(long)]
+        #[clap(long)]
         #[clap(value_delimiter = ',', num_args = 1..)]
         // this is the current list of all queries that work in perftest
         #[clap(default_value = "2,3,5,6,7,8,9,10,11,12,13,14,17")]
+        #[clap(help = "The queries to get the Q-error of")]
         query_ids: Vec<u32>,
 
-        #[arg(long)]
+        #[clap(long)]
+        #[clap(action)]
+        #[clap(help = "Whether to use the cached optd stats/cache generated stats")]
+        use_optd_stats_cache: bool,
+
+        #[clap(long)]
         #[clap(default_value = "default_user")]
         #[clap(help = "The name of a user with superuser privileges")]
         pguser: String,
 
-        #[arg(long)]
+        #[clap(long)]
         #[clap(default_value = "password")]
         #[clap(help = "The name of a user with superuser privileges")]
         pgpassword: String,
@@ -67,6 +73,7 @@ async fn main() -> anyhow::Result<()> {
             scale_factor,
             seed,
             query_ids,
+            use_optd_stats_cache,
             pguser,
             pgpassword,
         } => {
@@ -76,8 +83,14 @@ async fn main() -> anyhow::Result<()> {
                 seed,
                 query_ids: query_ids.clone(),
             };
-            let cardinfo_alldbs =
-                cardtest::cardtest(&workspace_dpath, &pguser, &pgpassword, tpch_config).await?;
+            let cardinfo_alldbs = cardtest::cardtest(
+                &workspace_dpath,
+                use_optd_stats_cache,
+                &pguser,
+                &pgpassword,
+                tpch_config,
+            )
+            .await?;
             println!();
             println!(" Aggregate Q-Error Comparison");
             let mut agg_qerror_table = Table::new();

--- a/optd-perftest/src/main.rs
+++ b/optd-perftest/src/main.rs
@@ -40,8 +40,10 @@ enum Commands {
         #[clap(action)]
         #[clap(help = "Whether to use the cached optd stats/cache generated stats")]
         // this is an option that is not enabled by default so that the user doesn't
-        // accidentally use a stale version of the stats
-        use_optd_stats_cache: bool,
+        //   accidentally use a stale version of the stats
+        // regardless of whether this is true or false, we still _write_ to the cache
+        //   so that the cache always has the latest version of the stats
+        use_optd_cached_stats: bool,
 
         #[clap(long)]
         #[clap(default_value = "default_user")]
@@ -75,7 +77,7 @@ async fn main() -> anyhow::Result<()> {
             scale_factor,
             seed,
             query_ids,
-            use_optd_stats_cache,
+            use_optd_cached_stats,
             pguser,
             pgpassword,
         } => {
@@ -87,7 +89,7 @@ async fn main() -> anyhow::Result<()> {
             };
             let cardinfo_alldbs = cardtest::cardtest(
                 &workspace_dpath,
-                use_optd_stats_cache,
+                use_optd_cached_stats,
                 &pguser,
                 &pgpassword,
                 tpch_config,

--- a/optd-perftest/src/main.rs
+++ b/optd-perftest/src/main.rs
@@ -39,6 +39,8 @@ enum Commands {
         #[clap(long)]
         #[clap(action)]
         #[clap(help = "Whether to use the cached optd stats/cache generated stats")]
+        // this is an option that is not enabled by default so that the user doesn't
+        // accidentally use a stale version of the stats
         use_optd_stats_cache: bool,
 
         #[clap(long)]

--- a/optd-perftest/src/postgres_dbms.rs
+++ b/optd-perftest/src/postgres_dbms.rs
@@ -158,8 +158,8 @@ impl PostgresDBMS {
 
         // load the constraints and indexes
         // TODO: constraints are currently broken
-        // let sql = fs::read_to_string(tpch_kit.constraints_fpath.to_str().unwrap())?;
-        // client.batch_execute(&sql).await?;
+        let sql = fs::read_to_string(tpch_kit.constraints_fpath.to_str().unwrap())?;
+        client.batch_execute(&sql).await?;
         let sql = fs::read_to_string(tpch_kit.indexes_fpath.to_str().unwrap())?;
         client.batch_execute(&sql).await?;
 

--- a/optd-perftest/src/postgres_dbms.rs
+++ b/optd-perftest/src/postgres_dbms.rs
@@ -13,7 +13,6 @@ use std::{
     fs,
     io::Cursor,
     path::{Path, PathBuf},
-    time::Instant,
 };
 use tokio::fs::File;
 use tokio::io::AsyncReadExt;

--- a/optd-perftest/src/postgres_dbms.rs
+++ b/optd-perftest/src/postgres_dbms.rs
@@ -139,8 +139,6 @@ impl PostgresDBMS {
         client: &Client,
         tpch_config: &TpchConfig,
     ) -> anyhow::Result<()> {
-        let start = Instant::now();
-
         // set up TpchKit
         let tpch_kit = TpchKit::build(&self.workspace_dpath)?;
 
@@ -167,9 +165,6 @@ impl PostgresDBMS {
         // you need to do VACUUM FULL ANALYZE and not just ANALYZE to make sure the stats are created in a deterministic way
         // this is standard practice for postgres benchmarking
         client.query("VACUUM FULL ANALYZE", &[]).await?;
-
-        let duration = start.elapsed();
-        println!("postgres load_tpch_data duration: {:?}", duration);
 
         Ok(())
     }
@@ -207,8 +202,6 @@ impl PostgresDBMS {
         client: &Client,
         tpch_config: &TpchConfig,
     ) -> anyhow::Result<Vec<usize>> {
-        let start = Instant::now();
-
         let tpch_kit = TpchKit::build(&self.workspace_dpath)?;
         tpch_kit.gen_queries(tpch_config)?;
 
@@ -218,9 +211,6 @@ impl PostgresDBMS {
             let estcard = self.eval_query_estcard(client, &sql).await?;
             estcards.push(estcard);
         }
-
-        let duration = start.elapsed();
-        println!("postgres eval_tpch_estcards duration: {:?}", duration);
 
         Ok(estcards)
     }
@@ -247,8 +237,6 @@ impl PostgresDBMS {
         dbname: &str, // used by truecard_cache
         truecard_cache: &mut TruecardCache,
     ) -> anyhow::Result<Vec<usize>> {
-        let start = Instant::now();
-
         let tpch_kit = TpchKit::build(&self.workspace_dpath)?;
         tpch_kit.gen_queries(tpch_config)?;
 
@@ -265,9 +253,6 @@ impl PostgresDBMS {
             };
             truecards.push(truecard);
         }
-
-        let duration = start.elapsed();
-        println!("postgres eval_tpch_truecards duration: {:?}", duration);
 
         Ok(truecards)
     }

--- a/optd-perftest/tests/cardtest_integration.rs
+++ b/optd-perftest/tests/cardtest_integration.rs
@@ -44,7 +44,7 @@ mod tests {
             // make sure scale factor is low so the test runs fast
             "--scale-factor",
             "0.01",
-            "--use-optd-cached-stats",
+            "--use-cached-optd-stats",
             "--pguser",
             "test_user",
             "--pgpassword",

--- a/optd-perftest/tests/cardtest_integration.rs
+++ b/optd-perftest/tests/cardtest_integration.rs
@@ -44,7 +44,7 @@ mod tests {
             // make sure scale factor is low so the test runs fast
             "--scale-factor",
             "0.01",
-            "--use-optd-stats-cache",
+            "--use-optd-cached-stats",
             "--pguser",
             "test_user",
             "--pgpassword",

--- a/optd-perftest/tests/cardtest_integration.rs
+++ b/optd-perftest/tests/cardtest_integration.rs
@@ -44,6 +44,7 @@ mod tests {
             // make sure scale factor is low so the test runs fast
             "--scale-factor",
             "0.01",
+            "--use-optd-stats-cache",
             "--pguser",
             "test_user",
             "--pgpassword",


### PR DESCRIPTION
**Summary**: Now caching the stat objects used by `OptCostModel`, meaning we don't need to load data into DataFusion after doing it the first time.

**Demo**:
12x speedup on TPC-H SF1 compared to not caching stats.

Caching everything _except_ optd stats takes 45.6s total.
![Screenshot 2024-03-23 at 16 59 04](https://github.com/cmu-db/optd/assets/20631215/4c199374-e2df-43fb-9eba-f348ea1e275a)

Caching everything, _including_ optd stats, takes 3.9s total.
![Screenshot 2024-03-23 at 16 57 45](https://github.com/cmu-db/optd/assets/20631215/4ef01ae9-c5a9-4fcd-bad9-c52d9a73c147)

**Details**:
* This caching is **disabled by default** to avoid accidentally using stale stats. I added a CLI arg to enable it.
* The main challenge of this PR was making `PerTableStats` a serializable object for `serde`.
* The serializability refactor will also help down the line when we want to **put statistics in the catalog**, since that is fundamentally a serialization problem too. Having `Box<dyn ...>` would make putting stats in the catalog more difficult.
* This required a significant refactor of how the `MostCommonValues` and `Distribution` traits are handled in `OptCostModel`. Instead of having `Box<dyn ...>` values in `PerColumnStats` which store any object that implements these traits, I made `PerColumnStats` a templated object.
* The one downside of this refactor is that we can no longer have a database which uses _different_ data structures for `Distribution` (like a t-digest for one column, a histogram for another, etc.). I didn't see this as a big enough reason to not do the refactor because it seems like a rare thing to do. Additionally, if we really needed to do this, we could just make an enum that had both types.