### PR TITLE
Fix: fix for heuristic rule wrapper

### DIFF
--- a/optd-core/src/cascades/tasks/apply_rule.rs
+++ b/optd-core/src/cascades/tasks/apply_rule.rs
@@ -233,11 +233,11 @@ impl<T: RelNodeTyp> Task<T> for ApplyRuleTask {
 
                     trace!(event = "apply_rule replace", expr_id = %self.expr_id, rule_id = %self.rule_id);
 
-                    // rules registed as heuristics are always logical, exploring its children
-                    tasks.push(
-                        Box::new(OptimizeExpressionTask::new(self.expr_id, self.exploring))
-                            as Box<dyn Task<T>>,
-                    );
+                    // the expr returned by heuristic rule is a brand new one
+                    // so there's no optimizeExpressionTask for it in the original task list
+                    // we should set exploring as false to both envoke tranform rule and impl rule for it
+                    tasks.push(Box::new(OptimizeExpressionTask::new(self.expr_id, false))
+                        as Box<dyn Task<T>>);
                 }
                 continue;
             }


### PR DESCRIPTION
The new expr returned by heuristic rules are not in the original group, which means it never got an OptimizeExpressionTask with exploring as false (OptimizeExpressionTask with exploring=False only be called in OptimizeGroup), it should evoke an OptimizeExpressionTask with exploring=false for itself to apply all the transform rules and implementation rules for itself.

Besides, the pr adds checks for whether the original expr equals to the output expr for heuristic rule. If that's the case, it should prompt an error as this breaks the heuristic rule's definition. (Silently accepting it will mark the input expr being as a dead end and there's no more new exprs to replace it)