### PR TITLE
fix: reference the correct column stats for nlj and hash join

### DIFF
--- a/optd-datafusion-repr/src/cost/base_cost.rs
+++ b/optd-datafusion-repr/src/cost/base_cost.rs
@@ -316,6 +316,8 @@ mod tests {
 
     pub const TABLE1_NAME: &str = "table1";
     pub const TABLE2_NAME: &str = "table2";
+    pub const TABLE1_COL_CNT: usize = 1;
+    pub const TABLE2_COL_CNT: usize = 1;
 
     // one column is sufficient for all filter selectivity tests
     pub fn create_one_column_cost_model(per_column_stats: TestPerColumnStats) -> TestOptCostModel {

--- a/optd-datafusion-repr/src/cost/base_cost.rs
+++ b/optd-datafusion-repr/src/cost/base_cost.rs
@@ -316,8 +316,6 @@ mod tests {
 
     pub const TABLE1_NAME: &str = "table1";
     pub const TABLE2_NAME: &str = "table2";
-    pub const TABLE1_COL_CNT: usize = 1;
-    pub const TABLE2_COL_CNT: usize = 1;
 
     // one column is sufficient for all filter selectivity tests
     pub fn create_one_column_cost_model(per_column_stats: TestPerColumnStats) -> TestOptCostModel {

--- a/optd-datafusion-repr/src/cost/base_cost/join.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/join.rs
@@ -102,6 +102,7 @@ impl<
     }
 
     /// A wrapper to convert the join keys to the format expected by get_join_selectivity_core()
+    #[allow(clippy::too_many_arguments)]
     fn get_join_selectivity_from_keys(
         &self,
         join_typ: JoinType,
@@ -139,6 +140,7 @@ impl<
     }
 
     /// The core logic of join selectivity which assumes we've already separated the expression into the on conditions and the filters
+    #[allow(clippy::too_many_arguments)]
     fn get_join_selectivity_core(
         &self,
         join_typ: JoinType,

--- a/optd-datafusion-repr/src/cost/base_cost/join.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/join.rs
@@ -111,7 +111,7 @@ impl<
         column_refs: &GroupColumnRefs,
         left_row_cnt: f64,
         right_row_cnt: f64,
-        right_col_ref_offset: usize,
+        left_col_cnt: usize,
     ) -> f64 {
         assert!(left_keys.len() == right_keys.len());
         // I assume that the keys are already in the right order s.t. the ith key of left_keys corresponds with the ith key of right_keys
@@ -135,11 +135,17 @@ impl<
             column_refs,
             left_row_cnt,
             right_row_cnt,
-            right_col_ref_offset,
+            left_col_cnt,
         )
     }
 
     /// The core logic of join selectivity which assumes we've already separated the expression into the on conditions and the filters
+    /// Hash join and NLJ reference right table columns differently, hence the `right_col_ref_offset` parameter.
+    /// For hash join, the right table columns indices are with respect to the right table,
+    ///   which means #0 is the first column of the right table.
+    /// For NLJ, the right table columns indices are with respect to the output of the join.
+    ///   For example, if the left table has 3 columns, the first column of the right table
+    ///   is #3 instead of #0.
     #[allow(clippy::too_many_arguments)]
     fn get_join_selectivity_core(
         &self,

--- a/optd-datafusion-repr/src/cost/base_cost/join.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/join.rs
@@ -94,13 +94,6 @@ impl<
         } else {
             DEFAULT_UNK_SEL
         };
-        println!(
-            "l: {:.2}, r: {:.2}, sel: {}, output: {}",
-            row_cnt_1,
-            row_cnt_2,
-            selectivity,
-            (row_cnt_1 * row_cnt_2 * selectivity).max(1.0)
-        );
         Self::cost(
             (row_cnt_1 * row_cnt_2 * selectivity).max(1.0),
             row_cnt_1 * 2.0 + row_cnt_2,
@@ -311,20 +304,12 @@ impl<
         column_refs: &GroupColumnRefs,
         right_col_ref_offset: usize,
     ) -> f64 {
-        println!("left col cnt: {}", right_col_ref_offset,);
-        println!("{:?}", column_refs);
         // multiply the selectivities of all individual conditions together
         on_col_ref_pairs.iter().map(|on_col_ref_pair| {
-            println!(
-                "left_idx: {}, right_idx: {}",
-                on_col_ref_pair.0.index(),
-                on_col_ref_pair.1.index()
-            );
             // the formula for each pair is min(1 / ndistinct1, 1 / ndistinct2) (see https://postgrespro.com/blog/pgsql/5969618)
             let ndistincts = vec![on_col_ref_pair.0.index(), on_col_ref_pair.1.index() + right_col_ref_offset].into_iter().map(|col_index| {
                 match self.get_single_column_stats_from_col_ref(&column_refs[col_index]) {
                     Some(per_col_stats) => {
-                        println!("{:?} ndistinct: {}", column_refs[col_index], per_col_stats.ndistinct);
                         per_col_stats.ndistinct
                     },
                     None => DEFAULT_NUM_DISTINCT,
@@ -418,8 +403,8 @@ mod tests {
                 Some(TestDistribution::empty()),
             ),
         );
-        let expr_tree = bin_op(BinOpType::Eq, col_ref(0), col_ref(0));
-        let expr_tree_rev = bin_op(BinOpType::Eq, col_ref(0), col_ref(0));
+        let expr_tree = bin_op(BinOpType::Eq, col_ref(0), col_ref(1));
+        let expr_tree_rev = bin_op(BinOpType::Eq, col_ref(1), col_ref(0));
         let column_refs = vec![
             ColumnRef::BaseTableColumnRef {
                 table: String::from(TABLE1_NAME),
@@ -462,8 +447,8 @@ mod tests {
                 Some(TestDistribution::empty()),
             ),
         );
-        let eq0and1 = bin_op(BinOpType::Eq, col_ref(0), col_ref(0));
-        let eq1and0 = bin_op(BinOpType::Eq, col_ref(0), col_ref(0));
+        let eq0and1 = bin_op(BinOpType::Eq, col_ref(0), col_ref(1));
+        let eq1and0 = bin_op(BinOpType::Eq, col_ref(1), col_ref(0));
         let expr_tree = log_op(LogOpType::And, vec![eq0and1.clone(), eq1and0.clone()]);
         let expr_tree_rev = log_op(LogOpType::And, vec![eq1and0.clone(), eq0and1.clone()]);
         let column_refs = vec![
@@ -508,8 +493,8 @@ mod tests {
                 Some(TestDistribution::empty()),
             ),
         );
-        let eq0and1 = bin_op(BinOpType::Eq, col_ref(0), col_ref(0));
-        let eq100 = bin_op(BinOpType::Eq, col_ref(0), cnst(Value::Int32(100)));
+        let eq0and1 = bin_op(BinOpType::Eq, col_ref(0), col_ref(1));
+        let eq100 = bin_op(BinOpType::Eq, col_ref(1), cnst(Value::Int32(100)));
         let expr_tree = log_op(LogOpType::And, vec![eq0and1.clone(), eq100.clone()]);
         let expr_tree_rev = log_op(LogOpType::And, vec![eq100.clone(), eq0and1.clone()]);
         let column_refs = vec![

--- a/optd-datafusion-repr/src/cost/base_cost/join.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/join.rs
@@ -6,9 +6,9 @@ use optd_core::{
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
-    cost::{
-        base_cost::stats::{Distribution, MostCommonValues},
-        base_cost::DEFAULT_NUM_DISTINCT,
+    cost::base_cost::{
+        stats::{Distribution, MostCommonValues},
+        DEFAULT_NUM_DISTINCT,
     },
     plan_nodes::{
         BinOpType, ColumnRefExpr, Expr, ExprList, JoinType, LogOpExpr, LogOpType, OptRelNode,
@@ -72,6 +72,9 @@ impl<
                 optimizer.get_property_by_group::<ColumnRefPropertyBuilder>(context.group_id, 1);
             let left_keys_group_id = context.children_group_ids[2];
             let right_keys_group_id = context.children_group_ids[3];
+            let left_col_cnt = optimizer
+                .get_property_by_group::<ColumnRefPropertyBuilder>(context.children_group_ids[0], 1)
+                .len();
             let left_keys_list = optimizer.get_all_group_bindings(left_keys_group_id, false);
             let right_keys_list = optimizer.get_all_group_bindings(right_keys_group_id, false);
             // there may be more than one expression tree in a group. see comment in OptRelNodeTyp::PhysicalFilter(_) for more information
@@ -86,10 +89,18 @@ impl<
                 &column_refs,
                 row_cnt_1,
                 row_cnt_2,
+                left_col_cnt,
             )
         } else {
             DEFAULT_UNK_SEL
         };
+        println!(
+            "l: {:.2}, r: {:.2}, sel: {}, output: {}",
+            row_cnt_1,
+            row_cnt_2,
+            selectivity,
+            (row_cnt_1 * row_cnt_2 * selectivity).max(1.0)
+        );
         Self::cost(
             (row_cnt_1 * row_cnt_2 * selectivity).max(1.0),
             row_cnt_1 * 2.0 + row_cnt_2,
@@ -106,6 +117,7 @@ impl<
         column_refs: &GroupColumnRefs,
         left_row_cnt: f64,
         right_row_cnt: f64,
+        right_col_ref_offset: usize,
     ) -> f64 {
         assert!(left_keys.len() == right_keys.len());
         // I assume that the keys are already in the right order s.t. the ith key of left_keys corresponds with the ith key of right_keys
@@ -129,6 +141,7 @@ impl<
             column_refs,
             left_row_cnt,
             right_row_cnt,
+            right_col_ref_offset,
         )
     }
 
@@ -141,8 +154,10 @@ impl<
         column_refs: &GroupColumnRefs,
         left_row_cnt: f64,
         right_row_cnt: f64,
+        right_col_ref_offset: usize,
     ) -> f64 {
-        let join_on_selectivity = self.get_join_on_selectivity(&on_col_ref_pairs, column_refs);
+        let join_on_selectivity =
+            self.get_join_on_selectivity(&on_col_ref_pairs, column_refs, right_col_ref_offset);
         // Currently, there is no difference in how we handle a join filter and a select filter, so we use the same function
         // One difference (that we *don't* care about right now) is that join filters can contain expressions from multiple
         //   different tables. Currently, this doesn't affect the get_filter_selectivity() function, but this may change in
@@ -210,6 +225,7 @@ impl<
                 column_refs,
                 left_row_cnt,
                 right_row_cnt,
+                0,
             )
         } else {
             #[allow(clippy::collapsible_else_if)]
@@ -222,6 +238,7 @@ impl<
                     column_refs,
                     left_row_cnt,
                     right_row_cnt,
+                    0,
                 )
             } else {
                 self.get_join_selectivity_core(
@@ -231,6 +248,7 @@ impl<
                     column_refs,
                     left_row_cnt,
                     right_row_cnt,
+                    0,
                 )
             }
         }
@@ -291,13 +309,24 @@ impl<
         &self,
         on_col_ref_pairs: &[(ColumnRefExpr, ColumnRefExpr)],
         column_refs: &GroupColumnRefs,
+        right_col_ref_offset: usize,
     ) -> f64 {
+        println!("left col cnt: {}", right_col_ref_offset,);
+        println!("{:?}", column_refs);
         // multiply the selectivities of all individual conditions together
         on_col_ref_pairs.iter().map(|on_col_ref_pair| {
+            println!(
+                "left_idx: {}, right_idx: {}",
+                on_col_ref_pair.0.index(),
+                on_col_ref_pair.1.index()
+            );
             // the formula for each pair is min(1 / ndistinct1, 1 / ndistinct2) (see https://postgrespro.com/blog/pgsql/5969618)
-            let ndistincts = vec![&on_col_ref_pair.0, &on_col_ref_pair.1].into_iter().map(|on_col_ref_expr| {
-                match self.get_single_column_stats_from_col_ref(&column_refs[on_col_ref_expr.index()]) {
-                    Some(per_col_stats) => per_col_stats.ndistinct,
+            let ndistincts = vec![on_col_ref_pair.0.index(), on_col_ref_pair.1.index() + right_col_ref_offset].into_iter().map(|col_index| {
+                match self.get_single_column_stats_from_col_ref(&column_refs[col_index]) {
+                    Some(per_col_stats) => {
+                        println!("{:?} ndistinct: {}", column_refs[col_index], per_col_stats.ndistinct);
+                        per_col_stats.ndistinct
+                    },
                     None => DEFAULT_NUM_DISTINCT,
                 }
             });
@@ -389,8 +418,8 @@ mod tests {
                 Some(TestDistribution::empty()),
             ),
         );
-        let expr_tree = bin_op(BinOpType::Eq, col_ref(0), col_ref(1));
-        let expr_tree_rev = bin_op(BinOpType::Eq, col_ref(1), col_ref(0));
+        let expr_tree = bin_op(BinOpType::Eq, col_ref(0), col_ref(0));
+        let expr_tree_rev = bin_op(BinOpType::Eq, col_ref(0), col_ref(0));
         let column_refs = vec![
             ColumnRef::BaseTableColumnRef {
                 table: String::from(TABLE1_NAME),
@@ -433,8 +462,8 @@ mod tests {
                 Some(TestDistribution::empty()),
             ),
         );
-        let eq0and1 = bin_op(BinOpType::Eq, col_ref(0), col_ref(1));
-        let eq1and0 = bin_op(BinOpType::Eq, col_ref(1), col_ref(0));
+        let eq0and1 = bin_op(BinOpType::Eq, col_ref(0), col_ref(0));
+        let eq1and0 = bin_op(BinOpType::Eq, col_ref(0), col_ref(0));
         let expr_tree = log_op(LogOpType::And, vec![eq0and1.clone(), eq1and0.clone()]);
         let expr_tree_rev = log_op(LogOpType::And, vec![eq1and0.clone(), eq0and1.clone()]);
         let column_refs = vec![
@@ -479,8 +508,8 @@ mod tests {
                 Some(TestDistribution::empty()),
             ),
         );
-        let eq0and1 = bin_op(BinOpType::Eq, col_ref(0), col_ref(1));
-        let eq100 = bin_op(BinOpType::Eq, col_ref(1), cnst(Value::Int32(100)));
+        let eq0and1 = bin_op(BinOpType::Eq, col_ref(0), col_ref(0));
+        let eq100 = bin_op(BinOpType::Eq, col_ref(0), cnst(Value::Int32(100)));
         let expr_tree = log_op(LogOpType::And, vec![eq0and1.clone(), eq100.clone()]);
         let expr_tree_rev = log_op(LogOpType::And, vec![eq100.clone(), eq0and1.clone()]);
         let column_refs = vec![


### PR DESCRIPTION
The indices of `ColumnRefExpr`s in hash join columns are with respect to left or right tables. For example, 

![image](https://github.com/cmu-db/optd/assets/52783948/b2ea40e1-695b-4406-8231-0d7a4020bb63)

The plan in this figure means join on 0th column of the left table and 3rd column of the right table.

But for NLJ, the column indices are with respect to the join output. For instance, if the condition is `#0 = #5` and the left table has 3 columns, the condition actually means join on 0th column of the left table and 3rd column of the right.