### PR TITLE
Fix: heuristic rule wrapper fix

### DIFF
--- a/optd-core/src/cascades/optimizer.rs
+++ b/optd-core/src/cascades/optimizer.rs
@@ -294,15 +294,19 @@ impl<T: RelNodeTyp> CascadesOptimizer<T> {
             // the old expr is replaced, so we clear the fired rules for old expr
             self.fired_rules
                 .entry(expr_id)
-                .and_modify(|fired_rules| fired_rules.clear());
+                .or_default().clear();
             return;
         }
-        // new expr merged with old expr, we mark old expr as a dead end
-        self.fired_rules.entry(expr_id).and_modify(|fired_rules| {
-            for i in 0..self.rules.len() {
-                fired_rules.insert(i);
+        
+        // We can mark the expr as a deadend
+        // However, even some of the exprs cannot be the winner for the group
+        // We still need the physical form of those expr to start the optimizeInput task
+        // So we don't mark the impl rules as fired
+        for i in 0..self.rules.len() {
+            if !self.rules[i].rule().is_impl_rule(){
+                self.fired_rules.entry(expr_id).or_default().insert(i);
             }
-        });
+        }
     }
 
     pub(super) fn get_group_info(&self, group_id: GroupId) -> GroupInfo {

--- a/optd-core/src/cascades/tasks/apply_rule.rs
+++ b/optd-core/src/cascades/tasks/apply_rule.rs
@@ -233,10 +233,7 @@ impl<T: RelNodeTyp> Task<T> for ApplyRuleTask {
 
                     trace!(event = "apply_rule replace", expr_id = %self.expr_id, rule_id = %self.rule_id);
 
-                    // the expr returned by heuristic rule is a brand new one
-                    // so there's no optimizeExpressionTask for it in the original task list
-                    // we should set exploring as false to both envoke tranform rule and impl rule for it
-                    tasks.push(Box::new(OptimizeExpressionTask::new(self.expr_id, false))
+                    tasks.push(Box::new(OptimizeExpressionTask::new(self.expr_id, self.exploring))
                         as Box<dyn Task<T>>);
                 }
                 continue;


### PR DESCRIPTION
The flow of the optimization is:

OptimizeGroup(root) --> exploreGroup(children)(can only apply logical->logical) --> after exploration, there are physical exprs in the root --> optimizeInput  --> optimizeGroup(children)(can apply logical to physical)

While marking the rules as deadend, we cannot mark the impl rules as fired as we might need them to start the optimizeGroup task of the children node after merging of groups even if we know the expr can never be the winner.