### PR TITLE
feat: JOB cardinality testing

### DIFF
--- a/optd-datafusion-repr/src/cost/base_cost/filter.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/filter.rs
@@ -346,7 +346,7 @@ impl<M: MostCommonValues, D: Distribution> OptCostModel<M, D> {
         value: &Value,
         is_eq: bool,
     ) -> f64 {
-        if let Some(per_column_stats) = self.get_per_column_stats(table, col_idx) {
+        let ret_freq = if let Some(per_column_stats) = self.get_per_column_stats(table, col_idx) {
             let eq_freq = if let Some(freq) = per_column_stats.mcvs.freq(value) {
                 freq
             } else {
@@ -372,7 +372,9 @@ impl<M: MostCommonValues, D: Distribution> OptCostModel<M, D> {
             } else {
                 1.0 - DEFAULT_EQ_SEL
             }
-        }
+        };
+        assert!(ret_freq >= 0.0 && ret_freq <= 1.0, "ret_freq ({}) should be in [0, 1]", ret_freq);
+        ret_freq
     }
 
     /// Compute the frequency of values in a column less than or equal to the given value.
@@ -383,7 +385,9 @@ impl<M: MostCommonValues, D: Distribution> OptCostModel<M, D> {
         let value = value.clone();
         let pred = Box::new(move |val: &Value| val <= &value);
         let mcvs_leq_freq = per_column_stats.mcvs.freq_over_pred(pred);
-        distr_leq_freq + mcvs_leq_freq
+        let ret_freq = distr_leq_freq + mcvs_leq_freq;
+        assert!(ret_freq >= 0.0 && ret_freq <= 1.0, "ret_freq ({}) should be in [0, 1]", ret_freq);
+        ret_freq
     }
 
     /// Compute the frequency of values in a column less than the given value.
@@ -396,10 +400,10 @@ impl<M: MostCommonValues, D: Distribution> OptCostModel<M, D> {
     ) -> f64 {
         // depending on whether value is in mcvs or not, we use different logic to turn total_lt_cdf into total_leq_cdf
         // this logic just so happens to be the exact same logic as get_column_equality_selectivity implements
-        let freq = Self::get_column_leq_value_freq(per_column_stats, value)
+        let ret_freq = Self::get_column_leq_value_freq(per_column_stats, value)
             - self.get_column_equality_selectivity(table, col_idx, value, true);
-        assert!(freq >= 0.0 && freq <= 1.0, "freq ({}) should be in [0, 1]", freq);
-        freq
+        assert!(ret_freq >= 0.0 && ret_freq <= 1.0, "ret_freq ({}) should be in [0, 1]", ret_freq);
+        ret_freq
     }
 
     /// Get the selectivity of an expression of the form "column </<=/>=/> value" (or "value </<=/>=/> column").

--- a/optd-datafusion-repr/src/cost/base_cost/filter.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/filter.rs
@@ -396,8 +396,10 @@ impl<M: MostCommonValues, D: Distribution> OptCostModel<M, D> {
     ) -> f64 {
         // depending on whether value is in mcvs or not, we use different logic to turn total_lt_cdf into total_leq_cdf
         // this logic just so happens to be the exact same logic as get_column_equality_selectivity implements
-        Self::get_column_leq_value_freq(per_column_stats, value)
-            - self.get_column_equality_selectivity(table, col_idx, value, true)
+        let freq = Self::get_column_leq_value_freq(per_column_stats, value)
+            - self.get_column_equality_selectivity(table, col_idx, value, true);
+        assert!(freq >= 0.0 && freq <= 1.0, "freq ({}) should be in [0, 1]", freq);
+        freq
     }
 
     /// Get the selectivity of an expression of the form "column </<=/>=/> value" (or "value </<=/>=/> column").
@@ -427,7 +429,7 @@ impl<M: MostCommonValues, D: Distribution> OptCostModel<M, D> {
                     self.get_column_lt_value_freq(per_column_stats, table, col_idx, value)
                 }
             };
