### PR TITLE
feat: refine like selectivity computation

### DIFF
--- a/optd-datafusion-repr/src/cost/base_cost.rs
+++ b/optd-datafusion-repr/src/cost/base_cost.rs
@@ -239,7 +239,7 @@ mod tests {
         cost::base_cost::stats::*,
         plan_nodes::{
             BinOpExpr, BinOpType, ColumnRefExpr, ConstantExpr, Expr, ExprList, InListExpr,
-            LogOpExpr, LogOpType, OptRelNode, OptRelNodeRef, UnOpExpr, UnOpType,
+            LikeExpr, LogOpExpr, LogOpType, OptRelNode, OptRelNodeRef, UnOpExpr, UnOpType,
         },
     };
 
@@ -420,6 +420,15 @@ mod tests {
                     .collect_vec(),
             ),
             negated,
+        )
+    }
+
+    pub fn like(col_ref_idx: u64, pattern: &str, negated: bool) -> LikeExpr {
+        LikeExpr::new(
+            negated,
+            false,
+            Expr::from_rel_node(col_ref(col_ref_idx)).unwrap(),
+            Expr::from_rel_node(cnst(Value::String(pattern.into()))).unwrap(),
         )
     }
 

--- a/optd-datafusion-repr/src/cost/base_cost.rs
+++ b/optd-datafusion-repr/src/cost/base_cost.rs
@@ -44,8 +44,6 @@ pub struct OptCostModel<
 const DEFAULT_EQ_SEL: f64 = 0.005;
 // Default selectivity estimate for inequalities such as "A < b"
 const DEFAULT_INEQ_SEL: f64 = 0.3333333333333333;
-// Default selectivity estimate for pattern-match operators such as LIKE
-const DEFAULT_MATCH_SEL: f64 = 0.005;
 // Default n-distinct estimate for derived columns or columns lacking statistics
 const DEFAULT_NUM_DISTINCT: u64 = 200;
 // Default selectivity if we have no information

--- a/optd-datafusion-repr/src/cost/base_cost/filter.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/filter.rs
@@ -1,6 +1,5 @@
 use std::ops::Bound;
 
-use datafusion::arrow::{array::StringArray, compute::like};
 use optd_core::{
     cascades::{CascadesOptimizer, RelNodeContext},
     cost::Cost,
@@ -23,6 +22,8 @@ use crate::{
 use super::{
     stats::ColumnCombValue, OptCostModel, DEFAULT_EQ_SEL, DEFAULT_INEQ_SEL, DEFAULT_UNK_SEL,
 };
+
+mod like;
 
 impl<
         M: MostCommonValues + Serialize + DeserializeOwned,
@@ -340,87 +341,6 @@ impl<
             }
         } else {
             // Child is a derived column.
-            UNIMPLEMENTED_SEL
-        }
-    }
-
-    /// Compute the selectivity of a (NOT) LIKE expression.
-    ///
-    /// The logic is somewhat similar to Postgres but different. Postgres first estimates the histogram part of the
-    /// population and then add up data for any MCV values. If the histogram is large enough, it just uses the number
-    /// of matches in the histogram, otherwise it estimates the fixed prefix and remainder of pattern separately and
-    /// combine them.
-    ///
-    /// Our approach is simpler and less selective. Firstly, we don't use histogram. The selectivity is composed of MCV
-    /// frequency and non-MCV selectivity. MCV frequency is computed by adding up frequencies of MCVs that match the
-    /// pattern. Non-MCV  selectivity is computed in the same way that Postgres computes selectivity for the wildcard
-    /// part of the pattern.
-    fn get_like_selectivity(&self, like_expr: &LikeExpr, column_refs: &GroupColumnRefs) -> f64 {
-        const FULL_WILDCARD_SEL: f64 = 5.0;
-        const FIXED_CHAR_SEL: f64 = 0.2;
-
-        let child = like_expr.child();
-
-        // Check child is a column ref.
-        if !matches!(child.typ(), OptRelNodeTyp::ColumnRef) {
-            return UNIMPLEMENTED_SEL;
-        }
-
-        // Check pattern is a constant.
-        let pattern = like_expr.pattern();
-        if !matches!(pattern.typ(), OptRelNodeTyp::Constant(_)) {
-            return UNIMPLEMENTED_SEL;
-        }
-
-        let col_ref_idx = ColumnRefExpr::from_rel_node(child.into_rel_node())
-            .unwrap()
-            .index();
-
-        if let ColumnRef::BaseTableColumnRef { table, col_idx } = &column_refs[col_ref_idx] {
-            let pattern = ConstantExpr::from_rel_node(pattern.into_rel_node())
-                .expect("we already checked pattern is a constant")
-                .value()
-                .as_str();
-
-            // Compute the selectivity exculuding MCVs.
-            // See Postgres `like_selectivity`.
-            let non_mcv_sel = pattern
-                .chars()
-                .fold(1.0, |acc, c| {
-                    if c == '%' {
-                        acc * FULL_WILDCARD_SEL
-                    } else {
-                        acc * FIXED_CHAR_SEL
-                    }
-                })
-                .min(1.0);
-
-            // Compute the selectivity in MCVs.
-            let column_stats = self.get_column_comb_stats(table, &[*col_idx]);
-            let (mcv_freq, null_frac) = if let Some(column_stats) = column_stats {
-                let pred = Box::new(move |val: &ColumnCombValue| {
-                    let string =
-                        StringArray::from(vec![val[0].as_ref().unwrap().as_str().as_ref()]);
-                    let pattern = StringArray::from(vec![pattern.as_ref()]);
-                    like(&string, &pattern).unwrap().value(0)
-                });
-                (
-                    column_stats.mcvs.freq_over_pred(pred),
-                    column_stats.null_frac,
-                )
-            } else {
-                (0.0, 0.0)
-            };
-
-            // Postgres clamps the result after histogram and before MCV. See Postgres `patternsel_common`.
-            let result = (non_mcv_sel + mcv_freq * (1.0 - null_frac)).clamp(0.0001, 0.9999);
-
-            if like_expr.negated() {
-                1.0 - result - null_frac
-            } else {
-                result
-            }
-        } else {
             UNIMPLEMENTED_SEL
         }
     }

