### PR TITLE
Feat: two stage heuristic

### DIFF
--- a/optd-core/src/heuristics/optimizer.rs
+++ b/optd-core/src/heuristics/optimizer.rs
@@ -162,6 +162,7 @@ impl<T: RelNodeTyp> HeuristicsOptimizer<T> {
                 Ok(node)
             }
             ApplyOrder::TopDown => {
+                self.infer_properties(root_rel.clone());
                 let root_rel = self.apply_rules(root_rel)?;
                 let optimized_children = self.optimize_inputs(&root_rel.children)?;
                 let node: Arc<RelNode<T>> = RelNode {

--- a/optd-datafusion-repr/src/bin/test_optimize.rs
+++ b/optd-datafusion-repr/src/bin/test_optimize.rs
@@ -92,6 +92,7 @@ pub fn main() {
             Arc::new(HashJoinRule::new()),
         ],
         optd_core::heuristics::ApplyOrder::BottomUp,
+        Arc::new([]),
     );
     let node = optimizer.optimize(fnal.0.into_rel_node()).unwrap();
     println!(


### PR DESCRIPTION
This pr adds infer properties for heuristic optimizer in optd core.

It splits the two passes for heuristic and cascades. Now heuristic rules can be used on the first heuristic optimizer as registering them as default_heuristic_rule and these rules are able to traverse the whole plan tree as there are no placeholder in heuristic stage.

The properties are not shared among heuristic pass and cascades pass though. It is recalculated in cascades.

The pr is for enabling more complicated heuristic rules and one can register their rules as either heuristic or cascade to test its usability and performance.

The logic for the rule creation is the same as previous heuristic rule wrapper:
heuristic rule either return 0 or 1 node. Returning 1 node means that the rule is successfully applied. Returning 0 node means it fails some constraints for the rule and heuristic optimizer will use the original node.