-            assert!(left_quantile <= right_quantile);
+            assert!(left_quantile <= right_quantile, "left_quantile ({}) should be <= right_quantile ({})", left_quantile, right_quantile);
             // `Distribution` does not account for NULL values, so the selectivity is smaller than frequency.
             (right_quantile - left_quantile) * (1.0 - per_column_stats.null_frac)
         } else {

--- a/optd-datafusion-repr/src/cost/base_cost/filter.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/filter.rs
@@ -373,7 +373,11 @@ impl<M: MostCommonValues, D: Distribution> OptCostModel<M, D> {
                 1.0 - DEFAULT_EQ_SEL
             }
         };
-        assert!(ret_freq >= 0.0 && ret_freq <= 1.0, "ret_freq ({}) should be in [0, 1]", ret_freq);
+        assert!(
+            (0.0..=1.0).contains(&ret_freq),
+            "ret_freq ({}) should be in [0, 1]",
+            ret_freq
+        );
         ret_freq
     }
 
@@ -386,7 +390,11 @@ impl<M: MostCommonValues, D: Distribution> OptCostModel<M, D> {
         let pred = Box::new(move |val: &Value| val <= &value);
         let mcvs_leq_freq = per_column_stats.mcvs.freq_over_pred(pred);
         let ret_freq = distr_leq_freq + mcvs_leq_freq;
-        assert!(ret_freq >= 0.0 && ret_freq <= 1.0, "ret_freq ({}) should be in [0, 1]", ret_freq);
+        assert!(
+            (0.0..=1.0).contains(&ret_freq),
+            "ret_freq ({}) should be in [0, 1]",
+            ret_freq
+        );
         ret_freq
     }
 
@@ -402,7 +410,11 @@ impl<M: MostCommonValues, D: Distribution> OptCostModel<M, D> {
         // this logic just so happens to be the exact same logic as get_column_equality_selectivity implements
         let ret_freq = Self::get_column_leq_value_freq(per_column_stats, value)
             - self.get_column_equality_selectivity(table, col_idx, value, true);
-        assert!(ret_freq >= 0.0 && ret_freq <= 1.0, "ret_freq ({}) should be in [0, 1]", ret_freq);
+        assert!(
+            (0.0..=1.0).contains(&ret_freq),
+            "ret_freq ({}) should be in [0, 1]",
+            ret_freq
+        );
         ret_freq
     }
 
@@ -433,7 +445,12 @@ impl<M: MostCommonValues, D: Distribution> OptCostModel<M, D> {
                     self.get_column_lt_value_freq(per_column_stats, table, col_idx, value)
                 }
             };