--- a/optd-datafusion-repr/src/cost/base_cost/filter.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/filter.rs
@@ -346,7 +346,7 @@ impl<
 
     /// Compute the selectivity of a (NOT) LIKE expression.
     ///
-    /// The logical is somewhat similar to Postgres but different. Postgres first estimates the histogram part of the
+    /// The logic is somewhat similar to Postgres but different. Postgres first estimates the histogram part of the
     /// population and then add up data for any MCV values. If the histogram is large enough, it just uses the number
     /// of matches in the histogram, otherwise it estimates the fixed prefix and remainder of pattern separately and
     /// combine them.

--- a/optd-datafusion-repr/src/cost/base_cost/filter.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/filter.rs
@@ -1,5 +1,6 @@
 use std::ops::Bound;
 
+use datafusion::arrow::{array::StringArray, compute::like};
 use optd_core::{
     cascades::{CascadesOptimizer, RelNodeContext},
     cost::Cost,
@@ -8,13 +9,13 @@ use optd_core::{
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
-    cost::{
-        base_cost::stats::{ColumnCombValueStats, Distribution, MostCommonValues},
-        base_cost::{DEFAULT_MATCH_SEL, UNIMPLEMENTED_SEL},
+    cost::base_cost::{
+        stats::{ColumnCombValueStats, Distribution, MostCommonValues},
+        UNIMPLEMENTED_SEL,
     },
     plan_nodes::{
-        BinOpType, ColumnRefExpr, ConstantExpr, ConstantType, InListExpr, LogOpType, OptRelNode,
-        OptRelNodeRef, OptRelNodeTyp, UnOpType,
+        BinOpType, ColumnRefExpr, ConstantExpr, ConstantType, InListExpr, LikeExpr, LogOpType,
+        OptRelNode, OptRelNodeRef, OptRelNodeTyp, UnOpType,
     },
     properties::column_ref::{ColumnRef, ColumnRefPropertyBuilder, GroupColumnRefs},
 };
@@ -113,7 +114,10 @@ impl<
             }
             OptRelNodeTyp::Between => UNIMPLEMENTED_SEL,
             OptRelNodeTyp::Cast => unimplemented!("check bool type or else panic"),
-            OptRelNodeTyp::Like => DEFAULT_MATCH_SEL,
+            OptRelNodeTyp::Like => {
+                let like_expr = LikeExpr::from_rel_node(expr_tree).unwrap();
+                self.get_like_selectivity(&like_expr, column_refs)
+            }
             OptRelNodeTyp::DataType(_) => {
                 panic!("the selectivity of a data type is not defined")
             }
@@ -336,6 +340,87 @@ impl<
             }
         } else {
             // Child is a derived column.
+            UNIMPLEMENTED_SEL
+        }
+    }
+
+    /// Compute the selectivity of a (NOT) LIKE expression.
+    ///
+    /// The logical is somewhat similar to Postgres but different. Postgres first estimates the histogram part of the
+    /// population and then add up data for any MCV values. If the histogram is large enough, it just uses the number
+    /// of matches in the histogram, otherwise it estimates the fixed prefix and remainder of pattern separately and
+    /// combine them.
+    ///
+    /// Our approach is simpler and less selective. Firstly, we don't use histogram. The selectivity is composed of MCV
+    /// frequency and non-MCV selectivity. MCV frequency is computed by adding up frequencies of MCVs that match the
+    /// pattern. Non-MCV  selectivity is computed in the same way that Postgres computes selectivity for the wildcard
+    /// part of the pattern.
+    fn get_like_selectivity(&self, like_expr: &LikeExpr, column_refs: &GroupColumnRefs) -> f64 {
+        const FULL_WILDCARD_SEL: f64 = 5.0;
+        const FIXED_CHAR_SEL: f64 = 0.2;
+
+        let child = like_expr.child();
+
+        // Check child is a column ref.
+        if !matches!(child.typ(), OptRelNodeTyp::ColumnRef) {
+            return UNIMPLEMENTED_SEL;
+        }
+
+        // Check pattern is a constant.
+        let pattern = like_expr.pattern();
+        if !matches!(pattern.typ(), OptRelNodeTyp::Constant(_)) {
+            return UNIMPLEMENTED_SEL;
+        }
+
+        let col_ref_idx = ColumnRefExpr::from_rel_node(child.into_rel_node())
+            .unwrap()
+            .index();
+
+        if let ColumnRef::BaseTableColumnRef { table, col_idx } = &column_refs[col_ref_idx] {
+            let pattern = ConstantExpr::from_rel_node(pattern.into_rel_node())
+                .expect("we already checked pattern is a constant")
+                .value()
+                .as_str();
+
+            // Compute the selectivity exculuding MCVs.
+            // See Postgres `like_selectivity`.
+            let non_mcv_sel = pattern
+                .chars()
+                .fold(1.0, |acc, c| {
+                    if c == '%' {
+                        acc * FULL_WILDCARD_SEL
+                    } else {
+                        acc * FIXED_CHAR_SEL
+                    }
+                })
+                .min(1.0);
+
+            // Compute the selectivity in MCVs.
+            let column_stats = self.get_column_comb_stats(table, &[*col_idx]);
+            let (mcv_freq, null_frac) = if let Some(column_stats) = column_stats {
+                let pred = Box::new(move |val: &ColumnCombValue| {
+                    let string =
+                        StringArray::from(vec![val[0].as_ref().unwrap().as_str().as_ref()]);
+                    let pattern = StringArray::from(vec![pattern.as_ref()]);
+                    like(&string, &pattern).unwrap().value(0)
+                });
+                (
+                    column_stats.mcvs.freq_over_pred(pred),
+                    column_stats.null_frac,
+                )
+            } else {
+                (0.0, 0.0)
+            };
+
+            // Postgres clamps the result after histogram and before MCV. See Postgres `patternsel_common`.
+            let result = (non_mcv_sel + mcv_freq * (1.0 - null_frac)).clamp(0.0001, 0.9999);
+
+            if like_expr.negated() {
+                1.0 - result - null_frac
+            } else {
+                result
+            }
+        } else {
             UNIMPLEMENTED_SEL
         }
     }

--- a/optd-datafusion-repr/src/cost/base_cost/filter.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/filter.rs
@@ -13,8 +13,8 @@ use crate::{
         UNIMPLEMENTED_SEL,
     },
     plan_nodes::{
-        BinOpType, ColumnRefExpr, ConstantExpr, ConstantType, InListExpr, LikeExpr, LogOpType,
-        OptRelNode, OptRelNodeRef, OptRelNodeTyp, UnOpType,
+        BinOpType, ColumnRefExpr, ConstantType, InListExpr, LikeExpr, LogOpType, OptRelNode,
+        OptRelNodeRef, OptRelNodeTyp, UnOpType,
     },
     properties::column_ref::{ColumnRef, ColumnRefPropertyBuilder, GroupColumnRefs},
 };
@@ -23,6 +23,7 @@ use super::{
     stats::ColumnCombValue, OptCostModel, DEFAULT_EQ_SEL, DEFAULT_INEQ_SEL, DEFAULT_UNK_SEL,
 };
 
+mod in_list;
 mod like;
 
 impl<
@@ -291,57 +292,6 @@ impl<
             Self::get_default_comparison_op_selectivity(comp_bin_op_typ)
         } else {
             unreachable!("we could have at most pushed left and right into col_ref_exprs")
-        }
-    }
-
-    /// Only support colA in (val1, val2, val3) where colA is a column ref and
-    /// val1, val2, val3 are constants.
-    fn get_in_list_selectivity(&self, expr: &InListExpr, column_refs: &GroupColumnRefs) -> f64 {
-        let child = expr.child();
-
-        // Check child is a column ref.
-        if !matches!(child.typ(), OptRelNodeTyp::ColumnRef) {
-            return UNIMPLEMENTED_SEL;
-        }
-
-        // Check all expressions in the list are constants.
-        let list_exprs = expr.list().to_vec();
-        if list_exprs
-            .iter()
-            .any(|expr| !matches!(expr.typ(), OptRelNodeTyp::Constant(_)))
-        {
-            return UNIMPLEMENTED_SEL;
-        }
-
-        // Convert child and const expressions to concrete types.
-        let col_ref_idx = ColumnRefExpr::from_rel_node(child.into_rel_node())
-            .unwrap()
-            .index();
-        let list_exprs = list_exprs
-            .into_iter()
-            .map(|expr| {
-                ConstantExpr::from_rel_node(expr.into_rel_node())
-                    .expect("we already checked all list elements are constants")
-            })
-            .collect::<Vec<_>>();
-        let negated = expr.negated();
-
-        if let ColumnRef::BaseTableColumnRef { table, col_idx } = &column_refs[col_ref_idx] {
-            let in_sel = list_exprs
-                .iter()
-                .map(|expr| {
-                    self.get_column_equality_selectivity(table, *col_idx, &expr.value(), true)
-                })
-                .sum::<f64>()
-                .min(1.0);
-            if negated {
-                1.0 - in_sel
-            } else {
-                in_sel
-            }
-        } else {
-            // Child is a derived column.
-            UNIMPLEMENTED_SEL
         }
     }
 