-            assert!(left_quantile <= right_quantile, "left_quantile ({}) should be <= right_quantile ({})", left_quantile, right_quantile);
+            assert!(
+                left_quantile <= right_quantile,
+                "left_quantile ({}) should be <= right_quantile ({})",
+                left_quantile,
+                right_quantile
+            );
             // `Distribution` does not account for NULL values, so the selectivity is smaller than frequency.
             (right_quantile - left_quantile) * (1.0 - per_column_stats.null_frac)
         } else {

--- a/optd-datafusion-repr/src/cost/base_cost/stats.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/stats.rs
@@ -218,8 +218,7 @@ impl PerTableStats<Counter<Value>, TDigest> {
             per_column_stats_vec.push(if Self::is_type_supported(&col_types[i]) {
                 Some(PerColumnStats::new(
                     counter,
-                    // hlls[i].n_distinct(), DEBUG(phw2)
-                    200,
+                    hlls[i].n_distinct(),
                     null_cnt[i] as f64 / row_cnt as f64,
                     distr[i].take().unwrap(),
                 ))

--- a/optd-datafusion-repr/src/cost/base_cost/stats.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/stats.rs
@@ -218,7 +218,8 @@ impl PerTableStats<Counter<Value>, TDigest> {
             per_column_stats_vec.push(if Self::is_type_supported(&col_types[i]) {
                 Some(PerColumnStats::new(
                     counter,
-                    hlls[i].n_distinct(),
+                    // hlls[i].n_distinct(), DEBUG(phw2)
+                    200,
                     null_cnt[i] as f64 / row_cnt as f64,
                     distr[i].take().unwrap(),
                 ))

--- a/optd-perftest/src/datafusion_dbms.rs
+++ b/optd-perftest/src/datafusion_dbms.rs
@@ -5,7 +5,10 @@ use std::{
 };
 
 use crate::{
-    benchmark::Benchmark, cardtest::CardtestRunnerDBMSHelper, job::{JobConfig, JobKit}, tpch::{TpchConfig, TpchKit}
+    benchmark::Benchmark,
+    cardtest::CardtestRunnerDBMSHelper,
+    job::{JobConfig, JobKit},
+    tpch::{TpchConfig, TpchKit},
 };
 use async_trait::async_trait;
 use datafusion::{
@@ -48,19 +51,19 @@ impl CardtestRunnerDBMSHelper for DatafusionDBMS {
     ) -> anyhow::Result<Vec<usize>> {
         let base_table_stats = self.get_benchmark_stats(benchmark).await?;
         self.clear_state(Some(base_table_stats)).await?;
-        
+
         match benchmark {
             Benchmark::Tpch(tpch_config) => {
                 // Create the tables. This must be done after clear_state because that clears everything
                 let tpch_kit = TpchKit::build(&self.workspace_dpath)?;
                 self.create_tpch_tables(&tpch_kit).await?;
                 self.eval_tpch_estcards(tpch_config).await
-            },
+            }
             Benchmark::Job(job_config) => {
                 let job_kit = JobKit::build(&self.workspace_dpath)?;
                 self.create_job_tables(&job_kit).await?;
                 self.eval_job_estcards(job_config).await
-            },
+            }
         }
     }
 }

--- a/optd-perftest/src/datafusion_dbms.rs
+++ b/optd-perftest/src/datafusion_dbms.rs
@@ -48,12 +48,19 @@ impl CardtestRunnerDBMSHelper for DatafusionDBMS {
     ) -> anyhow::Result<Vec<usize>> {
         let base_table_stats = self.get_benchmark_stats(benchmark).await?;
         self.clear_state(Some(base_table_stats)).await?;
-        // Create the tables. This must be done after clear_state because that clears everything
-        let tpch_kit = TpchKit::build(&self.workspace_dpath)?;
-        self.create_tpch_tables(&tpch_kit).await?;
+        
         match benchmark {
-            Benchmark::Tpch(tpch_config) => self.eval_tpch_estcards(tpch_config).await,
-            Benchmark::Job(_job_config) => unimplemented!(),
+            Benchmark::Tpch(tpch_config) => {
+                // Create the tables. This must be done after clear_state because that clears everything
+                let tpch_kit = TpchKit::build(&self.workspace_dpath)?;
+                self.create_tpch_tables(&tpch_kit).await?;
+                self.eval_tpch_estcards(tpch_config).await
+            },
+            Benchmark::Job(job_config) => {
+                let job_kit = JobKit::build(&self.workspace_dpath)?;
+                self.create_job_tables(&job_kit).await?;
+                self.eval_job_estcards(job_config).await
+            },
         }
     }
 }
@@ -155,6 +162,23 @@ impl DatafusionDBMS {
         Ok(estcards)
     }
 
+    async fn eval_job_estcards(&self, job_config: &JobConfig) -> anyhow::Result<Vec<usize>> {
+        let job_kit = JobKit::build(&self.workspace_dpath)?;
+
+        let mut estcards = vec![];
+        for (query_id, sql_fpath) in job_kit.get_sql_fpath_ordered_iter(job_config)? {
+            println!(
+                "about to evaluate datafusion's estcard for TPC-H Q{}",
+                query_id
+            );
+            let sql = fs::read_to_string(sql_fpath)?;
+            let estcard = self.eval_query_estcard(&sql).await?;
+            estcards.push(estcard);
+        }
+
+        Ok(estcards)
+    }
+
     fn log_explain(&self, explains: &[Vec<String>]) {
         // row_cnt is exclusively in physical_plan after optd
         let physical_plan_after_optd_lines = explains
@@ -232,6 +256,19 @@ impl DatafusionDBMS {
 
     async fn create_tpch_tables(&mut self, tpch_kit: &TpchKit) -> anyhow::Result<()> {
         let ddls = fs::read_to_string(&tpch_kit.schema_fpath)?;
+        let ddls = ddls
+            .split(';')
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<_>>();
+        for ddl in ddls {
+            Self::execute(&self.ctx, ddl).await?;
+        }
+        Ok(())
+    }
+
+    async fn create_job_tables(&mut self, job_kit: &JobKit) -> anyhow::Result<()> {
+        let ddls = fs::read_to_string(&job_kit.schema_fpath)?;
         let ddls = ddls
             .split(';')
             .map(|s| s.trim())
@@ -385,7 +422,8 @@ impl DatafusionDBMS {
                     let tbl_file = fs::File::open(&tbl_fpath)?;
                     let csv_reader1 = ReaderBuilder::new(schema.clone())
                         .has_header(false)
-                        .with_delimiter(b'|')
+                        .with_delimiter(b',')
+                        .with_escape(b'\\')
                         .build(tbl_file)
                         .unwrap();
                     Ok(RecordBatchIterator::new(csv_reader1, schema.clone()))

--- a/optd-perftest/src/datafusion_dbms.rs
+++ b/optd-perftest/src/datafusion_dbms.rs
@@ -244,8 +244,8 @@ impl DatafusionDBMS {
                 Benchmark::Job(job_config) => self.get_job_stats(job_config).await?,
             };
 
-            // When self.rebuild_cached_stats is true, we *don't read* from the cache but we still
-            //   *do write* to the cache.
+            // When self.rebuild_cached_optd_stats is true, we *don't read* from the cache but we
+            //   still *do write* to the cache.
             fs::create_dir_all(stats_cache_fpath.parent().unwrap())?;
             let file = File::create(&stats_cache_fpath)?;
             serde_json::to_writer(file, &base_table_stats)?;
@@ -418,7 +418,7 @@ impl DatafusionDBMS {
 
             base_table_stats.insert(
                 tbl_name.to_string(),
-                DataFusionPerTableStats::from_record_batches(|| {
+                DataFusionPerTableStats::from_record_batches_job(|| {
                     let tbl_file = fs::File::open(&tbl_fpath)?;
                     let csv_reader1 = ReaderBuilder::new(schema.clone())
                         .has_header(false)

--- a/optd-perftest/src/datafusion_dbms.rs
+++ b/optd-perftest/src/datafusion_dbms.rs
@@ -5,9 +5,7 @@ use std::{
 };
 
 use crate::{
-    benchmark::Benchmark,
-    cardtest::CardtestRunnerDBMSHelper,
-    tpch::{TpchConfig, TpchKit},
+    benchmark::Benchmark, cardtest::CardtestRunnerDBMSHelper, job::{JobConfig, JobKit}, tpch::{TpchConfig, TpchKit}
 };
 use async_trait::async_trait;
 use datafusion::{
@@ -219,7 +217,7 @@ impl DatafusionDBMS {
         } else {
             let base_table_stats = match benchmark {
                 Benchmark::Tpch(tpch_config) => self.get_tpch_stats(tpch_config).await?,
-                _ => unimplemented!(),
+                Benchmark::Job(job_config) => self.get_job_stats(job_config).await?,
             };
 
             // When self.rebuild_cached_stats is true, we *don't read* from the cache but we still
@@ -316,15 +314,67 @@ impl DatafusionDBMS {
             Self::execute(&ctx, ddl).await?;
         }
 
+        // Build the DataFusionBaseTableStats object.
         let mut base_table_stats = DataFusionBaseTableStats::default();
         for tbl_fpath in tpch_kit.get_tbl_fpath_iter(tpch_config).unwrap() {
-            let tbl_name = tbl_fpath.file_stem().unwrap().to_str().unwrap();
+            let tbl_name = TpchKit::get_tbl_name_from_tbl_fpath(&tbl_fpath);
             let schema = ctx
                 .catalog("datafusion")
                 .unwrap()
                 .schema("public")
                 .unwrap()
-                .table(tbl_name)
+                .table(&tbl_name)
+                .await
+                .unwrap()
+                .schema();
+
+            base_table_stats.insert(
+                tbl_name.to_string(),
+                DataFusionPerTableStats::from_record_batches(|| {
+                    let tbl_file = fs::File::open(&tbl_fpath)?;
+                    let csv_reader1 = ReaderBuilder::new(schema.clone())
+                        .has_header(false)
+                        .with_delimiter(b'|')
+                        .build(tbl_file)
+                        .unwrap();
+                    Ok(RecordBatchIterator::new(csv_reader1, schema.clone()))
+                })?,
+            );
+        }
+
+        Ok(base_table_stats)
+    }
+
+    async fn get_job_stats(
+        &mut self,
+        job_config: &JobConfig,
+    ) -> anyhow::Result<DataFusionBaseTableStats> {
+        // Generate the tables
+        let job_kit = JobKit::build(&self.workspace_dpath)?;
+        job_kit.download_tables(job_config)?;
+
+        // To get the schema of each table.
+        let ctx = Self::new_session_ctx(None).await?;
+        let ddls = fs::read_to_string(&job_kit.schema_fpath)?;
+        let ddls = ddls
+            .split(';')
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<_>>();
+        for ddl in ddls {
+            Self::execute(&ctx, ddl).await?;
+        }
+
+        // Build the DataFusionBaseTableStats object.
+        let mut base_table_stats = DataFusionBaseTableStats::default();
+        for tbl_fpath in job_kit.get_tbl_fpath_iter().unwrap() {
+            let tbl_name = JobKit::get_tbl_name_from_tbl_fpath(&tbl_fpath);
+            let schema = ctx
+                .catalog("datafusion")
+                .unwrap()
+                .schema("public")
+                .unwrap()
+                .table(&tbl_name)
                 .await
                 .unwrap()
                 .schema();

--- a/optd-perftest/src/job.rs
+++ b/optd-perftest/src/job.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 
 const JOB_KIT_REPO_URL: &str = "https://github.com/wangpatrick57/job-kit.git";
 const JOB_TABLES_URL: &str = "https://homepages.cwi.nl/~boncz/job/imdb.tgz";
+pub const WORKING_QUERY_IDS: &[&str] = &["1a", "1b"];
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct JobConfig {

--- a/optd-perftest/src/job.rs
+++ b/optd-perftest/src/job.rs
@@ -45,7 +45,7 @@ impl JobKit {
     pub fn build<P: AsRef<Path>>(workspace_dpath: P) -> io::Result<Self> {
         log::debug!("[start] building JobKit");
 
-        // build paths, sometimes creating them if they don't exist
+        // Build paths, sometimes creating them if they don't exist
         let workspace_dpath = workspace_dpath.as_ref().to_path_buf();
         let job_dpath = workspace_dpath.join("job");
         if !job_dpath.exists() {
@@ -57,10 +57,14 @@ impl JobKit {
         if !downloaded_tables_dpath.exists() {
             fs::create_dir(&downloaded_tables_dpath)?;
         }
+        // Note that the downloaded tables directory has a file called schematext.sql.
+        // I chose to use the schema.sql in the repo itself for one simple reason: since
+        //   we forked the repo, we can modify the schema.sql if necessary.
+        // Note also that I copied schematext.sql into our job-kit fork *for reference only*.
         let schema_fpath = job_kit_repo_dpath.join("schema.sql");
         let indexes_fpath = job_kit_repo_dpath.join("fkindexes.sql");
 
-        // create Self
+        // Create Self
         let kit = JobKit {
             _workspace_dpath: workspace_dpath,
             job_dpath,

--- a/optd-perftest/src/job.rs
+++ b/optd-perftest/src/job.rs
@@ -52,7 +52,7 @@ impl JobKit {
             fs::create_dir(&job_dpath)?;
         }
         let job_kit_repo_dpath = job_dpath.join("job-kit");
-        let queries_dpath = job_kit_repo_dpath.join("queries");
+        let queries_dpath = job_kit_repo_dpath.clone();
         let downloaded_tables_dpath = job_dpath.join("downloaded_tables");
         if !downloaded_tables_dpath.exists() {
             fs::create_dir(&downloaded_tables_dpath)?;

--- a/optd-perftest/src/main.rs
+++ b/optd-perftest/src/main.rs
@@ -1,6 +1,6 @@
 use clap::{Parser, Subcommand, ValueEnum};
 use optd_perftest::benchmark::Benchmark;
-use optd_perftest::cardtest;
+use optd_perftest::{cardtest, job, tpch};
 use optd_perftest::job::JobConfig;
 use optd_perftest::shell;
 use optd_perftest::tpch::{TpchConfig, TPCH_KIT_POSTGRES};
@@ -46,7 +46,7 @@ enum Commands {
         #[clap(long)]
         #[clap(value_delimiter = ',', num_args = 1..)]
         // This is the current list of all queries that work in perftest
-        #[clap(default_value = "2,3,5,6,7,8,9,10,11,12,13,14,17,19")]
+        #[clap(default_value = None)]
         #[clap(help = "The queries to get the Q-error of")]
         query_ids: Vec<String>,
 
@@ -89,13 +89,26 @@ async fn cardtest<P: AsRef<Path>>(
     pguser: String,
     pgpassword: String,
 ) -> anyhow::Result<()> {
+    let query_ids = if query_ids.is_empty() {
+        Vec::from(match benchmark_name {
+            BenchmarkName::Tpch => {
+                tpch::WORKING_QUERY_IDS
+            },
+            BenchmarkName::Job => {
+                job::WORKING_QUERY_IDS
+            },
+        }).into_iter().map(|s| String::from(s)).collect()
+    } else {
+        query_ids
+    };
+
     let benchmark = match benchmark_name {
         BenchmarkName::Tpch => Benchmark::Tpch(TpchConfig {
-            dbms: String::from(TPCH_KIT_POSTGRES),
-            scale_factor,
-            seed,
-            query_ids: query_ids.clone(),
-        }),
+                dbms: String::from(TPCH_KIT_POSTGRES),
+                scale_factor,
+                seed,
+                query_ids: query_ids.clone(),
+            }),
         BenchmarkName::Job => Benchmark::Job(JobConfig {
             query_ids: query_ids.clone(),
         }),

--- a/optd-perftest/src/main.rs
+++ b/optd-perftest/src/main.rs
@@ -104,11 +104,11 @@ async fn cardtest<P: AsRef<Path>>(
 
     let benchmark = match benchmark_name {
         BenchmarkName::Tpch => Benchmark::Tpch(TpchConfig {
-                dbms: String::from(TPCH_KIT_POSTGRES),
-                scale_factor,
-                seed,
-                query_ids: query_ids.clone(),
-            }),
+            dbms: String::from(TPCH_KIT_POSTGRES),
+            scale_factor,
+            seed,
+            query_ids: query_ids.clone(),
+        }),
         BenchmarkName::Job => Benchmark::Job(JobConfig {
             query_ids: query_ids.clone(),
         }),

--- a/optd-perftest/src/main.rs
+++ b/optd-perftest/src/main.rs
@@ -1,9 +1,9 @@
 use clap::{Parser, Subcommand, ValueEnum};
 use optd_perftest::benchmark::Benchmark;
-use optd_perftest::{cardtest, job, tpch};
 use optd_perftest::job::JobConfig;
 use optd_perftest::shell;
 use optd_perftest::tpch::{TpchConfig, TPCH_KIT_POSTGRES};
+use optd_perftest::{cardtest, job, tpch};
 use prettytable::{format, Table};
 use std::fs;
 use std::path::Path;
@@ -91,13 +91,12 @@ async fn cardtest<P: AsRef<Path>>(
 ) -> anyhow::Result<()> {
     let query_ids = if query_ids.is_empty() {
         Vec::from(match benchmark_name {
-            BenchmarkName::Tpch => {
-                tpch::WORKING_QUERY_IDS
-            },
-            BenchmarkName::Job => {
-                job::WORKING_QUERY_IDS
-            },
-        }).into_iter().map(|s| String::from(s)).collect()
+            BenchmarkName::Tpch => tpch::WORKING_QUERY_IDS,
+            BenchmarkName::Job => job::WORKING_QUERY_IDS,
+        })
+        .into_iter()
+        .map(String::from)
+        .collect()
     } else {
         query_ids
     };

--- a/optd-perftest/src/postgres_dbms.rs
+++ b/optd-perftest/src/postgres_dbms.rs
@@ -323,6 +323,33 @@ impl PostgresDBMS {
         Ok(truecards)
     }
 
+    async fn eval_job_truecards(
+        &mut self,
+        client: &Client,
+        job_config: &JobConfig,
+        dbname: &str, // used by truecard_cache
+        truecard_cache: &mut TruecardCache,
+    ) -> anyhow::Result<Vec<usize>> {
+        let job_kit = JobKit::build(&self.workspace_dpath)?;
+
+        let mut truecards = vec![];
+        for (query_id, sql_fpath) in job_kit.get_sql_fpath_ordered_iter(job_config)? {
+            println!("sql_fpath={:?}", sql_fpath);
+            let sql = fs::read_to_string(sql_fpath)?;
+            let truecard = match truecard_cache.get_truecard(dbname, &query_id) {
+                Some(truecard) => truecard,
+                None => {
+                    let truecard = self.eval_query_truecard(client, &sql).await?;
+                    truecard_cache.insert_truecard(dbname, &query_id, truecard);
+                    truecard
+                }
+            };
+            truecards.push(truecard);
+        }
+
+        Ok(truecards)
+    }
+
     async fn eval_query_truecard(&self, client: &Client, sql: &str) -> anyhow::Result<usize> {
         let rows = client.query(sql, &[]).await?;
         let truecard = rows.len();
@@ -389,11 +416,8 @@ impl TruecardGetter for PostgresDBMS {
         let client = self.connect_to_db(&dbname).await?;
         // all "eval_*" functions should add the truecards they find to the truecard cache
         match benchmark {
-            Benchmark::Tpch(tpch_config) => {
-                self.eval_tpch_truecards(&client, tpch_config, &dbname, &mut truecard_cache)
-                    .await
-            }
-            Benchmark::Job(_job_config) => unimplemented!(),
+            Benchmark::Tpch(tpch_config) => self.eval_tpch_truecards(&client, tpch_config, &dbname, &mut truecard_cache).await,
+            Benchmark::Job(job_config) => self.eval_job_truecards(&client, job_config, &dbname, &mut truecard_cache).await,
         }
         // note that truecard_cache will save itself when it goes out of scope
     }

--- a/optd-perftest/src/postgres_dbms.rs
+++ b/optd-perftest/src/postgres_dbms.rs
@@ -281,6 +281,23 @@ impl PostgresDBMS {
         Ok(estcards)
     }
 
+    async fn eval_job_estcards(
+        &self,
+        client: &Client,
+        job_config: &JobConfig,
+    ) -> anyhow::Result<Vec<usize>> {
+        let job_kit = JobKit::build(&self.workspace_dpath)?;
+
+        let mut estcards = vec![];
+        for (_, sql_fpath) in job_kit.get_sql_fpath_ordered_iter(job_config)? {
+            let sql = fs::read_to_string(sql_fpath)?;
+            let estcard = self.eval_query_estcard(client, &sql).await?;
+            estcards.push(estcard);
+        }
+
+        Ok(estcards)
+    }
+
     fn log_explain(&self, explain_rows: &[Row]) {
         let explain_lines: Vec<&str> = explain_rows.iter().map(|row| row.get(0)).collect();
         let explain_str = explain_lines.join("\n");
@@ -347,8 +364,6 @@ impl PostgresDBMS {
             truecards.push(truecard);
         }
 
-        panic!("done");
-
         Ok(truecards)
     }
 
@@ -394,7 +409,7 @@ impl CardtestRunnerDBMSHelper for PostgresDBMS {
         let client = self.connect_to_db(&dbname).await?;
         match benchmark {
             Benchmark::Tpch(tpch_config) => self.eval_tpch_estcards(&client, tpch_config).await,
-            Benchmark::Job(_job_config) => unimplemented!(),
+            Benchmark::Job(job_config) => self.eval_job_estcards(&client, job_config).await,
         }
     }
 }

--- a/optd-perftest/src/postgres_dbms.rs
+++ b/optd-perftest/src/postgres_dbms.rs
@@ -351,7 +351,6 @@ impl PostgresDBMS {
 
         let mut truecards = vec![];
         for (query_id, sql_fpath) in job_kit.get_sql_fpath_ordered_iter(job_config)? {
-            println!("sql_fpath={:?}", sql_fpath);
             let sql = fs::read_to_string(sql_fpath)?;
             let truecard = match truecard_cache.get_truecard(dbname, &query_id) {
                 Some(truecard) => truecard,
@@ -433,8 +432,14 @@ impl TruecardGetter for PostgresDBMS {
         let client = self.connect_to_db(&dbname).await?;
         // all "eval_*" functions should add the truecards they find to the truecard cache
         match benchmark {
-            Benchmark::Tpch(tpch_config) => self.eval_tpch_truecards(&client, tpch_config, &dbname, &mut truecard_cache).await,
-            Benchmark::Job(job_config) => self.eval_job_truecards(&client, job_config, &dbname, &mut truecard_cache).await,
+            Benchmark::Tpch(tpch_config) => {
+                self.eval_tpch_truecards(&client, tpch_config, &dbname, &mut truecard_cache)
+                    .await
+            }
+            Benchmark::Job(job_config) => {
+                self.eval_job_truecards(&client, job_config, &dbname, &mut truecard_cache)
+                    .await
+            }
         }
         // note that truecard_cache will save itself when it goes out of scope
     }

--- a/optd-perftest/src/postgres_dbms.rs
+++ b/optd-perftest/src/postgres_dbms.rs
@@ -347,6 +347,8 @@ impl PostgresDBMS {
             truecards.push(truecard);
         }
 
+        panic!("done");
+
         Ok(truecards)
     }
 

--- a/optd-perftest/src/tpch.rs
+++ b/optd-perftest/src/tpch.rs
@@ -13,6 +13,7 @@ use std::path::{Path, PathBuf};
 const TPCH_KIT_REPO_URL: &str = "https://github.com/wangpatrick57/tpch-kit.git";
 pub const TPCH_KIT_POSTGRES: &str = "POSTGRESQL";
 const NUM_TPCH_QUERIES: usize = 22;
+pub const WORKING_QUERY_IDS: &[&str] = &["2", "3", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "17", "19"];
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TpchConfig {

--- a/optd-perftest/src/tpch.rs
+++ b/optd-perftest/src/tpch.rs
@@ -13,7 +13,9 @@ use std::path::{Path, PathBuf};
 const TPCH_KIT_REPO_URL: &str = "https://github.com/wangpatrick57/tpch-kit.git";
 pub const TPCH_KIT_POSTGRES: &str = "POSTGRESQL";
 const NUM_TPCH_QUERIES: usize = 22;
-pub const WORKING_QUERY_IDS: &[&str] = &["2", "3", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "17", "19"];
+pub const WORKING_QUERY_IDS: &[&str] = &[
+    "2", "3", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "17", "19",
+];
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TpchConfig {

--- a/optd-perftest/tests/cardtest_integration.rs
+++ b/optd-perftest/tests/cardtest_integration.rs
@@ -14,8 +14,9 @@ mod tests {
     ///   preferred way of starting it (in Docker container, with Mac app, custom build, etc.)
     /// It's important to exercise all the different benchmarks to make sure their respective
     ///   kits, loading logic, and execution logic are sound.
+    /// While it'd be nice to test JOB, JOB only has one scale factor and that scale factor
+    ///   takes 30 minutes to build stats as of 4/15/24, so we don't test it right now.
     #[test_case::test_case("tpch")]
-    // #[test_case::test_case("job")]
     fn cli_run_cardtest_twice(benchmark_name: &str) {
         // perform cleanup (clear workspace)
         let workspace_dpath = shell::parse_pathstr(WORKSPACE).unwrap();


### PR DESCRIPTION
**Summary**: Basic JOB cardinality testing done with Postgres cost estimation, DataFusion stats building, and optd cost estimation for queries 1a and 1b.

**Demo**:
Working for queries 1a and 1b.
![Screenshot 2024-04-15 at 12 07 43](https://github.com/cmu-db/optd/assets/20631215/e75edc2a-e596-4628-99b5-9711786bfb18)

**Details**:
* HLL and MCVs currently cause issues that will be fixed in future PRs, so I create stats for JOB right now with a special `from_record_batches_job()`.
* I only did queries 1a and 1b because figuring out which queries work is a separate problem (and should wait until we have the stats completed).