@@ -1056,54 +1006,6 @@ mod tests {
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_filter_selectivity(expr_tree, &column_refs),
             0.7
-        );
-    }
-
-    #[test]
-    fn test_in_list() {
-        let cost_model = create_one_column_cost_model(TestPerColumnStats::new(
-            TestMostCommonValues::new(vec![(Value::Int32(1), 0.8), (Value::Int32(2), 0.2)]),
-            2,
-            0.0,
-            Some(TestDistribution::empty()),
-        ));
-        let column_refs = vec![ColumnRef::BaseTableColumnRef {
-            table: String::from(TABLE1_NAME),
-            col_idx: 0,
-        }];
-        assert_approx_eq::assert_approx_eq!(
-            cost_model
-                .get_in_list_selectivity(&in_list(0, vec![Value::Int32(1)], false), &column_refs),
-            0.8
-        );
-        assert_approx_eq::assert_approx_eq!(
-            cost_model.get_in_list_selectivity(
-                &in_list(0, vec![Value::Int32(1), Value::Int32(2)], false),
-                &column_refs
-            ),
-            1.0
-        );
-        assert_approx_eq::assert_approx_eq!(
-            cost_model
-                .get_in_list_selectivity(&in_list(0, vec![Value::Int32(3)], false), &column_refs),
-            0.0
-        );
-        assert_approx_eq::assert_approx_eq!(
-            cost_model
-                .get_in_list_selectivity(&in_list(0, vec![Value::Int32(1)], true), &column_refs),
-            0.2
-        );
-        assert_approx_eq::assert_approx_eq!(
-            cost_model.get_in_list_selectivity(
-                &in_list(0, vec![Value::Int32(1), Value::Int32(2)], true),
-                &column_refs
-            ),
-            0.0
-        );
-        assert_approx_eq::assert_approx_eq!(
-            cost_model
-                .get_in_list_selectivity(&in_list(0, vec![Value::Int32(3)], true), &column_refs),
-            1.0
         );
     }
 

--- a/optd-datafusion-repr/src/cost/base_cost/filter/in_list.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/filter/in_list.rs
@@ -1,0 +1,135 @@
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::{
+    cost::{
+        base_cost::{
+            stats::{Distribution, MostCommonValues},
+            UNIMPLEMENTED_SEL,
+        },
+        OptCostModel,
+    },
+    plan_nodes::{ColumnRefExpr, ConstantExpr, InListExpr, OptRelNode, OptRelNodeTyp},
+    properties::column_ref::{ColumnRef, GroupColumnRefs},
+};
+
+impl<
+        M: MostCommonValues + Serialize + DeserializeOwned,
+        D: Distribution + Serialize + DeserializeOwned,
+    > OptCostModel<M, D>
+{
+    /// Only support colA in (val1, val2, val3) where colA is a column ref and
+    /// val1, val2, val3 are constants.
+    pub(super) fn get_in_list_selectivity(
+        &self,
+        expr: &InListExpr,
+        column_refs: &GroupColumnRefs,
+    ) -> f64 {
+        let child = expr.child();
+
+        // Check child is a column ref.
+        if !matches!(child.typ(), OptRelNodeTyp::ColumnRef) {
+            return UNIMPLEMENTED_SEL;
+        }
+
+        // Check all expressions in the list are constants.
+        let list_exprs = expr.list().to_vec();
+        if list_exprs
+            .iter()
+            .any(|expr| !matches!(expr.typ(), OptRelNodeTyp::Constant(_)))
+        {
+            return UNIMPLEMENTED_SEL;
+        }
+
+        // Convert child and const expressions to concrete types.
+        let col_ref_idx = ColumnRefExpr::from_rel_node(child.into_rel_node())
+            .unwrap()
+            .index();
+        let list_exprs = list_exprs
+            .into_iter()
+            .map(|expr| {
+                ConstantExpr::from_rel_node(expr.into_rel_node())
+                    .expect("we already checked all list elements are constants")
+            })
+            .collect::<Vec<_>>();
+        let negated = expr.negated();
+
+        if let ColumnRef::BaseTableColumnRef { table, col_idx } = &column_refs[col_ref_idx] {
+            let in_sel = list_exprs
+                .iter()
+                .map(|expr| {
+                    self.get_column_equality_selectivity(table, *col_idx, &expr.value(), true)
+                })
+                .sum::<f64>()
+                .min(1.0);
+            if negated {
+                1.0 - in_sel
+            } else {
+                in_sel
+            }
+        } else {
+            // Child is a derived column.
+            UNIMPLEMENTED_SEL
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use optd_core::rel_node::Value;
+
+    use crate::{
+        cost::base_cost::tests::{
+            create_one_column_cost_model, in_list, TestDistribution, TestMostCommonValues,
+            TestPerColumnStats, TABLE1_NAME,
+        },
+        properties::column_ref::ColumnRef,
+    };
+
+    #[test]
+    fn test_in_list() {
+        let cost_model = create_one_column_cost_model(TestPerColumnStats::new(
+            TestMostCommonValues::new(vec![(Value::Int32(1), 0.8), (Value::Int32(2), 0.2)]),
+            2,
+            0.0,
+            Some(TestDistribution::empty()),
+        ));
+        let column_refs = vec![ColumnRef::BaseTableColumnRef {
+            table: String::from(TABLE1_NAME),
+            col_idx: 0,
+        }];
+        assert_approx_eq::assert_approx_eq!(
+            cost_model
+                .get_in_list_selectivity(&in_list(0, vec![Value::Int32(1)], false), &column_refs),
+            0.8
+        );
+        assert_approx_eq::assert_approx_eq!(
+            cost_model.get_in_list_selectivity(
+                &in_list(0, vec![Value::Int32(1), Value::Int32(2)], false),
+                &column_refs
+            ),
+            1.0
+        );
+        assert_approx_eq::assert_approx_eq!(
+            cost_model
+                .get_in_list_selectivity(&in_list(0, vec![Value::Int32(3)], false), &column_refs),
+            0.0
+        );
+        assert_approx_eq::assert_approx_eq!(
+            cost_model
+                .get_in_list_selectivity(&in_list(0, vec![Value::Int32(1)], true), &column_refs),
+            0.2
+        );
+        assert_approx_eq::assert_approx_eq!(
+            cost_model.get_in_list_selectivity(
+                &in_list(0, vec![Value::Int32(1), Value::Int32(2)], true),
+                &column_refs
+            ),
+            0.0
+        );
+        assert_approx_eq::assert_approx_eq!(
+            cost_model
+                .get_in_list_selectivity(&in_list(0, vec![Value::Int32(3)], true), &column_refs),
+            1.0
+        );
+    }
+}

--- a/optd-datafusion-repr/src/cost/base_cost/filter/like.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/filter/like.rs
@@ -1,0 +1,173 @@
+use datafusion::arrow::{array::StringArray, compute::like};
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::{
+    cost::{
+        base_cost::{
+            stats::{ColumnCombValue, Distribution, MostCommonValues},
+            UNIMPLEMENTED_SEL,
+        },
+        OptCostModel,
+    },
+    plan_nodes::{ColumnRefExpr, ConstantExpr, LikeExpr, OptRelNode, OptRelNodeTyp},
+    properties::column_ref::{ColumnRef, GroupColumnRefs},
+};
+
+const FULL_WILDCARD_SEL: f64 = 5.0;
+const FIXED_CHAR_SEL: f64 = 0.2;
+
+impl<
+        M: MostCommonValues + Serialize + DeserializeOwned,
+        D: Distribution + Serialize + DeserializeOwned,
+    > OptCostModel<M, D>
+{
+    /// Compute the selectivity of a (NOT) LIKE expression.
+    ///
+    /// The logic is somewhat similar to Postgres but different. Postgres first estimates the histogram part of the
+    /// population and then add up data for any MCV values. If the histogram is large enough, it just uses the number
+    /// of matches in the histogram, otherwise it estimates the fixed prefix and remainder of pattern separately and
+    /// combine them.
+    ///
+    /// Our approach is simpler and less selective. Firstly, we don't use histogram. The selectivity is composed of MCV
+    /// frequency and non-MCV selectivity. MCV frequency is computed by adding up frequencies of MCVs that match the
+    /// pattern. Non-MCV  selectivity is computed in the same way that Postgres computes selectivity for the wildcard
+    /// part of the pattern.
+    pub(super) fn get_like_selectivity(
+        &self,
+        like_expr: &LikeExpr,
+        column_refs: &GroupColumnRefs,
+    ) -> f64 {
+        let child = like_expr.child();
+
+        // Check child is a column ref.
+        if !matches!(child.typ(), OptRelNodeTyp::ColumnRef) {
+            return UNIMPLEMENTED_SEL;
+        }
+
+        // Check pattern is a constant.
+        let pattern = like_expr.pattern();
+        if !matches!(pattern.typ(), OptRelNodeTyp::Constant(_)) {
+            return UNIMPLEMENTED_SEL;
+        }
+
+        let col_ref_idx = ColumnRefExpr::from_rel_node(child.into_rel_node())
+            .unwrap()
+            .index();
+
+        if let ColumnRef::BaseTableColumnRef { table, col_idx } = &column_refs[col_ref_idx] {
+            let pattern = ConstantExpr::from_rel_node(pattern.into_rel_node())
+                .expect("we already checked pattern is a constant")
+                .value()
+                .as_str();
+
+            // Compute the selectivity exculuding MCVs.
+            // See Postgres `like_selectivity`.
+            let non_mcv_sel = pattern
+                .chars()
+                .fold(1.0, |acc, c| {
+                    if c == '%' {
+                        acc * FULL_WILDCARD_SEL
+                    } else {
+                        acc * FIXED_CHAR_SEL
+                    }
+                })
+                .min(1.0);
+
+            // Compute the selectivity in MCVs.
+            let column_stats = self.get_column_comb_stats(table, &[*col_idx]);
+            let (mcv_freq, null_frac) = if let Some(column_stats) = column_stats {
+                let pred = Box::new(move |val: &ColumnCombValue| {
+                    let string =
+                        StringArray::from(vec![val[0].as_ref().unwrap().as_str().as_ref()]);
+                    let pattern = StringArray::from(vec![pattern.as_ref()]);
+                    like(&string, &pattern).unwrap().value(0)
+                });
+                (
+                    column_stats.mcvs.freq_over_pred(pred),
+                    column_stats.null_frac,
+                )
+            } else {
+                (0.0, 0.0)
+            };
+
+            // Postgres clamps the result after histogram and before MCV. See Postgres `patternsel_common`.
+            let result = ((non_mcv_sel + mcv_freq) * (1.0 - null_frac)).clamp(0.0001, 0.9999);
+
+            if like_expr.negated() {
+                1.0 - result - null_frac
+            } else {
+                result
+            }
+        } else {
+            UNIMPLEMENTED_SEL
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use optd_core::rel_node::Value;
+
+    use crate::{
+        cost::base_cost::{
+            filter::like::{FIXED_CHAR_SEL, FULL_WILDCARD_SEL},
+            tests::{
+                create_one_column_cost_model, like, TestDistribution, TestMostCommonValues,
+                TestPerColumnStats, TABLE1_NAME,
+            },
+        },
+        properties::column_ref::ColumnRef,
+    };
+
+    #[test]
+    fn test_like_no_nulls() {
+        let cost_model = create_one_column_cost_model(TestPerColumnStats::new(
+            TestMostCommonValues::new(vec![
+                (Value::String("abcd".into()), 0.1),
+                (Value::String("abc".into()), 0.1),
+            ]),
+            2,
+            0.0,
+            Some(TestDistribution::empty()),
+        ));
+        let column_refs = vec![ColumnRef::BaseTableColumnRef {
+            table: String::from(TABLE1_NAME),
+            col_idx: 0,
+        }];
+        assert_approx_eq::assert_approx_eq!(
+            cost_model.get_like_selectivity(&like(0, "%abcd%", false), &column_refs),
+            0.1 + FULL_WILDCARD_SEL.powi(2) * FIXED_CHAR_SEL.powi(4)
+        );
+        assert_approx_eq::assert_approx_eq!(
+            cost_model.get_like_selectivity(&like(0, "%abc%", false), &column_refs),
+            0.1 + 0.1 + FULL_WILDCARD_SEL.powi(2) * FIXED_CHAR_SEL.powi(3)
+        );
+        assert_approx_eq::assert_approx_eq!(
+            cost_model.get_like_selectivity(&like(0, "%abc%", true), &column_refs),
+            1.0 - (0.1 + 0.1 + FULL_WILDCARD_SEL.powi(2) * FIXED_CHAR_SEL.powi(3))
+        );
+    }
+
+    #[test]
+    fn test_like_with_nulls() {
+        let null_frac = 0.5;
+        let cost_model = create_one_column_cost_model(TestPerColumnStats::new(
+            TestMostCommonValues::new(vec![(Value::String("abcd".into()), 0.1)]),
+            2,
+            null_frac,
+            Some(TestDistribution::empty()),
+        ));
+        let column_refs = vec![ColumnRef::BaseTableColumnRef {
+            table: String::from(TABLE1_NAME),
+            col_idx: 0,
+        }];
+        assert_approx_eq::assert_approx_eq!(
+            cost_model.get_like_selectivity(&like(0, "%abcd%", false), &column_refs),
+            (0.1 + FULL_WILDCARD_SEL.powi(2) * FIXED_CHAR_SEL.powi(4)) * null_frac
+        );
+        assert_approx_eq::assert_approx_eq!(
+            cost_model.get_like_selectivity(&like(0, "%abcd%", true), &column_refs),
+            1.0 - (0.1 + FULL_WILDCARD_SEL.powi(2) * FIXED_CHAR_SEL.powi(4)) * null_frac - 0.5
+        );
+    }
+}

--- a/optd-datafusion-repr/src/cost/base_cost/filter/like.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/filter/like.rs
@@ -13,8 +13,13 @@ use crate::{
     properties::column_ref::{ColumnRef, GroupColumnRefs},
 };
 
-const FULL_WILDCARD_SEL: f64 = 5.0;
-const FIXED_CHAR_SEL: f64 = 0.2;
+// Used for estimating pattern selectivity character-by-character. These numbers
+// are not used on their own. Depending on the characters in the pattern, the
+// selectivity is multiplied by these factors.
+//
+// See `FULL_WILDCARD_SEL` and `FIXED_CHAR_SEL` in Postgres.
+const FULL_WILDCARD_SEL_FACTOR: f64 = 5.0;
+const FIXED_CHAR_SEL_FACTOR: f64 = 0.2;
 
 impl<
         M: MostCommonValues + Serialize + DeserializeOwned,
@@ -66,9 +71,9 @@ impl<
                 .chars()
                 .fold(1.0, |acc, c| {
                     if c == '%' {
-                        acc * FULL_WILDCARD_SEL
+                        acc * FULL_WILDCARD_SEL_FACTOR
                     } else {
-                        acc * FIXED_CHAR_SEL
+                        acc * FIXED_CHAR_SEL_FACTOR
                     }
                 })
                 .min(1.0);
@@ -110,7 +115,7 @@ mod tests {
 
     use crate::{
         cost::base_cost::{
-            filter::like::{FIXED_CHAR_SEL, FULL_WILDCARD_SEL},
+            filter::like::{FIXED_CHAR_SEL_FACTOR, FULL_WILDCARD_SEL_FACTOR},
             tests::{
                 create_one_column_cost_model, like, TestDistribution, TestMostCommonValues,
                 TestPerColumnStats, TABLE1_NAME,
@@ -136,15 +141,15 @@ mod tests {
         }];
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_like_selectivity(&like(0, "%abcd%", false), &column_refs),
-            0.1 + FULL_WILDCARD_SEL.powi(2) * FIXED_CHAR_SEL.powi(4)
+            0.1 + FULL_WILDCARD_SEL_FACTOR.powi(2) * FIXED_CHAR_SEL_FACTOR.powi(4)
         );
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_like_selectivity(&like(0, "%abc%", false), &column_refs),
-            0.1 + 0.1 + FULL_WILDCARD_SEL.powi(2) * FIXED_CHAR_SEL.powi(3)
+            0.1 + 0.1 + FULL_WILDCARD_SEL_FACTOR.powi(2) * FIXED_CHAR_SEL_FACTOR.powi(3)
         );
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_like_selectivity(&like(0, "%abc%", true), &column_refs),
-            1.0 - (0.1 + 0.1 + FULL_WILDCARD_SEL.powi(2) * FIXED_CHAR_SEL.powi(3))
+            1.0 - (0.1 + 0.1 + FULL_WILDCARD_SEL_FACTOR.powi(2) * FIXED_CHAR_SEL_FACTOR.powi(3))
         );
     }
 
@@ -163,11 +168,13 @@ mod tests {
         }];
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_like_selectivity(&like(0, "%abcd%", false), &column_refs),
-            (0.1 + FULL_WILDCARD_SEL.powi(2) * FIXED_CHAR_SEL.powi(4)) * null_frac
+            (0.1 + FULL_WILDCARD_SEL_FACTOR.powi(2) * FIXED_CHAR_SEL_FACTOR.powi(4)) * null_frac
         );
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_like_selectivity(&like(0, "%abcd%", true), &column_refs),
-            1.0 - (0.1 + FULL_WILDCARD_SEL.powi(2) * FIXED_CHAR_SEL.powi(4)) * null_frac - 0.5
+            1.0 - (0.1 + FULL_WILDCARD_SEL_FACTOR.powi(2) * FIXED_CHAR_SEL_FACTOR.powi(4))
+                * null_frac
+                - 0.5
         );
     }
 }

--- a/optd-datafusion-repr/src/cost/base_cost/join.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/join.rs
@@ -159,6 +159,10 @@ impl<
     ) -> f64 {
         let join_on_selectivity =
             self.get_join_on_selectivity(&on_col_ref_pairs, column_refs, right_col_ref_offset);
+        println!(
+            "l: {:.2}, r: {:.2}, sel: {:.2}",
+            left_row_cnt, right_row_cnt, join_on_selectivity
+        );
         // Currently, there is no difference in how we handle a join filter and a select filter, so we use the same function
         // One difference (that we *don't* care about right now) is that join filters can contain expressions from multiple
         //   different tables. Currently, this doesn't affect the get_filter_selectivity() function, but this may change in
@@ -316,6 +320,7 @@ impl<
         on_col_ref_pairs.iter().map(|on_col_ref_pair| {
             // the formula for each pair is min(1 / ndistinct1, 1 / ndistinct2) (see https://postgrespro.com/blog/pgsql/5969618)
             let ndistincts = vec![on_col_ref_pair.0.index(), on_col_ref_pair.1.index() + right_col_ref_offset].into_iter().map(|col_index| {
+                println!("col: {:?}", column_refs[col_index]);
                 match self.get_single_column_stats_from_col_ref(&column_refs[col_index]) {
                     Some(per_col_stats) => {
                         per_col_stats.ndistinct
@@ -325,6 +330,7 @@ impl<
             });
             // using reduce(f64::min) is the idiomatic workaround to min() because f64 does not implement Ord due to NaN
             let selectivity = ndistincts.map(|ndistinct| 1.0 / ndistinct as f64).reduce(f64::min).expect("reduce() only returns None if the iterator is empty, which is impossible since col_ref_exprs.len() == 2");
+            println!("selectivity: {:?}", selectivity);
             assert!(!selectivity.is_nan(), "it should be impossible for selectivity to be NaN since n-distinct is never 0");
             selectivity
         }).product()


### PR DESCRIPTION
See `get_like_selectivity` for details. This fix significantly narrows the selectivity gap of `LIKE` between optd and Postgres on JOB.

https://github.com/cmu-db/optd/blob/4fae01af3cbc723be5b6a85e1fae8bc31c1fa297/optd-datafusion-repr/src/cost/base_cost/filter.rs#L347-L357