### PR TITLE
optimize: speed up stat gen by factor x15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2848,6 +2848,7 @@ dependencies = [
  "optd-gungnir",
  "ordered-float 4.2.0",
  "pretty-xmlish",
+ "rayon",
  "serde",
  "serde_with",
  "tracing",
@@ -3441,6 +3442,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 dependencies = [
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2891,6 +2891,7 @@ dependencies = [
  "optd-datafusion-repr",
  "optd-gungnir",
  "prettytable-rs",
+ "rayon",
  "regex",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,9 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "const-random",
@@ -2035,6 +2035,7 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
  "ahash",
  "allocator-api2",
+ "serde",
 ]
 
 [[package]]
@@ -2862,6 +2863,7 @@ name = "optd-gungnir"
 version = "0.1.0"
 dependencies = [
  "crossbeam",
+ "hashbrown 0.14.3",
  "itertools 0.11.0",
  "lazy_static",
  "optd-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1821,6 +1821,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1966,8 +1978,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2545,6 +2559,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2842,6 +2865,7 @@ dependencies = [
  "camelpaste",
  "datafusion",
  "datafusion-expr",
+ "flume",
  "itertools 0.11.0",
  "num-derive",
  "num-traits",
@@ -2884,6 +2908,7 @@ dependencies = [
  "datafusion",
  "datafusion-optd-cli",
  "env_logger 0.11.2",
+ "flume",
  "futures",
  "futures-util",
  "itertools 0.12.1",
@@ -4018,6 +4043,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "sqlparser"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,15 +958,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.31"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -2892,6 +2892,7 @@ dependencies = [
  "optd-datafusion-bridge",
  "optd-datafusion-repr",
  "optd-gungnir",
+ "parquet",
  "prettytable-rs",
  "rayon",
  "regex",

--- a/optd-datafusion-repr/Cargo.toml
+++ b/optd-datafusion-repr/Cargo.toml
@@ -28,3 +28,4 @@ bincode = "1.3.3"
 rayon = "1.10"
 union-find = { git = "https://github.com/Gun9niR/union-find-rs.git", rev = "794821514f7daefcbb8d5f38ef04e62fc18b5665" }
 test-case = "3.3"
+flume = "0.11.0"

--- a/optd-datafusion-repr/Cargo.toml
+++ b/optd-datafusion-repr/Cargo.toml
@@ -25,3 +25,4 @@ assert_approx_eq = "1.1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_with = {version = "3.7.0", features = ["json"]}
 bincode = "1.3.3"
+rayon = "1.10"

--- a/optd-datafusion-repr/src/cost/base_cost/stats.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/stats.rs
@@ -1,13 +1,12 @@
-use std::{
-    collections::HashMap,
-    sync::{mpsc::Receiver, Arc},
-    thread::JoinHandle,
-};
+use std::{collections::HashMap, sync::Arc};
 
-use arrow_schema::{ArrowError, DataType, Schema, SchemaRef};
-use datafusion::arrow::array::{
-    Array, BooleanArray, Date32Array, Float32Array, Int16Array, Int32Array, Int8Array, RecordBatch,
-    StringArray, UInt16Array, UInt32Array, UInt8Array,
+use arrow_schema::{DataType, Schema, SchemaRef};
+use datafusion::{
+    arrow::array::{
+        Array, BooleanArray, Date32Array, Float32Array, Float64Array, Int16Array, Int32Array,
+        Int8Array, RecordBatch, StringArray, UInt16Array, UInt32Array, UInt8Array,
+    },
+    parquet::arrow::arrow_reader::ParquetRecordBatchReader,
 };
 use itertools::Itertools;
 use optd_core::rel_node::{SerializableOrderedF64, Value};
@@ -169,50 +168,43 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
 
     fn first_pass_stats_id(
         nb_stats: usize,
-    ) -> impl Fn() -> anyhow::Result<(
+    ) -> anyhow::Result<(
         Vec<HyperLogLog<ColumnCombValue>>,
         Vec<MisraGries<ColumnCombValue>>,
         Vec<i32>,
     )> {
-        move || {
-            Ok((
-                vec![HyperLogLog::<ColumnCombValue>::new(hyperloglog::DEFAULT_PRECISION); nb_stats],
-                vec![MisraGries::<ColumnCombValue>::new(misragries::DEFAULT_K_TO_TRACK); nb_stats],
-                vec![0; nb_stats],
-            ))
-        }
+        Ok((
+            vec![HyperLogLog::<ColumnCombValue>::new(hyperloglog::DEFAULT_PRECISION); nb_stats],
+            vec![MisraGries::<ColumnCombValue>::new(misragries::DEFAULT_K_TO_TRACK); nb_stats],
+            vec![0; nb_stats],
+        ))
     }
 
-    fn second_pass_stats_id<'a, 'b>(
-        comb_stat_types: &'a [(Vec<usize>, Vec<DataType>, StatType)],
-        mgs: &'a [MisraGries<ColumnCombValue>],
+    fn second_pass_stats_id(
+        comb_stat_types: &[(Vec<usize>, Vec<DataType>, StatType)],
+        mgs: &[MisraGries<ColumnCombValue>],
         nb_stats: usize,
-    ) -> impl Fn() -> anyhow::Result<(
+    ) -> anyhow::Result<(
         Vec<Option<TDigest<Value>>>,
         Vec<Counter<ColumnCombValue>>,
         Vec<i32>,
-    )> + 'b
-    where
-        'a: 'b,
-    {
-        move || {
-            Ok((
-                comb_stat_types
-                    .iter()
-                    .map(|(_, _, stat_type)| match stat_type {
-                        StatType::Full => Some(TDigest::new(tdigest::DEFAULT_COMPRESSION)),
-                        StatType::Partial => None,
-                    })
-                    .collect(),
-                mgs.iter()
-                    .map(|mg| {
-                        let mfk = mg.most_frequent_keys().into_iter().cloned().collect_vec();
-                        Counter::new(&mfk)
-                    })
-                    .collect(),
-                vec![0; nb_stats],
-            ))
-        }
+    )> {
+        Ok((
+            comb_stat_types
+                .iter()
+                .map(|(_, _, stat_type)| match stat_type {
+                    StatType::Full => Some(TDigest::new(tdigest::DEFAULT_COMPRESSION)),
+                    StatType::Partial => None,
+                })
+                .collect(),
+            mgs.iter()
+                .map(|mg| {
+                    let mfk = mg.most_frequent_keys().into_iter().cloned().collect_vec();
+                    Counter::new(&mfk)
+                })
+                .collect(),
+            vec![0; nb_stats],
+        ))
     }
 
     fn get_stats_types(
@@ -255,9 +247,9 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
         }
 
         macro_rules! float_col_cast {
-            ({ $col:expr}) => {
+            ({ $col:expr, $array_type:path}) => {
                 $col.as_any()
-                    .downcast_ref::<Float32Array>()
+                    .downcast_ref::<$array_type>()
                     .unwrap()
                     .iter()
                     .map(|x| {
@@ -288,8 +280,8 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
             DataType::UInt8 => simple_col_cast!({col, UInt8Array, Value::UInt8}),
             DataType::UInt16 => simple_col_cast!({col, UInt16Array, Value::UInt16}),
             DataType::UInt32 => simple_col_cast!({col, UInt32Array, Value::UInt32}),
-            DataType::Float32 => float_col_cast!({ col }),
-            DataType::Float64 => float_col_cast!({ col }),
+            DataType::Float32 => float_col_cast!({ col, Float32Array }),
+            DataType::Float64 => float_col_cast!({ col, Float64Array }),
             DataType::Date32 => simple_col_cast!({col, Date32Array, Value::Date32}),
             DataType::Utf8 => utf8_col_cast!({ col }),
             _ => unreachable!(),
@@ -379,10 +371,8 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
     }
 
     pub fn from_record_batches(
-        first_batch_channel: impl FnOnce()
-            -> (JoinHandle<()>, Receiver<Result<RecordBatch, ArrowError>>),
-        second_batch_channel: impl FnOnce()
-            -> (JoinHandle<()>, Receiver<Result<RecordBatch, ArrowError>>),
+        first_batch_reader: impl FnOnce() -> Vec<ParquetRecordBatchReader>,
+        second_batch_reader: impl FnOnce() -> Vec<ParquetRecordBatchReader>,
         combinations: Vec<ColumnsIdx>,
         schema: Arc<Schema>,
     ) -> anyhow::Result<Self> {
@@ -391,98 +381,95 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
 
         // 1. FIRST PASS: hlls + mgs + null_cnts.
         let now = std::time::Instant::now();
-        let (handle, receiver) = first_batch_channel();
-
-        let (hlls, mgs, null_cnts) = receiver
-            .into_iter()
-            .par_bridge()
-            .fold(Self::first_pass_stats_id(nb_stats), |local_stats, batch| {
-                let mut local_stats = local_stats?;
-
-                match batch {
-                    Ok(batch) => {
-                        let (hlls, mgs, null_cnts) = &mut local_stats;
-                        let comb = Self::get_column_combs(&batch, &comb_stat_types);
-                        Self::generate_partial_stats(&comb, mgs, hlls, null_cnts);
-                        Ok(local_stats)
-                    }
-                    Err(e) => {
-                        println!("Err: {:?},, {:?}", e, comb_stat_types.len());
-                        Err(e.into())
-                    }
-                }
-            })
-            .reduce(
-                Self::first_pass_stats_id(nb_stats),
-                |final_stats, local_stats| {
-                    let mut final_stats = final_stats?;
-                    let local_stats = local_stats?;
-
-                    let (final_hlls, final_mgs, final_counts) = &mut final_stats;
-                    let (local_hlls, local_mgs, local_counts) = local_stats;
-
-                    for i in 0..nb_stats {
-                        final_hlls[i].merge(&local_hlls[i]);
-                        final_mgs[i].merge(&local_mgs[i]);
-                        final_counts[i] += local_counts[i];
-                    }
-
-                    Ok(final_stats)
-                },
-            )?;
-
-        let _ = handle.join();
-        let first = now.elapsed();
-
-        // 2. SECOND PASS: mcv + tdigest + row_cnts.
-        let now = std::time::Instant::now();
-        let (handle, receiver) = second_batch_channel();
-
-        let (distrs, cnts, row_cnts) = receiver
-            .into_iter()
-            .par_bridge()
-            .fold(
-                Self::second_pass_stats_id(&comb_stat_types, &mgs, nb_stats),
-                |local_stats, batch| {
+        let local_partial_stats: Vec<_> = first_batch_reader()
+            .into_par_iter()
+            .map(|group| {
+                group.fold(Self::first_pass_stats_id(nb_stats), |local_stats, batch| {
                     let mut local_stats = local_stats?;
 
                     match batch {
                         Ok(batch) => {
-                            let (distrs, cnts, row_cnts) = &mut local_stats;
+                            let (hlls, mgs, null_cnts) = &mut local_stats;
                             let comb = Self::get_column_combs(&batch, &comb_stat_types);
-                            Self::generate_full_stats(&comb, cnts, distrs, row_cnts);
+                            Self::generate_partial_stats(&comb, mgs, hlls, null_cnts);
                             Ok(local_stats)
                         }
                         Err(e) => Err(e.into()),
                     }
-                },
-            )
-            .reduce(
-                Self::second_pass_stats_id(&comb_stat_types, &mgs, nb_stats),
-                |final_stats, local_stats| {
-                    let mut final_stats = final_stats?;
-                    let local_stats = local_stats?;
+                })
+            })
+            .collect();
 
-                    let (final_distrs, final_cnts, final_counts) = &mut final_stats;
-                    let (local_distrs, local_cnts, local_counts) = local_stats;
+        let (hlls, mgs, null_cnts) = local_partial_stats.into_iter().fold(
+            Self::first_pass_stats_id(nb_stats),
+            |final_stats, local_stats| {
+                let mut final_stats = final_stats?;
+                let local_stats = local_stats?;
 
-                    for i in 0..nb_stats {
-                        final_cnts[i].merge(&local_cnts[i]);
-                        if let (Some(final_distr), Some(local_distr)) =
-                            (&mut final_distrs[i], &local_distrs[i])
-                        {
-                            final_distr.merge(local_distr);
-                            final_distr.norm_weight += local_distr.norm_weight;
+                let (final_hlls, final_mgs, final_counts) = &mut final_stats;
+                let (local_hlls, local_mgs, local_counts) = local_stats;
+
+                for i in 0..nb_stats {
+                    final_hlls[i].merge(&local_hlls[i]);
+                    final_mgs[i].merge(&local_mgs[i]);
+                    final_counts[i] += local_counts[i];
+                }
+
+                Ok(final_stats)
+            },
+        )?;
+
+        let first = now.elapsed();
+
+        // 2. SECOND PASS: mcv + tdigest + row_cnts.
+        let now = std::time::Instant::now();
+        let local_final_stats: Vec<_> = second_batch_reader()
+            .into_par_iter()
+            .map(|group| {
+                group.fold(
+                    Self::second_pass_stats_id(&comb_stat_types, &mgs, nb_stats),
+                    |local_stats, batch| {
+                        let mut local_stats = local_stats?;
+
+                        match batch {
+                            Ok(batch) => {
+                                let (distrs, cnts, row_cnts) = &mut local_stats;
+                                let comb = Self::get_column_combs(&batch, &comb_stat_types);
+                                Self::generate_full_stats(&comb, cnts, distrs, row_cnts);
+                                Ok(local_stats)
+                            }
+                            Err(e) => Err(e.into()),
                         }
+                    },
+                )
+            })
+            .collect();
 
-                        final_counts[i] += local_counts[i];
+        let (distrs, cnts, row_cnts) = local_final_stats.into_iter().fold(
+            Self::second_pass_stats_id(&comb_stat_types, &mgs, nb_stats),
+            |final_stats, local_stats| {
+                let mut final_stats = final_stats?;
+                let local_stats = local_stats?;
+
+                let (final_distrs, final_cnts, final_counts) = &mut final_stats;
+                let (local_distrs, local_cnts, local_counts) = local_stats;
+
+                for i in 0..nb_stats {
+                    final_cnts[i].merge(&local_cnts[i]);
+                    if let (Some(final_distr), Some(local_distr)) =
+                        (&mut final_distrs[i], &local_distrs[i])
+                    {
+                        final_distr.merge(local_distr);
+                        final_distr.norm_weight += local_distr.norm_weight;
                     }
 
-                    Ok(final_stats)
-                },
-            )?;
+                    final_counts[i] += local_counts[i];
+                }
 
-        let _ = handle.join();
+                Ok(final_stats)
+            },
+        )?;
+
         println!("First: {:?}, Second: {:?}", first, now.elapsed());
 
         // 3. ASSEMBLE STATS.

--- a/optd-datafusion-repr/src/cost/base_cost/stats.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/stats.rs
@@ -308,7 +308,7 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
                     for (row_values, value) in
                         column_comb_values.iter_mut().zip(column_values.iter())
                     {
-                        // TODO(Alexis): Redundant copy.
+                        // This redundant copy is faster than making to_typed_column return an iterator!
                         row_values.push(value.clone());
                     }
                 }
@@ -338,14 +338,9 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
                 let nb_rows = column_comb.len() as i32;
 
                 *count += nb_rows - filtered_nulls.len() as i32;
-                //let now = std::time::Instant::now();
                 mg.aggregate(&filtered_nulls);
-                //let mg_time = now.elapsed();
-                //let now = std::time::Instant::now();
                 hll.aggregate(&filtered_nulls);
-                //println!("HLL took {:?} and MG {:?}", now.elapsed(), mg_time);
             });
-        //println!("generate_partial_stats took {:?}", now.elapsed());
     }
 
     fn generate_full_stats(
@@ -354,14 +349,12 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
         distrs: &mut [Option<TDigest<Value>>],
         row_counts: &mut [i32],
     ) {
-        //let now = std::time::Instant::now();
         column_combs
             .iter()
             .zip(cnts)
             .zip(distrs)
             .zip(row_counts)
             .for_each(|(((column_comb, cnt), distr), count)| {
-                //let now = std::time::Instant::now();
                 let nb_rows = column_comb.len() as i32;
                 *count += nb_rows;
                 cnt.aggregate(column_comb);
@@ -376,10 +369,8 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
 
                     d.norm_weight += nb_rows as usize;
                     d.merge_values(&filtered_values);
-                    //println!("generate_full_stats one task took {:?}", now.elapsed());
                 }
             });
-        //println!("generate_full_stats took {:?}", now.elapsed());
     }
 
     pub fn from_record_batches<I: IntoIterator<Item = Result<RecordBatch, ArrowError>>>(
@@ -407,8 +398,8 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
         // Unfortunately, par_bridge doesn't work as the BatchIterator doesn't implement Send.
         let materialized: Vec<_> = batch_iter.collect(); 
         
-
         // 1. FIRST PASS: hlls + mgs + null_cnts.        
+        let now = std::time::Instant::now();
         let (hlls, mgs, null_cnts) = materialized
             .par_iter()
             .fold(Self::first_pass_stats_id(nb_stats), |local_stats, batch| {
@@ -442,8 +433,10 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
                     Ok(final_stats)
                 },
             )?;
+        let first = now.elapsed();
 
         // 2. SECOND PASS: mcv + tdigest + row_cnts.
+        let now = std::time::Instant::now();
         let (distrs, cnts, row_cnts) = materialized
             .par_iter()
             .fold(
@@ -486,8 +479,10 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
                     Ok(final_stats)
                 },
             )?;
+        let second = now.elapsed();
 
         // 3. ASSEMBLE STATS.
+        let now = std::time::Instant::now();
         let row_cnt = row_cnts[0];
         let mut column_comb_stats = HashMap::new();
 
@@ -511,6 +506,7 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
             );
             column_comb_stats.insert(comb, column_stats);
         }
+        println!("First: {:?}, Second: {:?}, Third: {:?}", first, second, now.elapsed());
 
         Ok(Self {
             row_cnt: row_cnt as usize,

--- a/optd-datafusion-repr/src/cost/base_cost/stats.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/stats.rs
@@ -1,9 +1,13 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    sync::{mpsc::Receiver, Arc},
+    thread::JoinHandle,
+};
 
-use arrow_schema::{ArrowError, DataType, SchemaRef};
+use arrow_schema::{ArrowError, DataType, Schema, SchemaRef};
 use datafusion::arrow::array::{
     Array, BooleanArray, Date32Array, Float32Array, Int16Array, Int32Array, Int8Array, RecordBatch,
-    RecordBatchIterator, RecordBatchReader, StringArray, UInt16Array, UInt32Array, UInt8Array,
+    StringArray, UInt16Array, UInt32Array, UInt8Array,
 };
 use itertools::Itertools;
 use optd_core::rel_node::{SerializableOrderedF64, Value};
@@ -330,16 +334,17 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
             .zip(hlls)
             .zip(null_counts)
             .for_each(|(((column_comb, mg), hll), count)| {
-                let filtered_nulls: Vec<ColumnCombValue> = column_comb
-                    .iter()
-                    .filter(|row| row.iter().any(|val| val.is_some()))
-                    .cloned()
-                    .collect();
-                let nb_rows = column_comb.len() as i32;
+                let filtered_nulls = column_comb
+                    .into_iter()
+                    .filter(|row| row.iter().any(|val| val.is_some()));
 
-                *count += nb_rows - filtered_nulls.len() as i32;
-                mg.aggregate(&filtered_nulls);
-                hll.aggregate(&filtered_nulls);
+                *count += column_comb.len() as i32;
+
+                filtered_nulls.for_each(|e| {
+                    mg.insert_element(e, 1);
+                    hll.process(e);
+                    *count -= 1;
+                });
             });
     }
 
@@ -373,46 +378,38 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
             });
     }
 
-    pub fn from_record_batches<I: IntoIterator<Item = Result<RecordBatch, ArrowError>>>(
-        batch_iter_builder: impl Fn() -> anyhow::Result<RecordBatchIterator<I>>,
+    pub fn from_record_batches(
+        first_batch_channel: impl FnOnce()
+            -> (JoinHandle<()>, Receiver<Result<RecordBatch, ArrowError>>),
+        second_batch_channel: impl FnOnce()
+            -> (JoinHandle<()>, Receiver<Result<RecordBatch, ArrowError>>),
         combinations: Vec<ColumnsIdx>,
+        schema: Arc<Schema>,
     ) -> anyhow::Result<Self> {
-        let batch_iter = batch_iter_builder()?;
-        let comb_stat_types = Self::get_stats_types(&combinations, &batch_iter.schema());
+        let comb_stat_types = Self::get_stats_types(&combinations, &schema);
         let nb_stats = comb_stat_types.len();
 
-        // 0. Just count row numbers if no combinations can give stats.
-        if nb_stats == 0 {
-            let mut row_cnt = 0;
-            for batch in batch_iter {
-                row_cnt += batch?.num_rows();
-            }
-
-            return Ok(Self {
-                row_cnt,
-                column_comb_stats: HashMap::new(),
-            });
-        }
-
-        // TODO(Alexis): This materialization is OK as JOB only takes 1GB, but should be made in parallel...
-        // Unfortunately, par_bridge doesn't work as the BatchIterator doesn't implement Send.
-        let materialized: Vec<_> = batch_iter.collect(); 
-        
-        // 1. FIRST PASS: hlls + mgs + null_cnts.        
+        // 1. FIRST PASS: hlls + mgs + null_cnts.
         let now = std::time::Instant::now();
-        let (hlls, mgs, null_cnts) = materialized
-            .par_iter()
+        let (handle, receiver) = first_batch_channel();
+
+        let (hlls, mgs, null_cnts) = receiver
+            .into_iter()
+            .par_bridge()
             .fold(Self::first_pass_stats_id(nb_stats), |local_stats, batch| {
                 let mut local_stats = local_stats?;
 
                 match batch {
                     Ok(batch) => {
                         let (hlls, mgs, null_cnts) = &mut local_stats;
-                        let comb = Self::get_column_combs(batch, &comb_stat_types);
+                        let comb = Self::get_column_combs(&batch, &comb_stat_types);
                         Self::generate_partial_stats(&comb, mgs, hlls, null_cnts);
                         Ok(local_stats)
                     }
-                    Err(_) => todo!(), // TODO(Alexis): Could not satisfy the type checker otherwise, but never happens!
+                    Err(e) => {
+                        println!("Err: {:?},, {:?}", e, comb_stat_types.len());
+                        Err(e.into())
+                    }
                 }
             })
             .reduce(
@@ -433,12 +430,17 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
                     Ok(final_stats)
                 },
             )?;
+
+        let _ = handle.join();
         let first = now.elapsed();
 
         // 2. SECOND PASS: mcv + tdigest + row_cnts.
         let now = std::time::Instant::now();
-        let (distrs, cnts, row_cnts) = materialized
-            .par_iter()
+        let (handle, receiver) = second_batch_channel();
+
+        let (distrs, cnts, row_cnts) = receiver
+            .into_iter()
+            .par_bridge()
             .fold(
                 Self::second_pass_stats_id(&comb_stat_types, &mgs, nb_stats),
                 |local_stats, batch| {
@@ -447,11 +449,11 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
                     match batch {
                         Ok(batch) => {
                             let (distrs, cnts, row_cnts) = &mut local_stats;
-                            let comb = Self::get_column_combs(batch, &comb_stat_types);
+                            let comb = Self::get_column_combs(&batch, &comb_stat_types);
                             Self::generate_full_stats(&comb, cnts, distrs, row_cnts);
                             Ok(local_stats)
                         }
-                        Err(_) => todo!(), // TODO(Alexis): Could not satisfy the type checker otherwise, but never happens!
+                        Err(e) => Err(e.into()),
                     }
                 },
             )
@@ -479,10 +481,11 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
                     Ok(final_stats)
                 },
             )?;
-        let second = now.elapsed();
+
+        let _ = handle.join();
+        println!("First: {:?}, Second: {:?}", first, now.elapsed());
 
         // 3. ASSEMBLE STATS.
-        let now = std::time::Instant::now();
         let row_cnt = row_cnts[0];
         let mut column_comb_stats = HashMap::new();
 
@@ -506,7 +509,6 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
             );
             column_comb_stats.insert(comb, column_stats);
         }
-        println!("First: {:?}, Second: {:?}, Third: {:?}", first, second, now.elapsed());
 
         Ok(Self {
             row_cnt: row_cnt as usize,

--- a/optd-datafusion-repr/src/cost/base_cost/stats.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/stats.rs
@@ -163,6 +163,54 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
         )
     }
 
+    fn first_pass_stats_id(
+        nb_stats: usize,
+    ) -> impl Fn() -> anyhow::Result<(
+        Vec<HyperLogLog<ColumnCombValue>>,
+        Vec<MisraGries<ColumnCombValue>>,
+        Vec<i32>,
+    )> {
+        move || {
+            Ok((
+                vec![HyperLogLog::<ColumnCombValue>::new(hyperloglog::DEFAULT_PRECISION); nb_stats],
+                vec![MisraGries::<ColumnCombValue>::new(misragries::DEFAULT_K_TO_TRACK); nb_stats],
+                vec![0; nb_stats],
+            ))
+        }
+    }
+
+    fn second_pass_stats_id<'a, 'b>(
+        comb_stat_types: &'a Vec<(Vec<usize>, Vec<DataType>, StatType)>,
+        mgs: &'a Vec<MisraGries<ColumnCombValue>>,
+        nb_stats: usize,
+    ) -> impl Fn() -> anyhow::Result<(
+        Vec<Option<TDigest<Value>>>,
+        Vec<Counter<ColumnCombValue>>,
+        Vec<i32>,
+    )> + 'b
+    where
+        'a: 'b,
+    {
+        move || {
+            Ok((
+                comb_stat_types
+                    .iter()
+                    .map(|(_, _, stat_type)| match stat_type {
+                        StatType::Full => Some(TDigest::new(tdigest::DEFAULT_COMPRESSION)),
+                        StatType::Partial => None,
+                    })
+                    .collect(),
+                mgs.iter()
+                    .map(|mg| {
+                        let mfk = mg.most_frequent_keys().into_iter().cloned().collect_vec();
+                        Counter::new(&mfk)
+                    })
+                    .collect(),
+                vec![0; nb_stats],
+            ))
+        }
+    }
+
     fn get_stats_types(
         combinations: &[ColumnsIdx],
         schema: &SchemaRef,
@@ -276,14 +324,12 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
         hlls: &mut [HyperLogLog<ColumnCombValue>],
         null_counts: &mut [i32],
     ) {
-        let now = std::time::Instant::now();
         column_combs
-            .par_iter()
+            .iter()
             .zip(mgs)
             .zip(hlls)
             .zip(null_counts)
             .for_each(|(((column_comb, mg), hll), count)| {
-                let now = std::time::Instant::now();
                 let filtered_nulls: Vec<ColumnCombValue> = column_comb
                     .iter()
                     .filter(|row| row.iter().any(|val| val.is_some()))
@@ -292,11 +338,14 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
                 let nb_rows = column_comb.len() as i32;
 
                 *count += nb_rows - filtered_nulls.len() as i32;
+                //let now = std::time::Instant::now();
                 mg.aggregate(&filtered_nulls);
+                //let mg_time = now.elapsed();
+                //let now = std::time::Instant::now();
                 hll.aggregate(&filtered_nulls);
-                println!("generate_partial_stats one task took {:?}", now.elapsed());
+                //println!("HLL took {:?} and MG {:?}", now.elapsed(), mg_time);
             });
-        println!("generate_partial_stats took {:?}, per row {:?}", now.elapsed(), now.elapsed().as_millis() as f64 / column_combs[0].len() as f64);
+        //println!("generate_partial_stats took {:?}", now.elapsed());
     }
 
     fn generate_full_stats(
@@ -305,14 +354,14 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
         distrs: &mut [Option<TDigest<Value>>],
         row_counts: &mut [i32],
     ) {
-        let now = std::time::Instant::now();
+        //let now = std::time::Instant::now();
         column_combs
-            .par_iter()
+            .iter()
             .zip(cnts)
             .zip(distrs)
             .zip(row_counts)
             .for_each(|(((column_comb, cnt), distr), count)| {
-                let now = std::time::Instant::now();
+                //let now = std::time::Instant::now();
                 let nb_rows = column_comb.len() as i32;
                 *count += nb_rows;
                 cnt.aggregate(column_comb);
@@ -327,17 +376,16 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
 
                     d.norm_weight += nb_rows as usize;
                     d.merge_values(&filtered_values);
-                    println!("generate_full_stats one task took {:?}", now.elapsed());
+                    //println!("generate_full_stats one task took {:?}", now.elapsed());
                 }
             });
-            println!("generate_full_stats took {:?}, per row {:?}", now.elapsed(), now.elapsed().as_micros() as f64 / column_combs[0].len() as f64);
-        }
+        //println!("generate_full_stats took {:?}", now.elapsed());
+    }
 
     pub fn from_record_batches<I: IntoIterator<Item = Result<RecordBatch, ArrowError>>>(
         batch_iter_builder: impl Fn() -> anyhow::Result<RecordBatchIterator<I>>,
         combinations: Vec<ColumnsIdx>,
     ) -> anyhow::Result<Self> {
-        println!("new table");
         let batch_iter = batch_iter_builder()?;
         let comb_stat_types = Self::get_stats_types(&combinations, &batch_iter.schema());
         let nb_stats = comb_stat_types.len();
@@ -355,53 +403,89 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
             });
         }
 
-        // 1. FIRST PASS: hlls + mgs + null_cnts.
-        let mut hlls = vec![HyperLogLog::new(hyperloglog::DEFAULT_PRECISION); nb_stats];
-        let mut mgs = vec![MisraGries::new(misragries::DEFAULT_K_TO_TRACK); nb_stats];
-        let mut null_cnts = vec![0; nb_stats];
+        // TODO(Alexis): This materialization is OK as JOB only takes 1GB, but should be made in parallel...
+        // Unfortunately, par_bridge doesn't work as the BatchIterator doesn't implement Send.
+        let materialized: Vec<_> = batch_iter.collect(); 
+        
 
-        for batch in batch_iter {
-            let batch = batch?;
+        // 1. FIRST PASS: hlls + mgs + null_cnts.        
+        let (hlls, mgs, null_cnts) = materialized
+            .par_iter()
+            .fold(Self::first_pass_stats_id(nb_stats), |local_stats, batch| {
+                let mut local_stats = local_stats?;
 
-            let now = std::time::Instant::now();
-            let comn = &Self::get_column_combs(&batch, &comb_stat_types);
-            println!("comb took {:?}", now.elapsed());
-
-            Self::generate_partial_stats(
-                comn,
-                &mut mgs,
-                &mut hlls,
-                &mut null_cnts,
-            );
-        }
-
-        // 2. SECOND PASS:  MCV + TDigest + row_cnts.
-        let batch_iter = batch_iter_builder()?;
-        let mut distrs = comb_stat_types
-            .iter()
-            .map(|(_, _, stat_type)| match stat_type {
-                StatType::Full => Some(TDigest::new(tdigest::DEFAULT_COMPRESSION)),
-                StatType::Partial => None,
+                match batch {
+                    Ok(batch) => {
+                        let (hlls, mgs, null_cnts) = &mut local_stats;
+                        let comb = Self::get_column_combs(&batch, &comb_stat_types);
+                        Self::generate_partial_stats(&comb, mgs, hlls, null_cnts);
+                        Ok(local_stats)
+                    }
+                    Err(_) => todo!(), // TODO(Alexis): Could not satisfy the type checker otherwise, but never happens!
+                }
             })
-            .collect_vec();
-        let mut cnts = mgs
-            .iter()
-            .map(|mg| {
-                let mfk = mg.most_frequent_keys().into_iter().cloned().collect_vec();
-                Counter::new(&mfk)
-            })
-            .collect_vec();
-        let mut row_cnts = vec![0; nb_stats]; // All the same, but more convenient like this.
+            .reduce(
+                Self::first_pass_stats_id(nb_stats),
+                |final_stats, local_stats| {
+                    let mut final_stats = final_stats?;
+                    let local_stats = local_stats?;
 
-        for batch in batch_iter {
-            let batch = batch?;
-            Self::generate_full_stats(
-                &Self::get_column_combs(&batch, &comb_stat_types),
-                &mut cnts,
-                &mut distrs,
-                &mut row_cnts,
-            );
-        }
+                    let (final_hlls, final_mgs, final_counts) = &mut final_stats;
+                    let (local_hlls, local_mgs, local_counts) = local_stats;
+
+                    for i in 0..nb_stats {
+                        final_hlls[i].merge(&local_hlls[i]);
+                        final_mgs[i].merge(&local_mgs[i]);
+                        final_counts[i] += local_counts[i];
+                    }
+
+                    Ok(final_stats)
+                },
+            )?;
+
+        // 2. SECOND PASS: mcv + tdigest + row_cnts.
+        let (distrs, cnts, row_cnts) = materialized
+            .par_iter()
+            .fold(
+                Self::second_pass_stats_id(&comb_stat_types, &mgs, nb_stats),
+                |local_stats, batch| {
+                    let mut local_stats = local_stats?;
+
+                    match batch {
+                        Ok(batch) => {
+                            let (distrs, cnts, row_cnts) = &mut local_stats;
+                            let comb = Self::get_column_combs(&batch, &comb_stat_types);
+                            Self::generate_full_stats(&comb, cnts, distrs, row_cnts);
+                            Ok(local_stats)
+                        }
+                        Err(_) => todo!(), // TODO(Alexis): Could not satisfy the type checker otherwise, but never happens!
+                    }
+                },
+            )
+            .reduce(
+                Self::second_pass_stats_id(&comb_stat_types, &mgs, nb_stats),
+                |final_stats, local_stats| {
+                    let mut final_stats = final_stats?;
+                    let local_stats = local_stats?;
+
+                    let (final_distrs, final_cnts, final_counts) = &mut final_stats;
+                    let (local_distrs, local_cnts, local_counts) = local_stats;
+
+                    for i in 0..nb_stats {
+                        final_cnts[i].merge(&local_cnts[i]);
+                        if let (Some(final_distr), Some(local_distr)) =
+                            (&mut final_distrs[i], &local_distrs[i])
+                        {
+                            final_distr.merge(local_distr);
+                            final_distr.norm_weight += local_distr.norm_weight;
+                        }
+
+                        final_counts[i] += local_counts[i];
+                    }
+
+                    Ok(final_stats)
+                },
+            )?;
 
         // 3. ASSEMBLE STATS.
         let row_cnt = row_cnts[0];

--- a/optd-datafusion-repr/src/cost/base_cost/stats.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/stats.rs
@@ -14,6 +14,7 @@ use optd_gungnir::stats::{
     tdigest::{self, TDigest},
 };
 use ordered_float::OrderedFloat;
+use rayon::prelude::*;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 // The "standard" concrete types that optd currently uses.
@@ -275,20 +276,23 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
         hlls: &mut [HyperLogLog<ColumnCombValue>],
         null_counts: &mut [i32],
     ) {
-        for (idx, column_comb) in column_combs.iter().enumerate() {
-            // TODO(Alexis): Redundant copy.
-            let filtered_nulls: Vec<ColumnCombValue> = column_comb
-                .iter()
-                .filter(|row| row.iter().any(|val| val.is_some()))
-                .cloned()
-                .collect();
-            let nb_rows: i32 = column_comb.len() as i32;
+        column_combs
+            .par_iter()
+            .zip(mgs)
+            .zip(hlls)
+            .zip(null_counts)
+            .for_each(|(((column_comb, mg), hll), count)| {
+                let filtered_nulls: Vec<ColumnCombValue> = column_comb
+                    .iter()
+                    .filter(|row| row.iter().any(|val| val.is_some()))
+                    .cloned()
+                    .collect();
+                let nb_rows = column_comb.len() as i32;
 
-            null_counts[idx] += nb_rows - filtered_nulls.len() as i32;
-
-            mgs[idx].aggregate(&filtered_nulls);
-            hlls[idx].aggregate(&filtered_nulls);
-        }
+                *count += nb_rows - filtered_nulls.len() as i32;
+                mg.aggregate(&filtered_nulls);
+                hll.aggregate(&filtered_nulls);
+            });
     }
 
     fn generate_full_stats(
@@ -297,25 +301,28 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
         distrs: &mut [Option<TDigest<Value>>],
         row_counts: &mut [i32],
     ) {
-        for (idx, column_comb) in column_combs.iter().enumerate() {
-            let nb_rows: i32 = column_comb.len() as i32;
-            row_counts[idx] += nb_rows;
+        column_combs
+            .par_iter()
+            .zip(cnts)
+            .zip(distrs)
+            .zip(row_counts)
+            .for_each(|(((column_comb, cnt), distr), count)| {
+                let nb_rows = column_comb.len() as i32;
+                *count += nb_rows;
+                cnt.aggregate(column_comb);
 
-            cnts[idx].aggregate(column_comb);
-            if let Some(distr) = &mut distrs[idx] {
-                // TODO(Alexis): Redundant copy.
-                // We project it down to 1D, as we do not support nD TDigests.
-                let single_col_filtered = column_comb
-                    .iter()
-                    .filter(|row| !cnts[idx].is_tracking(row))
-                    .filter_map(|row| row[0].as_ref())
-                    .cloned()
-                    .collect_vec();
+                if let Some(d) = distr.as_mut() {
+                    let filtered_values: Vec<_> = column_comb
+                        .iter()
+                        .filter(|row| !cnt.is_tracking(row))
+                        .filter_map(|row| row.get(0).and_then(|v| v.as_ref()))
+                        .cloned()
+                        .collect();
 
-                distr.norm_weight += nb_rows as usize;
-                distr.merge_values(&single_col_filtered);
-            }
-        }
+                    d.norm_weight += nb_rows as usize;
+                    d.merge_values(&filtered_values);
+                }
+            });
     }
 
     pub fn from_record_batches<I: IntoIterator<Item = Result<RecordBatch, ArrowError>>>(

--- a/optd-datafusion-repr/src/cost/base_cost/stats.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/stats.rs
@@ -149,6 +149,18 @@ impl<
 
 pub type BaseTableStats<M, D> = HashMap<String, TableStats<M, D>>;
 
+type FirstPassState = (
+    Vec<HyperLogLog<ColumnCombValue>>,
+    Vec<MisraGries<ColumnCombValue>>,
+    Vec<i32>,
+);
+
+type SecondPassState = (
+    Vec<Option<TDigest<Value>>>,
+    Vec<Counter<ColumnCombValue>>,
+    Vec<i32>,
+);
+
 impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
     fn is_type_supported(data_type: &DataType) -> bool {
         matches!(
@@ -166,13 +178,7 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
         )
     }
 
-    fn first_pass_stats_id(
-        nb_stats: usize,
-    ) -> anyhow::Result<(
-        Vec<HyperLogLog<ColumnCombValue>>,
-        Vec<MisraGries<ColumnCombValue>>,
-        Vec<i32>,
-    )> {
+    fn first_pass_stats_id(nb_stats: usize) -> anyhow::Result<FirstPassState> {
         Ok((
             vec![HyperLogLog::<ColumnCombValue>::new(hyperloglog::DEFAULT_PRECISION); nb_stats],
             vec![MisraGries::<ColumnCombValue>::new(misragries::DEFAULT_K_TO_TRACK); nb_stats],
@@ -184,11 +190,7 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
         comb_stat_types: &[(Vec<usize>, Vec<DataType>, StatType)],
         mgs: &[MisraGries<ColumnCombValue>],
         nb_stats: usize,
-    ) -> anyhow::Result<(
-        Vec<Option<TDigest<Value>>>,
-        Vec<Counter<ColumnCombValue>>,
-        Vec<i32>,
-    )> {
+    ) -> anyhow::Result<SecondPassState> {
         Ok((
             comb_stat_types
                 .iter()
@@ -327,7 +329,7 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
             .zip(null_counts)
             .for_each(|(((column_comb, mg), hll), count)| {
                 let filtered_nulls = column_comb
-                    .into_iter()
+                    .iter()
                     .filter(|row| row.iter().any(|val| val.is_some()));
 
                 *count += column_comb.len() as i32;

--- a/optd-datafusion-repr/src/cost/base_cost/stats.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/stats.rs
@@ -180,8 +180,8 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
     }
 
     fn second_pass_stats_id<'a, 'b>(
-        comb_stat_types: &'a Vec<(Vec<usize>, Vec<DataType>, StatType)>,
-        mgs: &'a Vec<MisraGries<ColumnCombValue>>,
+        comb_stat_types: &'a [(Vec<usize>, Vec<DataType>, StatType)],
+        mgs: &'a [MisraGries<ColumnCombValue>],
         nb_stats: usize,
     ) -> impl Fn() -> anyhow::Result<(
         Vec<Option<TDigest<Value>>>,
@@ -370,7 +370,7 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
                     let filtered_values: Vec<_> = column_comb
                         .iter()
                         .filter(|row| !cnt.is_tracking(row))
-                        .filter_map(|row| row.get(0).and_then(|v| v.as_ref()))
+                        .filter_map(|row| row.first().and_then(|v| v.as_ref()))
                         .cloned()
                         .collect();
 
@@ -417,7 +417,7 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
                 match batch {
                     Ok(batch) => {
                         let (hlls, mgs, null_cnts) = &mut local_stats;
-                        let comb = Self::get_column_combs(&batch, &comb_stat_types);
+                        let comb = Self::get_column_combs(batch, &comb_stat_types);
                         Self::generate_partial_stats(&comb, mgs, hlls, null_cnts);
                         Ok(local_stats)
                     }
@@ -454,7 +454,7 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
                     match batch {
                         Ok(batch) => {
                             let (distrs, cnts, row_cnts) = &mut local_stats;
-                            let comb = Self::get_column_combs(&batch, &comb_stat_types);
+                            let comb = Self::get_column_combs(batch, &comb_stat_types);
                             Self::generate_full_stats(&comb, cnts, distrs, row_cnts);
                             Ok(local_stats)
                         }

--- a/optd-datafusion-repr/src/cost/base_cost/stats.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/stats.rs
@@ -380,7 +380,6 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
         let nb_stats = comb_stat_types.len();
 
         // 1. FIRST PASS: hlls + mgs + null_cnts.
-        let now = std::time::Instant::now();
         let local_partial_stats: Vec<_> = first_batch_reader()
             .into_par_iter()
             .map(|group| {
@@ -419,10 +418,7 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
             },
         )?;
 
-        let first = now.elapsed();
-
         // 2. SECOND PASS: mcv + tdigest + row_cnts.
-        let now = std::time::Instant::now();
         let local_final_stats: Vec<_> = second_batch_reader()
             .into_par_iter()
             .map(|group| {
@@ -469,8 +465,6 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
                 Ok(final_stats)
             },
         )?;
-
-        println!("First: {:?}, Second: {:?}", first, now.elapsed());
 
         // 3. ASSEMBLE STATS.
         let row_cnt = row_cnts[0];

--- a/optd-datafusion-repr/src/cost/base_cost/stats.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/stats.rs
@@ -276,12 +276,14 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
         hlls: &mut [HyperLogLog<ColumnCombValue>],
         null_counts: &mut [i32],
     ) {
+        let now = std::time::Instant::now();
         column_combs
             .par_iter()
             .zip(mgs)
             .zip(hlls)
             .zip(null_counts)
             .for_each(|(((column_comb, mg), hll), count)| {
+                let now = std::time::Instant::now();
                 let filtered_nulls: Vec<ColumnCombValue> = column_comb
                     .iter()
                     .filter(|row| row.iter().any(|val| val.is_some()))
@@ -292,7 +294,9 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
                 *count += nb_rows - filtered_nulls.len() as i32;
                 mg.aggregate(&filtered_nulls);
                 hll.aggregate(&filtered_nulls);
+                println!("generate_partial_stats one task took {:?}", now.elapsed());
             });
+        println!("generate_partial_stats took {:?}, per row {:?}", now.elapsed(), now.elapsed().as_millis() as f64 / column_combs[0].len() as f64);
     }
 
     fn generate_full_stats(
@@ -301,12 +305,14 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
         distrs: &mut [Option<TDigest<Value>>],
         row_counts: &mut [i32],
     ) {
+        let now = std::time::Instant::now();
         column_combs
             .par_iter()
             .zip(cnts)
             .zip(distrs)
             .zip(row_counts)
             .for_each(|(((column_comb, cnt), distr), count)| {
+                let now = std::time::Instant::now();
                 let nb_rows = column_comb.len() as i32;
                 *count += nb_rows;
                 cnt.aggregate(column_comb);
@@ -321,14 +327,17 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
 
                     d.norm_weight += nb_rows as usize;
                     d.merge_values(&filtered_values);
+                    println!("generate_full_stats one task took {:?}", now.elapsed());
                 }
             });
-    }
+            println!("generate_full_stats took {:?}, per row {:?}", now.elapsed(), now.elapsed().as_micros() as f64 / column_combs[0].len() as f64);
+        }
 
     pub fn from_record_batches<I: IntoIterator<Item = Result<RecordBatch, ArrowError>>>(
         batch_iter_builder: impl Fn() -> anyhow::Result<RecordBatchIterator<I>>,
         combinations: Vec<ColumnsIdx>,
     ) -> anyhow::Result<Self> {
+        println!("new table");
         let batch_iter = batch_iter_builder()?;
         let comb_stat_types = Self::get_stats_types(&combinations, &batch_iter.schema());
         let nb_stats = comb_stat_types.len();
@@ -353,8 +362,13 @@ impl TableStats<Counter<ColumnCombValue>, TDigest<Value>> {
 
         for batch in batch_iter {
             let batch = batch?;
+
+            let now = std::time::Instant::now();
+            let comn = &Self::get_column_combs(&batch, &comb_stat_types);
+            println!("comb took {:?}", now.elapsed());
+
             Self::generate_partial_stats(
-                &Self::get_column_combs(&batch, &comb_stat_types),
+                comn,
                 &mut mgs,
                 &mut hlls,
                 &mut null_cnts,

--- a/optd-gungnir/Cargo.toml
+++ b/optd-gungnir/Cargo.toml
@@ -14,3 +14,4 @@ serde = {version = "1.0", features = ["derive"]}
 serde_with = {version = "3.7.0", features = ["json"]}
 ordered-float = "4"
 optd-core = { path = "../optd-core" }
+hashbrown = { version = "0.14", features = ["serde"] }

--- a/optd-gungnir/src/stats/hyperloglog.rs
+++ b/optd-gungnir/src/stats/hyperloglog.rs
@@ -197,7 +197,7 @@ mod tests {
     fn hll_small_strings() {
         let mut hll = HyperLogLog::new(12);
 
-        let data = vec!["a".to_string(), "b".to_string()];
+        let data = ["a".to_string(), "b".to_string()];
         hll.aggregate(data.iter());
         assert_eq!(hll.n_distinct(), data.len() as u64);
     }
@@ -206,7 +206,7 @@ mod tests {
     fn hll_small_u64() {
         let mut hll = HyperLogLog::new(12);
 
-        let data = vec![1, 2];
+        let data = [1, 2];
         hll.aggregate(data.iter());
         assert_eq!(hll.n_distinct(), data.len() as u64);
     }

--- a/optd-gungnir/src/stats/hyperloglog.rs
+++ b/optd-gungnir/src/stats/hyperloglog.rs
@@ -88,9 +88,9 @@ impl_byte_serializable_for_numeric!(usize, isize);
 impl_byte_serializable_for_numeric!(f64, f32);
 
 // Self-contained implementation of the HyperLogLog data structure.
-impl<T> HyperLogLog<T>
+impl<'a, T> HyperLogLog<T>
 where
-    T: ByteSerializable,
+    T: ByteSerializable + 'a,
 {
     /// Creates and initializes a new empty HyperLogLog.
     pub fn new(precision: u8) -> Self {
@@ -109,17 +109,23 @@ where
         }
     }
 
-    /// Digests an array of ByteSerializable data into the HLL.
-    pub fn aggregate(&mut self, data: &[T])
+    pub fn process(&mut self, element: &T)
     where
         T: ByteSerializable,
     {
-        for d in data {
-            let hash = murmur_hash(&d.to_bytes(), 0); // TODO: We ignore DoS attacks (seed).
-            let mask = (1 << (self.precision)) - 1;
-            let idx = (hash & mask) as usize; // LSB is bucket discriminator; MSB is zero streak.
-            self.registers[idx] = max(self.registers[idx], self.zeros(hash) + 1);
-        }
+        let hash = murmur_hash(&element.to_bytes(), 0); // TODO: We ignore DoS attacks (seed).
+        let mask = (1 << (self.precision)) - 1;
+        let idx = (hash & mask) as usize; // LSB is bucket discriminator; MSB is zero streak.
+        self.registers[idx] = max(self.registers[idx], self.zeros(hash) + 1);
+    }
+
+    /// Digests an array of ByteSerializable data into the HLL.
+    pub fn aggregate<I>(&mut self, data: I)
+    where
+        I: Iterator<Item = &'a T>,
+        T: ByteSerializable,
+    {
+        data.for_each(|e| self.process(e));
     }
 
     /// Merges two HLLs together and returns a new one.
@@ -192,7 +198,7 @@ mod tests {
         let mut hll = HyperLogLog::new(12);
 
         let data = vec!["a".to_string(), "b".to_string()];
-        hll.aggregate(&data);
+        hll.aggregate(data.iter());
         assert_eq!(hll.n_distinct(), data.len() as u64);
     }
 
@@ -201,7 +207,7 @@ mod tests {
         let mut hll = HyperLogLog::new(12);
 
         let data = vec![1, 2];
-        hll.aggregate(&data);
+        hll.aggregate(data.iter());
         assert_eq!(hll.n_distinct(), data.len() as u64);
     }
 
@@ -239,7 +245,7 @@ mod tests {
         let relative_error = 0.05; // We allow a 5% relatative error rate.
 
         let strings = generate_random_strings(n_distinct, 100, 0);
-        hll.aggregate(&strings);
+        hll.aggregate(strings.iter());
 
         assert!(is_close(
             hll.n_distinct() as f64,
@@ -264,7 +270,7 @@ mod tests {
                     let curr_job_id = job_id.fetch_add(1, Ordering::SeqCst);
 
                     let strings = generate_random_strings(n_distinct, 100, curr_job_id);
-                    local_hll.aggregate(&strings);
+                    local_hll.aggregate(strings.iter());
 
                     assert!(is_close(
                         local_hll.n_distinct() as f64,

--- a/optd-gungnir/src/stats/misragries.rs
+++ b/optd-gungnir/src/stats/misragries.rs
@@ -97,7 +97,7 @@ where
     where
         I: Iterator<Item = &'a T>,
     {
-        data.for_each(|key| self.insert_element(&key, 1));
+        data.for_each(|key| self.insert_element(key, 1));
     }
 
     /// Merges another MisraGries into the current one.

--- a/optd-gungnir/src/stats/misragries.rs
+++ b/optd-gungnir/src/stats/misragries.rs
@@ -23,9 +23,9 @@ pub struct MisraGries<T: PartialEq + Eq + Hash + Clone> {
 }
 
 // Self-contained implementation of the Misra-Gries data structure.
-impl<T> MisraGries<T>
+impl<'a, T> MisraGries<T>
 where
-    T: PartialEq + Eq + Hash + Clone,
+    T: PartialEq + Eq + Hash + Clone + 'a,
 {
     /// Creates and initializes a new empty Misra-Gries.
     pub fn new(k: u16) -> Self {
@@ -48,7 +48,7 @@ where
     }
 
     // Inserts an element occ times into the `self` Misra-Gries structure.
-    fn insert_element(&mut self, elem: &T, occ: i32) {
+    pub fn insert_element(&mut self, elem: &T, occ: i32) {
         match self.frequencies.get_mut(elem) {
             Some(freq) => {
                 *freq += occ; // Hit.
@@ -93,8 +93,11 @@ where
     }
 
     /// Digests an array of data into the Misra-Gries structure.
-    pub fn aggregate(&mut self, data: &[T]) {
-        data.iter().for_each(|key| self.insert_element(key, 1));
+    pub fn aggregate<I>(&mut self, data: I)
+    where
+        I: Iterator<Item = &'a T>,
+    {
+        data.for_each(|key| self.insert_element(&key, 1));
     }
 
     /// Merges another MisraGries into the current one.
@@ -131,7 +134,7 @@ mod tests {
         let data = vec![0, 1, 2, 3];
         let mut misra_gries = MisraGries::<i32>::new(data.len() as u16);
 
-        misra_gries.aggregate(&data);
+        misra_gries.aggregate(data.iter());
 
         for key in misra_gries.most_frequent_keys() {
             assert!(data.contains(key));
@@ -145,7 +148,7 @@ mod tests {
 
         let mut misra_gries = MisraGries::<i32>::new(data.len() as u16);
 
-        misra_gries.aggregate(&data_dup);
+        misra_gries.aggregate(data_dup.iter());
 
         for key in misra_gries.most_frequent_keys() {
             assert!(data.contains(key));
@@ -189,7 +192,7 @@ mod tests {
         let data = create_zipfian(n_distinct, 0);
         let mut misra_gries = MisraGries::<i32>::new(k as u16);
 
-        misra_gries.aggregate(&data);
+        misra_gries.aggregate(data.iter());
 
         check_zipfian(&misra_gries, n_distinct);
     }
@@ -209,7 +212,7 @@ mod tests {
                     let curr_job_id = job_id.fetch_add(1, Ordering::SeqCst);
 
                     let data = create_zipfian(n_distinct, curr_job_id as u64);
-                    local_misra_gries.aggregate(&data);
+                    local_misra_gries.aggregate(data.iter());
 
                     check_zipfian(&local_misra_gries, n_distinct);
 

--- a/optd-gungnir/src/stats/misragries.rs
+++ b/optd-gungnir/src/stats/misragries.rs
@@ -18,6 +18,8 @@ pub const DEFAULT_K_TO_TRACK: u16 = 1000;
 pub struct MisraGries<T: PartialEq + Eq + Hash + Clone> {
     frequencies: HashMap<T, i32>, // The approximated frequencies of an element T.
     k: u16,                       // The max size of our frequencies hashmap.
+
+    least_frequent: Option<(T, i32)>, // The least frequent element in frequencies.
 }
 
 // Self-contained implementation of the Misra-Gries data structure.
@@ -32,6 +34,8 @@ where
         MisraGries::<T> {
             frequencies: HashMap::with_capacity(k as usize),
             k,
+
+            least_frequent: None,
         }
     }
 
@@ -44,27 +48,44 @@ where
     }
 
     // Inserts an element occ times into the `self` Misra-Gries structure.
-    fn insert_element(&mut self, elem: T, occ: i32) {
+    fn insert_element(&mut self, elem: &T, occ: i32) {
         match self.frequencies.get_mut(&elem) {
-            Some(freq) => *freq += occ, // Hit.
+            Some(freq) => {
+                *freq += occ; // Hit.
+                if *elem == self.least_frequent.as_ref().unwrap().0 {
+                    self.least_frequent = Some(self.find_least_frequent());
+                }
+            }
             None => {
                 if self.frequencies.len() < self.k as usize {
-                    self.frequencies.insert(elem, occ); // Discovery phase.
+                    self.frequencies.insert(elem.clone(), occ); // Discovery phase.
+
+                    match &self.least_frequent {
+                        Some(prev) => {
+                            if prev.1 > occ {
+                                self.least_frequent = Some((elem.clone(), occ));
+                            }
+                        }
+                        None => self.least_frequent = Some((elem.clone(), occ)),
+                    }
                 } else {
-                    // Check if there *will* be an evictable frequency; decrement & insert.
-                    let (smallest_freq_key, smallest_freq) = self.find_least_frequent();
+                    let smallest_freq = self.least_frequent.as_ref().unwrap().1;
 
                     let decr = min(smallest_freq, occ);
                     if decr > 0 {
                         for freq in self.frequencies.values_mut() {
                             *freq -= decr;
                         }
+                        self.least_frequent.as_mut().unwrap().1 -= decr;
                     }
 
                     let delta = smallest_freq - occ;
                     if delta < 0 {
-                        self.frequencies.remove(&smallest_freq_key);
-                        self.frequencies.insert(elem, -delta);
+                        self.frequencies
+                            .remove(&self.least_frequent.as_ref().unwrap().0);
+                        self.frequencies.insert(elem.clone(), -delta);
+
+                        self.least_frequent = Some(self.find_least_frequent());
                     }
                 }
             }
@@ -73,8 +94,7 @@ where
 
     /// Digests an array of data into the Misra-Gries structure.
     pub fn aggregate(&mut self, data: &[T]) {
-        data.iter()
-            .for_each(|key| self.insert_element(key.clone(), 1));
+        data.iter().for_each(|key| self.insert_element(key, 1));
     }
 
     /// Merges another MisraGries into the current one.
@@ -85,7 +105,7 @@ where
         other
             .frequencies
             .iter()
-            .for_each(|(key, occ)| self.insert_element(key.clone(), *occ));
+            .for_each(|(key, occ)| self.insert_element(key, *occ));
     }
 
     /// Returns all elements with frequency f >= (n/k),

--- a/optd-gungnir/src/stats/misragries.rs
+++ b/optd-gungnir/src/stats/misragries.rs
@@ -5,10 +5,9 @@
 //! For more details, refer to:
 //! https://people.csail.mit.edu/rrw/6.045-2017/encalgs-mg.pdf
 
+use hashbrown::HashMap;
 use itertools::Itertools;
 use std::{cmp::min, hash::Hash};
-use hashbrown::HashMap;
-
 
 pub const DEFAULT_K_TO_TRACK: u16 = 200;
 

--- a/optd-gungnir/src/stats/misragries.rs
+++ b/optd-gungnir/src/stats/misragries.rs
@@ -131,7 +131,7 @@ mod tests {
 
     #[test]
     fn aggregate_simple() {
-        let data = vec![0, 1, 2, 3];
+        let data = [0, 1, 2, 3];
         let mut misra_gries = MisraGries::<i32>::new(data.len() as u16);
 
         misra_gries.aggregate(data.iter());
@@ -143,7 +143,7 @@ mod tests {
 
     #[test]
     fn aggregate_double() {
-        let data = vec![0, 1, 2, 3];
+        let data = [0, 1, 2, 3];
         let data_dup = [data.as_slice(), data.as_slice()].concat();
 
         let mut misra_gries = MisraGries::<i32>::new(data.len() as u16);

--- a/optd-gungnir/src/stats/misragries.rs
+++ b/optd-gungnir/src/stats/misragries.rs
@@ -49,7 +49,7 @@ where
 
     // Inserts an element occ times into the `self` Misra-Gries structure.
     fn insert_element(&mut self, elem: &T, occ: i32) {
-        match self.frequencies.get_mut(&elem) {
+        match self.frequencies.get_mut(elem) {
             Some(freq) => {
                 *freq += occ; // Hit.
                 if *elem == self.least_frequent.as_ref().unwrap().0 {

--- a/optd-gungnir/src/stats/misragries.rs
+++ b/optd-gungnir/src/stats/misragries.rs
@@ -5,11 +5,12 @@
 //! For more details, refer to:
 //! https://people.csail.mit.edu/rrw/6.045-2017/encalgs-mg.pdf
 
-use std::{cmp::min, collections::HashMap, hash::Hash};
-
 use itertools::Itertools;
+use std::{cmp::min, hash::Hash};
+use hashbrown::HashMap;
 
-pub const DEFAULT_K_TO_TRACK: u16 = 1000;
+
+pub const DEFAULT_K_TO_TRACK: u16 = 200;
 
 /// The Misra-Gries structure to approximate the k most frequent elements in
 /// a stream of N elements. It will always identify elements with frequency

--- a/optd-perftest/Cargo.toml
+++ b/optd-perftest/Cargo.toml
@@ -47,6 +47,7 @@ itertools = "0.12.1"
 test-case = "3.3"
 rayon = "1.10"
 parquet = "47.0.0"
+flume = "0.11.0"
 
 [dev_dependencies]
 assert_cmd = "2.0"

--- a/optd-perftest/Cargo.toml
+++ b/optd-perftest/Cargo.toml
@@ -45,6 +45,7 @@ serde = "1.0"
 serde_json = "1.0"
 itertools = "0.12.1"
 test-case = "3.3"
+rayon = "1.10"
 
 [dev_dependencies]
 assert_cmd = "2.0"

--- a/optd-perftest/Cargo.toml
+++ b/optd-perftest/Cargo.toml
@@ -46,6 +46,7 @@ serde_json = "1.0"
 itertools = "0.12.1"
 test-case = "3.3"
 rayon = "1.10"
+parquet = "47.0.0"
 
 [dev_dependencies]
 assert_cmd = "2.0"

--- a/optd-perftest/src/datafusion_dbms.rs
+++ b/optd-perftest/src/datafusion_dbms.rs
@@ -25,7 +25,6 @@ use datafusion::{
     sql::{parser::DFParser, sqlparser::dialect::GenericDialect},
 };
 use datafusion_optd_cli::helper::unescape_input;
-use itertools::iproduct;
 use lazy_static::lazy_static;
 use optd_datafusion_bridge::{DatafusionCatalog, OptdQueryPlanner};
 use optd_datafusion_repr::{
@@ -370,9 +369,9 @@ impl DatafusionDBMS {
 
             let nb_cols = schema.fields().len();
             let single_cols = (0..nb_cols).map(|v| vec![v]);
-            let pairwise_cols = iproduct!(0..nb_cols, 0..nb_cols)
+            /*let pairwise_cols = iproduct!(0..nb_cols, 0..nb_cols)
                 .filter(|(i, j)| i != j)
-                .map(|(i, j)| vec![i, j]);
+                .map(|(i, j)| vec![i, j]);*/
 
             base_table_stats.insert(
                 tbl_name.to_string(),
@@ -381,12 +380,13 @@ impl DatafusionDBMS {
                         let tbl_file = fs::File::open(&tbl_fpath)?;
                         let csv_reader1 = ReaderBuilder::new(schema.clone())
                             .has_header(false)
+                            .with_batch_size(1024)
                             .with_delimiter(b'|')
                             .build(tbl_file)
                             .unwrap();
                         Ok(RecordBatchIterator::new(csv_reader1, schema.clone()))
                     },
-                    single_cols.chain(pairwise_cols).collect(),
+                    single_cols.collect(),
                 )?,
             );
         }
@@ -416,6 +416,7 @@ impl DatafusionDBMS {
 
         // Build the DataFusionBaseTableStats object.
         let mut base_table_stats = DataFusionBaseTableStats::default();
+        let now = std::time::Instant::now();
         for tbl_fpath in job_kit.get_tbl_fpath_iter().unwrap() {
             let tbl_name = JobKit::get_tbl_name_from_tbl_fpath(&tbl_fpath);
             let schema = ctx
@@ -430,9 +431,9 @@ impl DatafusionDBMS {
 
             let nb_cols = schema.fields().len();
             let single_cols = (0..nb_cols).map(|v| vec![v]);
-            let pairwise_cols = iproduct!(0..nb_cols, 0..nb_cols)
+            /*let pairwise_cols = iproduct!(0..nb_cols, 0..nb_cols)
                 .filter(|(i, j)| i != j)
-                .map(|(i, j)| vec![i, j]);
+                .map(|(i, j)| vec![i, j]);*/
 
             base_table_stats.insert(
                 tbl_name.to_string(),
@@ -441,16 +442,18 @@ impl DatafusionDBMS {
                         let tbl_file = fs::File::open(&tbl_fpath)?;
                         let csv_reader1 = ReaderBuilder::new(schema.clone())
                             .has_header(false)
+                            .with_batch_size(65536)
                             .with_delimiter(b',')
                             .with_escape(b'\\')
                             .build(tbl_file)
                             .unwrap();
                         Ok(RecordBatchIterator::new(csv_reader1, schema.clone()))
                     },
-                    single_cols.chain(pairwise_cols).collect(),
+                    single_cols.collect(),
                 )?,
             );
         }
+        println!("Gungnir took {:?}", now.elapsed());
 
         Ok(base_table_stats)
     }

--- a/optd-perftest/src/datafusion_dbms.rs
+++ b/optd-perftest/src/datafusion_dbms.rs
@@ -437,7 +437,7 @@ impl DatafusionDBMS {
         let tbl_paths = job_kit.get_tbl_fpath_vec().unwrap();
 
         tbl_paths.par_iter().for_each(|tbl_fpath| {
-            let tbl_name = JobKit::get_tbl_name_from_tbl_fpath(&tbl_fpath);
+            let tbl_name = JobKit::get_tbl_name_from_tbl_fpath(tbl_fpath);
             let start = Instant::now();
 
             let schema = block_on(async {
@@ -461,7 +461,7 @@ impl DatafusionDBMS {
 
             let stats_result = DataFusionPerTableStats::from_record_batches(
                 || {
-                    let tbl_file = fs::File::open(&tbl_fpath)?;
+                    let tbl_file = fs::File::open(tbl_fpath)?;
                     let csv_reader1 = ReaderBuilder::new(schema.clone())
                         .has_header(false)
                         .with_delimiter(b',')

--- a/optd-perftest/src/datafusion_dbms.rs
+++ b/optd-perftest/src/datafusion_dbms.rs
@@ -477,6 +477,8 @@ impl DatafusionDBMS {
         println!("Total execution time {:?}...", now.elapsed());
 
         Ok(base_table_stats.into_inner()?)
+    }
+
     // Load job data from a .csv file.
     async fn load_job_data_no_stats(
         &mut self,
@@ -492,7 +494,7 @@ impl DatafusionDBMS {
         Self::create_job_tables(&ctx, &job_kit).await?;
 
         // Load each table using register_csv()
-        let tbl_fpath_iter = job_kit.get_tbl_fpath_iter().unwrap();
+        let tbl_fpath_iter = job_kit.get_tbl_fpath_vec("csv").unwrap();
         for tbl_fpath in tbl_fpath_iter {
             let tbl_name = tbl_fpath.file_stem().unwrap().to_str().unwrap();
             let schema = ctx

--- a/optd-perftest/src/datafusion_dbms.rs
+++ b/optd-perftest/src/datafusion_dbms.rs
@@ -25,6 +25,7 @@ use datafusion::{
     sql::{parser::DFParser, sqlparser::dialect::GenericDialect},
 };
 use datafusion_optd_cli::helper::unescape_input;
+use itertools::iproduct;
 use lazy_static::lazy_static;
 use optd_datafusion_bridge::{DatafusionCatalog, OptdQueryPlanner};
 use optd_datafusion_repr::{
@@ -369,9 +370,9 @@ impl DatafusionDBMS {
 
             let nb_cols = schema.fields().len();
             let single_cols = (0..nb_cols).map(|v| vec![v]);
-            /*let pairwise_cols = iproduct!(0..nb_cols, 0..nb_cols)
-            .filter(|(i, j)| i != j)
-            .map(|(i, j)| vec![i, j]);*/
+            let pairwise_cols = iproduct!(0..nb_cols, 0..nb_cols)
+                .filter(|(i, j)| i != j)
+                .map(|(i, j)| vec![i, j]);
 
             base_table_stats.insert(
                 tbl_name.to_string(),
@@ -385,7 +386,7 @@ impl DatafusionDBMS {
                             .unwrap();
                         Ok(RecordBatchIterator::new(csv_reader1, schema.clone()))
                     },
-                    single_cols.collect(),
+                    single_cols.chain(pairwise_cols).collect(),
                 )?,
             );
         }
@@ -429,9 +430,9 @@ impl DatafusionDBMS {
 
             let nb_cols = schema.fields().len();
             let single_cols = (0..nb_cols).map(|v| vec![v]);
-            /*let pairwise_cols = iproduct!(0..nb_cols, 0..nb_cols)
-            .filter(|(i, j)| i != j)
-            .map(|(i, j)| vec![i, j]);*/
+            let pairwise_cols = iproduct!(0..nb_cols, 0..nb_cols)
+                .filter(|(i, j)| i != j)
+                .map(|(i, j)| vec![i, j]);
 
             base_table_stats.insert(
                 tbl_name.to_string(),
@@ -446,7 +447,7 @@ impl DatafusionDBMS {
                             .unwrap();
                         Ok(RecordBatchIterator::new(csv_reader1, schema.clone()))
                     },
-                    single_cols.collect(),
+                    single_cols.chain(pairwise_cols).collect(),
                 )?,
             );
         }

--- a/optd-perftest/src/datafusion_dbms.rs
+++ b/optd-perftest/src/datafusion_dbms.rs
@@ -466,6 +466,7 @@ impl DatafusionDBMS {
                         .has_header(false)
                         .with_delimiter(b',')
                         .with_escape(b'\\')
+                        .with_batch_size(1024)
                         .build(tbl_file)
                         .unwrap();
                     Ok(RecordBatchIterator::new(csv_reader1, schema.clone()))

--- a/optd-perftest/src/datafusion_dbms.rs
+++ b/optd-perftest/src/datafusion_dbms.rs
@@ -1,11 +1,7 @@
 use std::{
     fs::{self, File},
     path::{Path, PathBuf},
-    sync::{
-        mpsc::{self, Receiver},
-        Arc, Mutex,
-    },
-    thread::{self, JoinHandle},
+    sync::{Arc, Mutex},
     time::Instant,
 };
 
@@ -31,14 +27,16 @@ use datafusion::{
 };
 
 use datafusion_optd_cli::helper::unescape_input;
-use futures::executor::block_on;
+use flume::Receiver;
 use lazy_static::lazy_static;
 use optd_datafusion_bridge::{DatafusionCatalog, OptdQueryPlanner};
 use optd_datafusion_repr::{
     cost::{DataFusionBaseTableStats, DataFusionPerTableStats},
     DatafusionOptimizer,
 };
-use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use parquet::arrow::arrow_reader::{
+    ArrowReaderMetadata, ParquetRecordBatchReader, ParquetRecordBatchReaderBuilder,
+};
 use rayon::prelude::*;
 use regex::Regex;
 
@@ -356,10 +354,33 @@ impl DatafusionDBMS {
         Ok(())
     }
 
-    fn gen_base_stats(
-        tbl_paths: Vec<PathBuf>,
-        ctx: SessionContext,
-    ) -> anyhow::Result<DataFusionBaseTableStats> {
+    fn build_batch_reader(
+        tbl_fpath: PathBuf,
+        num_row_groups: usize,
+    ) -> impl FnOnce() -> Vec<ParquetRecordBatchReader> {
+        println!("{:#?}", num_row_groups);
+        move || {
+            let groups: Vec<ParquetRecordBatchReader> = (0..num_row_groups)
+                .map(|group_num| {
+                    let tbl_file = File::open(tbl_fpath.clone()).expect("Failed to open file");
+                    let metadata =
+                        ArrowReaderMetadata::load(&tbl_file, Default::default()).unwrap();
+
+                    ParquetRecordBatchReaderBuilder::new_with_metadata(
+                        tbl_file.try_clone().unwrap(),
+                        metadata.clone(),
+                    )
+                    .with_row_groups(vec![group_num])
+                    .build()
+                    .unwrap()
+                })
+                .collect();
+
+            groups
+        }
+    }
+
+    fn gen_base_stats(tbl_paths: Vec<PathBuf>) -> anyhow::Result<DataFusionBaseTableStats> {
         let base_table_stats = Mutex::new(DataFusionBaseTableStats::default());
         let now = Instant::now();
 
@@ -367,25 +388,19 @@ impl DatafusionDBMS {
             let tbl_name = TpchKit::get_tbl_name_from_tbl_fpath(tbl_fpath);
             let start = Instant::now();
 
-            let schema = block_on(async {
-                ctx.catalog("datafusion")
-                    .unwrap()
-                    .schema("public")
-                    .unwrap()
-                    .table(&tbl_name)
-                    .await
-                    .unwrap()
-                    .schema()
-            });
+            let tbl_file = File::open(tbl_fpath).expect("Failed to open file");
+            let parquet =
+                ParquetRecordBatchReaderBuilder::try_new(tbl_file.try_clone().unwrap()).unwrap();
+            let schema = parquet.schema();
 
             let nb_cols = schema.fields().len();
             let single_cols = (0..nb_cols).map(|v| vec![v]).collect::<Vec<_>>();
 
             let stats_result = DataFusionPerTableStats::from_record_batches(
-                Self::create_batch_channel(tbl_fpath.clone()),
-                Self::create_batch_channel(tbl_fpath.clone()),
+                Self::build_batch_reader(tbl_fpath.clone(), parquet.metadata().num_row_groups()),
+                Self::build_batch_reader(tbl_fpath.clone(), parquet.metadata().num_row_groups()),
                 single_cols,
-                schema,
+                schema.clone(),
             );
 
             if let Ok(per_table_stats) = stats_result {
@@ -403,35 +418,6 @@ impl DatafusionDBMS {
         println!("Total execution time {:?}...", now.elapsed());
 
         Ok(base_table_stats.into_inner()?)
-    }
-
-    fn create_batch_channel(
-        tbl_fpath: PathBuf,
-    ) -> impl FnOnce() -> (JoinHandle<()>, Receiver<Result<RecordBatch, ArrowError>>) {
-        move || {
-            let (sender, receiver) = mpsc::channel();
-
-            let handle = thread::spawn(move || {
-                // Get the number of row groups.
-                let tbl_file = File::open(tbl_fpath).expect("Failed to open file");
-                let builder =
-                    ParquetRecordBatchReaderBuilder::try_new(tbl_file.try_clone().unwrap())
-                        .unwrap();
-                let num_row_groups = builder.metadata().num_row_groups();
-
-                // Read row groups in parallel.
-                (0..num_row_groups).into_par_iter().for_each(|i| {
-                    ParquetRecordBatchReaderBuilder::try_new(tbl_file.try_clone().unwrap())
-                        .unwrap()
-                        .with_row_groups(vec![i])
-                        .build()
-                        .unwrap()
-                        .for_each(|batch| sender.send(batch).expect("Failed to send batch"))
-                });
-            });
-
-            (handle, receiver)
-        }
     }
 
     async fn get_tpch_stats(
@@ -456,7 +442,7 @@ impl DatafusionDBMS {
 
         // Compute base statistics.
         let tbl_paths = tpch_kit.get_tbl_fpath_vec(tpch_kit_config)?;
-        Self::gen_base_stats(tbl_paths, ctx)
+        Self::gen_base_stats(tbl_paths)
     }
 
     async fn get_job_stats(
@@ -480,8 +466,8 @@ impl DatafusionDBMS {
         }
 
         // Compute base statistics.
-        let tbl_paths = job_kit.get_tbl_fpath_vec("parquet").unwrap();
-        Self::gen_base_stats(tbl_paths, ctx)
+        let tbl_paths = job_kit.get_tbl_fpath_vec("parquet").unwrap(); // TODO(Alexis): URGENT FIX make this modular!
+        Self::gen_base_stats(tbl_paths)
     }
 }
 

--- a/optd-perftest/src/datafusion_dbms.rs
+++ b/optd-perftest/src/datafusion_dbms.rs
@@ -13,11 +13,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use datafusion::{
-    arrow::{
-        array::RecordBatch,
-        error::ArrowError,
-        util::display::{ArrayFormatter, FormatOptions},
-    },
+    arrow::util::display::{ArrayFormatter, FormatOptions},
     execution::{
         config::SessionConfig,
         context::{SessionContext, SessionState},
@@ -27,7 +23,6 @@ use datafusion::{
 };
 
 use datafusion_optd_cli::helper::unescape_input;
-use flume::Receiver;
 use lazy_static::lazy_static;
 use optd_datafusion_bridge::{DatafusionCatalog, OptdQueryPlanner};
 use optd_datafusion_repr::{
@@ -313,7 +308,7 @@ impl DatafusionDBMS {
         self.create_tpch_tables(&tpch_kit).await?;
 
         // Load the data by creating an external table first and copying the data to real tables.
-        let tbl_fpath_iter = tpch_kit.get_tbl_fpath_vec(tpch_kit_config).unwrap();
+        let tbl_fpath_iter = tpch_kit.get_tbl_fpath_vec(tpch_kit_config, "tbl").unwrap();
         for tbl_fpath in tbl_fpath_iter {
             let tbl_name = tbl_fpath.file_stem().unwrap().to_str().unwrap();
             Self::execute(
@@ -358,7 +353,6 @@ impl DatafusionDBMS {
         tbl_fpath: PathBuf,
         num_row_groups: usize,
     ) -> impl FnOnce() -> Vec<ParquetRecordBatchReader> {
-        println!("{:#?}", num_row_groups);
         move || {
             let groups: Vec<ParquetRecordBatchReader> = (0..num_row_groups)
                 .map(|group_num| {
@@ -388,6 +382,9 @@ impl DatafusionDBMS {
             let tbl_name = TpchKit::get_tbl_name_from_tbl_fpath(tbl_fpath);
             let start = Instant::now();
 
+            // We get the schema from the Parquet file, to ensure there's no divergence between
+            // the context and the file we are going to read.
+            // Further rounds of refactoring should adapt the entry point of stat gen.
             let tbl_file = File::open(tbl_fpath).expect("Failed to open file");
             let parquet =
                 ParquetRecordBatchReaderBuilder::try_new(tbl_file.try_clone().unwrap()).unwrap();
@@ -440,8 +437,8 @@ impl DatafusionDBMS {
             Self::execute(&ctx, ddl).await?;
         }
 
-        // Compute base statistics.
-        let tbl_paths = tpch_kit.get_tbl_fpath_vec(tpch_kit_config)?;
+        // Compute base statistics on Parquet.
+        let tbl_paths = tpch_kit.get_tbl_fpath_vec(tpch_kit_config, "parquet")?;
         Self::gen_base_stats(tbl_paths)
     }
 
@@ -465,8 +462,8 @@ impl DatafusionDBMS {
             Self::execute(&ctx, ddl).await?;
         }
 
-        // Compute base statistics.
-        let tbl_paths = job_kit.get_tbl_fpath_vec("parquet").unwrap(); // TODO(Alexis): URGENT FIX make this modular!
+        // Compute base statistics on Parquet.
+        let tbl_paths = job_kit.get_tbl_fpath_vec("parquet").unwrap();
         Self::gen_base_stats(tbl_paths)
     }
 }

--- a/optd-perftest/src/datafusion_dbms.rs
+++ b/optd-perftest/src/datafusion_dbms.rs
@@ -18,9 +18,7 @@ use crate::{
 use async_trait::async_trait;
 use datafusion::{
     arrow::{
-        array::{RecordBatch, RecordBatchIterator},
-        csv::ReaderBuilder,
-        datatypes::SchemaRef,
+        array::RecordBatch,
         error::ArrowError,
         util::display::{ArrayFormatter, FormatOptions},
     },
@@ -31,6 +29,7 @@ use datafusion::{
     },
     sql::{parser::DFParser, sqlparser::dialect::GenericDialect},
 };
+
 use datafusion_optd_cli::helper::unescape_input;
 use futures::executor::block_on;
 use lazy_static::lazy_static;
@@ -39,6 +38,7 @@ use optd_datafusion_repr::{
     cost::{DataFusionBaseTableStats, DataFusionPerTableStats},
     DatafusionOptimizer,
 };
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use rayon::prelude::*;
 use regex::Regex;
 
@@ -359,7 +359,6 @@ impl DatafusionDBMS {
     fn gen_base_stats(
         tbl_paths: Vec<PathBuf>,
         ctx: SessionContext,
-        delim: u8,
     ) -> anyhow::Result<DataFusionBaseTableStats> {
         let base_table_stats = Mutex::new(DataFusionBaseTableStats::default());
         let now = Instant::now();
@@ -383,8 +382,8 @@ impl DatafusionDBMS {
             let single_cols = (0..nb_cols).map(|v| vec![v]).collect::<Vec<_>>();
 
             let stats_result = DataFusionPerTableStats::from_record_batches(
-                Self::create_batch_channel(tbl_fpath.clone(), schema.clone(), delim),
-                Self::create_batch_channel(tbl_fpath.clone(), schema.clone(), delim),
+                Self::create_batch_channel(tbl_fpath.clone()),
+                Self::create_batch_channel(tbl_fpath.clone()),
                 single_cols,
                 schema,
             );
@@ -408,26 +407,27 @@ impl DatafusionDBMS {
 
     fn create_batch_channel(
         tbl_fpath: PathBuf,
-        schema: SchemaRef,
-        delim: u8,
     ) -> impl FnOnce() -> (JoinHandle<()>, Receiver<Result<RecordBatch, ArrowError>>) {
         move || {
             let (sender, receiver) = mpsc::channel();
 
             let handle = thread::spawn(move || {
+                // Get the number of row groups.
                 let tbl_file = File::open(tbl_fpath).expect("Failed to open file");
-                let csv_reader = ReaderBuilder::new(schema.clone())
-                    .has_header(false)
-                    .with_delimiter(delim)
-                    .with_escape(b'\\')
-                    .with_batch_size(1024)
-                    .build(tbl_file)
-                    .expect("Failed to build CSV reader");
+                let builder =
+                    ParquetRecordBatchReaderBuilder::try_new(tbl_file.try_clone().unwrap())
+                        .unwrap();
+                let num_row_groups = builder.metadata().num_row_groups();
 
-                let batch_iter = RecordBatchIterator::new(csv_reader, schema);
-                for batch in batch_iter {
-                    sender.send(batch).expect("Failed to send batch");
-                }
+                // Read row groups in parallel.
+                (0..num_row_groups).into_par_iter().for_each(|i| {
+                    ParquetRecordBatchReaderBuilder::try_new(tbl_file.try_clone().unwrap())
+                        .unwrap()
+                        .with_row_groups(vec![i])
+                        .build()
+                        .unwrap()
+                        .for_each(|batch| sender.send(batch).expect("Failed to send batch"))
+                });
             });
 
             (handle, receiver)
@@ -456,7 +456,7 @@ impl DatafusionDBMS {
 
         // Compute base statistics.
         let tbl_paths = tpch_kit.get_tbl_fpath_vec(tpch_kit_config)?;
-        Self::gen_base_stats(tbl_paths, ctx, b'|')
+        Self::gen_base_stats(tbl_paths, ctx)
     }
 
     async fn get_job_stats(
@@ -480,8 +480,8 @@ impl DatafusionDBMS {
         }
 
         // Compute base statistics.
-        let tbl_paths = job_kit.get_tbl_fpath_vec().unwrap();
-        Self::gen_base_stats(tbl_paths, ctx, b',')
+        let tbl_paths = job_kit.get_tbl_fpath_vec("parquet").unwrap();
+        Self::gen_base_stats(tbl_paths, ctx)
     }
 }
 

--- a/optd-perftest/src/datafusion_dbms.rs
+++ b/optd-perftest/src/datafusion_dbms.rs
@@ -1,7 +1,11 @@
 use std::{
     fs::{self, File},
     path::{Path, PathBuf},
-    sync::{Arc, Mutex},
+    sync::{
+        mpsc::{self, Receiver},
+        Arc, Mutex,
+    },
+    thread::{self, JoinHandle},
     time::Instant,
 };
 
@@ -14,8 +18,10 @@ use crate::{
 use async_trait::async_trait;
 use datafusion::{
     arrow::{
-        array::RecordBatchIterator,
+        array::{RecordBatch, RecordBatchIterator},
         csv::ReaderBuilder,
+        datatypes::SchemaRef,
+        error::ArrowError,
         util::display::{ArrayFormatter, FormatOptions},
     },
     execution::{
@@ -309,7 +315,7 @@ impl DatafusionDBMS {
         self.create_tpch_tables(&tpch_kit).await?;
 
         // Load the data by creating an external table first and copying the data to real tables.
-        let tbl_fpath_iter = tpch_kit.get_tbl_fpath_iter(tpch_kit_config).unwrap();
+        let tbl_fpath_iter = tpch_kit.get_tbl_fpath_vec(tpch_kit_config).unwrap();
         for tbl_fpath in tbl_fpath_iter {
             let tbl_name = tbl_fpath.file_stem().unwrap().to_str().unwrap();
             Self::execute(
@@ -350,6 +356,84 @@ impl DatafusionDBMS {
         Ok(())
     }
 
+    fn gen_base_stats(
+        tbl_paths: Vec<PathBuf>,
+        ctx: SessionContext,
+        delim: u8,
+    ) -> anyhow::Result<DataFusionBaseTableStats> {
+        let base_table_stats = Mutex::new(DataFusionBaseTableStats::default());
+        let now = Instant::now();
+
+        tbl_paths.par_iter().for_each(|tbl_fpath| {
+            let tbl_name = TpchKit::get_tbl_name_from_tbl_fpath(tbl_fpath);
+            let start = Instant::now();
+
+            let schema = block_on(async {
+                ctx.catalog("datafusion")
+                    .unwrap()
+                    .schema("public")
+                    .unwrap()
+                    .table(&tbl_name)
+                    .await
+                    .unwrap()
+                    .schema()
+            });
+
+            let nb_cols = schema.fields().len();
+            let single_cols = (0..nb_cols).map(|v| vec![v]).collect::<Vec<_>>();
+
+            let stats_result = DataFusionPerTableStats::from_record_batches(
+                Self::create_batch_channel(tbl_fpath.clone(), schema.clone(), delim),
+                Self::create_batch_channel(tbl_fpath.clone(), schema.clone(), delim),
+                single_cols,
+                schema,
+            );
+
+            if let Ok(per_table_stats) = stats_result {
+                let mut stats = base_table_stats.lock().unwrap();
+                stats.insert(tbl_name.to_string(), per_table_stats);
+            }
+
+            println!(
+                "Table {:?} took in total {:?}...",
+                tbl_name,
+                start.elapsed()
+            );
+        });
+
+        println!("Total execution time {:?}...", now.elapsed());
+
+        Ok(base_table_stats.into_inner()?)
+    }
+
+    fn create_batch_channel(
+        tbl_fpath: PathBuf,
+        schema: SchemaRef,
+        delim: u8,
+    ) -> impl FnOnce() -> (JoinHandle<()>, Receiver<Result<RecordBatch, ArrowError>>) {
+        move || {
+            let (sender, receiver) = mpsc::channel();
+
+            let handle = thread::spawn(move || {
+                let tbl_file = File::open(tbl_fpath).expect("Failed to open file");
+                let csv_reader = ReaderBuilder::new(schema.clone())
+                    .has_header(false)
+                    .with_delimiter(delim)
+                    .with_escape(b'\\')
+                    .with_batch_size(1024)
+                    .build(tbl_file)
+                    .expect("Failed to build CSV reader");
+
+                let batch_iter = RecordBatchIterator::new(csv_reader, schema);
+                for batch in batch_iter {
+                    sender.send(batch).expect("Failed to send batch");
+                }
+            });
+
+            (handle, receiver)
+        }
+    }
+
     async fn get_tpch_stats(
         &mut self,
         tpch_kit_config: &TpchKitConfig,
@@ -370,44 +454,9 @@ impl DatafusionDBMS {
             Self::execute(&ctx, ddl).await?;
         }
 
-        // Build the DataFusionBaseTableStats object.
-        let mut base_table_stats = DataFusionBaseTableStats::default();
-        for tbl_fpath in tpch_kit.get_tbl_fpath_iter(tpch_kit_config).unwrap() {
-            let tbl_name = TpchKit::get_tbl_name_from_tbl_fpath(&tbl_fpath);
-            let schema = ctx
-                .catalog("datafusion")
-                .unwrap()
-                .schema("public")
-                .unwrap()
-                .table(&tbl_name)
-                .await
-                .unwrap()
-                .schema();
-
-            let nb_cols = schema.fields().len();
-            let single_cols = (0..nb_cols).map(|v| vec![v]);
-            /*let pairwise_cols = iproduct!(0..nb_cols, 0..nb_cols)
-            .filter(|(i, j)| i != j)
-            .map(|(i, j)| vec![i, j]);*/
-
-            base_table_stats.insert(
-                tbl_name.to_string(),
-                DataFusionPerTableStats::from_record_batches(
-                    || {
-                        let tbl_file = fs::File::open(&tbl_fpath)?;
-                        let csv_reader1 = ReaderBuilder::new(schema.clone())
-                            .has_header(false)
-                            .with_delimiter(b'|')
-                            .build(tbl_file)
-                            .unwrap();
-                        Ok(RecordBatchIterator::new(csv_reader1, schema.clone()))
-                    },
-                    single_cols.collect(),
-                )?,
-            );
-        }
-
-        Ok(base_table_stats)
+        // Compute base statistics.
+        let tbl_paths = tpch_kit.get_tbl_fpath_vec(tpch_kit_config)?;
+        Self::gen_base_stats(tbl_paths, ctx, b'|')
     }
 
     async fn get_job_stats(
@@ -430,64 +479,9 @@ impl DatafusionDBMS {
             Self::execute(&ctx, ddl).await?;
         }
 
-        let now = Instant::now();
-
-        // Build the DataFusionBaseTableStats object.
-        let base_table_stats = Mutex::new(DataFusionBaseTableStats::default());
+        // Compute base statistics.
         let tbl_paths = job_kit.get_tbl_fpath_vec().unwrap();
-
-        tbl_paths.par_iter().for_each(|tbl_fpath| {
-            let tbl_name = JobKit::get_tbl_name_from_tbl_fpath(tbl_fpath);
-            let start = Instant::now();
-
-            let schema = block_on(async {
-                ctx.catalog("datafusion")
-                    .unwrap()
-                    .schema("public")
-                    .unwrap()
-                    .table(&tbl_name)
-                    .await
-                    .unwrap()
-                    .schema()
-            });
-            println!(
-                "Table {:?} starting after {:?}...",
-                tbl_name,
-                start.elapsed()
-            );
-
-            let nb_cols = schema.fields().len();
-            let single_cols = (0..nb_cols).map(|v| vec![v]).collect::<Vec<_>>();
-
-            let stats_result = DataFusionPerTableStats::from_record_batches(
-                || {
-                    let tbl_file = fs::File::open(tbl_fpath)?;
-                    let csv_reader1 = ReaderBuilder::new(schema.clone())
-                        .has_header(false)
-                        .with_delimiter(b',')
-                        .with_escape(b'\\')
-                        .with_batch_size(1024)
-                        .build(tbl_file)
-                        .unwrap();
-                    Ok(RecordBatchIterator::new(csv_reader1, schema.clone()))
-                },
-                single_cols,
-            );
-
-            if let Ok(per_table_stats) = stats_result {
-                let mut stats = base_table_stats.lock().unwrap();
-                stats.insert(tbl_name.to_string(), per_table_stats);
-            }
-
-            println!(
-                "Table {:?} took in total {:?}...",
-                tbl_name,
-                start.elapsed()
-            );
-        });
-
-        println!("Total execution time {:?}...", now.elapsed());
-        Ok(base_table_stats.into_inner().unwrap())
+        Self::gen_base_stats(tbl_paths, ctx, b',')
     }
 }
 

--- a/optd-perftest/src/datafusion_dbms.rs
+++ b/optd-perftest/src/datafusion_dbms.rs
@@ -1,7 +1,8 @@
 use std::{
     fs::{self, File},
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, Mutex},
+    time::Instant,
 };
 
 use crate::{
@@ -25,13 +26,16 @@ use datafusion::{
     sql::{parser::DFParser, sqlparser::dialect::GenericDialect},
 };
 use datafusion_optd_cli::helper::unescape_input;
+use futures::executor::block_on;
 use lazy_static::lazy_static;
 use optd_datafusion_bridge::{DatafusionCatalog, OptdQueryPlanner};
 use optd_datafusion_repr::{
     cost::{DataFusionBaseTableStats, DataFusionPerTableStats},
     DatafusionOptimizer,
 };
+use rayon::prelude::*;
 use regex::Regex;
+
 pub struct DatafusionDBMS {
     workspace_dpath: PathBuf,
     rebuild_cached_stats: bool,
@@ -383,8 +387,8 @@ impl DatafusionDBMS {
             let nb_cols = schema.fields().len();
             let single_cols = (0..nb_cols).map(|v| vec![v]);
             /*let pairwise_cols = iproduct!(0..nb_cols, 0..nb_cols)
-                .filter(|(i, j)| i != j)
-                .map(|(i, j)| vec![i, j]);*/
+            .filter(|(i, j)| i != j)
+            .map(|(i, j)| vec![i, j]);*/
 
             base_table_stats.insert(
                 tbl_name.to_string(),
@@ -393,7 +397,6 @@ impl DatafusionDBMS {
                         let tbl_file = fs::File::open(&tbl_fpath)?;
                         let csv_reader1 = ReaderBuilder::new(schema.clone())
                             .has_header(false)
-                            .with_batch_size(1024)
                             .with_delimiter(b'|')
                             .build(tbl_file)
                             .unwrap();
@@ -411,7 +414,7 @@ impl DatafusionDBMS {
         &mut self,
         job_kit_config: &JobKitConfig,
     ) -> anyhow::Result<DataFusionBaseTableStats> {
-        // Generate the tables
+        // Generate the tables.
         let job_kit = JobKit::build(&self.workspace_dpath)?;
         job_kit.download_tables(job_kit_config)?;
 
@@ -427,48 +430,63 @@ impl DatafusionDBMS {
             Self::execute(&ctx, ddl).await?;
         }
 
+        let now = Instant::now();
+
         // Build the DataFusionBaseTableStats object.
-        let mut base_table_stats = DataFusionBaseTableStats::default();
-        let now = std::time::Instant::now();
-        for tbl_fpath in job_kit.get_tbl_fpath_iter().unwrap() {
+        let base_table_stats = Mutex::new(DataFusionBaseTableStats::default());
+        let tbl_paths = job_kit.get_tbl_fpath_vec().unwrap();
+
+        tbl_paths.par_iter().for_each(|tbl_fpath| {
             let tbl_name = JobKit::get_tbl_name_from_tbl_fpath(&tbl_fpath);
-            let schema = ctx
-                .catalog("datafusion")
-                .unwrap()
-                .schema("public")
-                .unwrap()
-                .table(&tbl_name)
-                .await
-                .unwrap()
-                .schema();
+            let start = Instant::now();
+
+            let schema = block_on(async {
+                ctx.catalog("datafusion")
+                    .unwrap()
+                    .schema("public")
+                    .unwrap()
+                    .table(&tbl_name)
+                    .await
+                    .unwrap()
+                    .schema()
+            });
+            println!(
+                "Table {:?} starting after {:?}...",
+                tbl_name,
+                start.elapsed()
+            );
 
             let nb_cols = schema.fields().len();
-            let single_cols = (0..nb_cols).map(|v| vec![v]);
-            /*let pairwise_cols = iproduct!(0..nb_cols, 0..nb_cols)
-                .filter(|(i, j)| i != j)
-                .map(|(i, j)| vec![i, j]);*/
+            let single_cols = (0..nb_cols).map(|v| vec![v]).collect::<Vec<_>>();
 
-            base_table_stats.insert(
-                tbl_name.to_string(),
-                DataFusionPerTableStats::from_record_batches(
-                    || {
-                        let tbl_file = fs::File::open(&tbl_fpath)?;
-                        let csv_reader1 = ReaderBuilder::new(schema.clone())
-                            .has_header(false)
-                            .with_batch_size(65536)
-                            .with_delimiter(b',')
-                            .with_escape(b'\\')
-                            .build(tbl_file)
-                            .unwrap();
-                        Ok(RecordBatchIterator::new(csv_reader1, schema.clone()))
-                    },
-                    single_cols.collect(),
-                )?,
+            let stats_result = DataFusionPerTableStats::from_record_batches(
+                || {
+                    let tbl_file = fs::File::open(&tbl_fpath)?;
+                    let csv_reader1 = ReaderBuilder::new(schema.clone())
+                        .has_header(false)
+                        .with_delimiter(b',')
+                        .with_escape(b'\\')
+                        .build(tbl_file)
+                        .unwrap();
+                    Ok(RecordBatchIterator::new(csv_reader1, schema.clone()))
+                },
+                single_cols,
             );
-        }
-        println!("Gungnir took {:?}", now.elapsed());
 
-        Ok(base_table_stats)
+            if let Ok(per_table_stats) = stats_result {
+                let mut stats = base_table_stats.lock().unwrap();
+                stats.insert(tbl_name.to_string(), per_table_stats);
+            }
+
+            println!(
+                "Table {:?} took in total {:?}...",
+                tbl_name,
+                start.elapsed()
+            );
+        });
+
+        println!("Total execution time {:?}...", now.elapsed());
+        Ok(base_table_stats.into_inner().unwrap())
     }
 }
 

--- a/optd-perftest/src/job.rs
+++ b/optd-perftest/src/job.rs
@@ -137,15 +137,30 @@ impl JobKit {
             .to_string()
     }
 
-    /// Get an iterator through all generated .tbl files of a given config
-    pub fn get_tbl_fpath_iter(&self) -> io::Result<impl Iterator<Item = PathBuf>> {
+    /// Get a vector of all generated .csv files in a given directory path
+    pub fn get_tbl_fpath_vec(&self) -> io::Result<Vec<PathBuf>> {
         let dirent_iter = fs::read_dir(&self.downloaded_tables_dpath)?;
-        // all results/options are fine to be unwrapped except for path.extension() because that could
-        // return None in various cases
-        let path_iter = dirent_iter.map(|dirent| dirent.unwrap().path());
-        let tbl_fpath_iter = path_iter
-            .filter(|path| path.extension().map(|ext| ext.to_str().unwrap()) == Some("csv"));
-        Ok(tbl_fpath_iter)
+
+        let entries: Vec<_> = dirent_iter.collect::<Result<Vec<_>, io::Error>>()?;
+
+        let tbl_fpaths: Vec<_> = entries
+            .into_iter()
+            .filter_map(|dirent| {
+                let path = dirent.path();
+                if path
+                    .extension()
+                    .and_then(|ext| ext.to_str())
+                    .map(|ext| ext == "csv")
+                    .unwrap_or(false)
+                {
+                    Some(path)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        Ok(tbl_fpaths)
     }
 
     /// Get an iterator through all generated .sql files _in order_ of a given config

--- a/optd-perftest/src/job.rs
+++ b/optd-perftest/src/job.rs
@@ -138,7 +138,7 @@ impl JobKit {
     }
 
     /// Get a vector of all generated .csv files in a given directory path
-    pub fn get_tbl_fpath_vec(&self) -> io::Result<Vec<PathBuf>> {
+    pub fn get_tbl_fpath_vec(&self, target_ext: &str) -> io::Result<Vec<PathBuf>> {
         let dirent_iter = fs::read_dir(&self.downloaded_tables_dpath)?;
 
         let entries: Vec<_> = dirent_iter.collect::<Result<Vec<_>, io::Error>>()?;
@@ -150,7 +150,7 @@ impl JobKit {
                 if path
                     .extension()
                     .and_then(|ext| ext.to_str())
-                    .map(|ext| ext == "csv")
+                    .map(|ext| ext == target_ext)
                     .unwrap_or(false)
                 {
                     Some(path)

--- a/optd-perftest/src/postgres_dbms.rs
+++ b/optd-perftest/src/postgres_dbms.rs
@@ -158,7 +158,7 @@ impl PostgresDBMS {
 
         // load the tables
         tpch_kit.gen_tables(tpch_kit_config)?;
-        for tbl_fpath in tpch_kit.get_tbl_fpath_iter(tpch_kit_config)? {
+        for tbl_fpath in tpch_kit.get_tbl_fpath_vec(tpch_kit_config)? {
             Self::copy_from_stdin(client, tbl_fpath, "|", "\\").await?;
         }
 

--- a/optd-perftest/src/postgres_dbms.rs
+++ b/optd-perftest/src/postgres_dbms.rs
@@ -158,7 +158,7 @@ impl PostgresDBMS {
 
         // load the tables
         tpch_kit.gen_tables(tpch_kit_config)?;
-        for tbl_fpath in tpch_kit.get_tbl_fpath_vec(tpch_kit_config)? {
+        for tbl_fpath in tpch_kit.get_tbl_fpath_vec(tpch_kit_config, "tbl")? {
             Self::copy_from_stdin(client, tbl_fpath, "|", "\\").await?;
         }
 

--- a/optd-perftest/src/postgres_dbms.rs
+++ b/optd-perftest/src/postgres_dbms.rs
@@ -193,7 +193,7 @@ impl PostgresDBMS {
 
         // load the tables
         job_kit.download_tables(job_kit_config)?;
-        for tbl_fpath in job_kit.get_tbl_fpath_vec()? {
+        for tbl_fpath in job_kit.get_tbl_fpath_vec("csv")? {
             Self::copy_from_stdin(client, tbl_fpath, ",", "\\").await?;
         }
 

--- a/optd-perftest/src/postgres_dbms.rs
+++ b/optd-perftest/src/postgres_dbms.rs
@@ -193,7 +193,7 @@ impl PostgresDBMS {
 
         // load the tables
         job_kit.download_tables(job_kit_config)?;
-        for tbl_fpath in job_kit.get_tbl_fpath_iter()? {
+        for tbl_fpath in job_kit.get_tbl_fpath_vec()? {
             Self::copy_from_stdin(client, tbl_fpath, ",", "\\").await?;
         }
 

--- a/optd-perftest/src/tpch.rs
+++ b/optd-perftest/src/tpch.rs
@@ -209,7 +209,7 @@ impl TpchKit {
     }
 
     /// Get a vector of all generated .tbl files of a given config
-    pub fn get_tbl_fpath_vec(&self, tpch_kit_config: &TpchKitConfig) -> io::Result<Vec<PathBuf>> {
+    pub fn get_tbl_fpath_vec(&self, tpch_kit_config: &TpchKitConfig, target_ext: &str) -> io::Result<Vec<PathBuf>> {
         let this_genned_tables_dpath = self.get_this_genned_tables_dpath(tpch_kit_config);
         let dirent_iter = fs::read_dir(this_genned_tables_dpath)?;
 
@@ -219,7 +219,7 @@ impl TpchKit {
             .filter(|path| {
                 path.extension()
                     .and_then(|ext| ext.to_str())
-                    .map(|ext| ext == "tbl")
+                    .map(|ext| ext == target_ext)
                     .unwrap_or(false)
             })
             .collect();

--- a/optd-perftest/src/tpch.rs
+++ b/optd-perftest/src/tpch.rs
@@ -209,7 +209,11 @@ impl TpchKit {
     }
 
     /// Get a vector of all generated .tbl files of a given config
-    pub fn get_tbl_fpath_vec(&self, tpch_kit_config: &TpchKitConfig, target_ext: &str) -> io::Result<Vec<PathBuf>> {
+    pub fn get_tbl_fpath_vec(
+        &self,
+        tpch_kit_config: &TpchKitConfig,
+        target_ext: &str,
+    ) -> io::Result<Vec<PathBuf>> {
         let this_genned_tables_dpath = self.get_this_genned_tables_dpath(tpch_kit_config);
         let dirent_iter = fs::read_dir(this_genned_tables_dpath)?;
 

--- a/optd-perftest/src/tpch.rs
+++ b/optd-perftest/src/tpch.rs
@@ -208,19 +208,23 @@ impl TpchKit {
             .to_string()
     }
 
-    /// Get an iterator through all generated .tbl files of a given config
-    pub fn get_tbl_fpath_iter(
-        &self,
-        tpch_kit_config: &TpchKitConfig,
-    ) -> io::Result<impl Iterator<Item = PathBuf>> {
+    /// Get a vector of all generated .tbl files of a given config
+    pub fn get_tbl_fpath_vec(&self, tpch_kit_config: &TpchKitConfig) -> io::Result<Vec<PathBuf>> {
         let this_genned_tables_dpath = self.get_this_genned_tables_dpath(tpch_kit_config);
         let dirent_iter = fs::read_dir(this_genned_tables_dpath)?;
-        // all results/options are fine to be unwrapped except for path.extension() because that could
-        // return None in various cases
-        let path_iter = dirent_iter.map(|dirent| dirent.unwrap().path());
-        let tbl_fpath_iter = path_iter
-            .filter(|path| path.extension().map(|ext| ext.to_str().unwrap()) == Some("tbl"));
-        Ok(tbl_fpath_iter)
+
+        let tbl_fpath_vec: Vec<PathBuf> = dirent_iter
+            .filter_map(|dirent| dirent.ok())
+            .map(|dirent| dirent.path())
+            .filter(|path| {
+                path.extension()
+                    .and_then(|ext| ext.to_str())
+                    .map(|ext| ext == "tbl")
+                    .unwrap_or(false)
+            })
+            .collect();
+
+        Ok(tbl_fpath_vec)
     }
 
     /// Get an iterator through all generated .sql files _in order_ of a given config


### PR DESCRIPTION
Made the stat generation faster using Rayon's thread pool.

Various improvements, such as;
- slightly less copying
- optimized MG
- process in parallel using Rayon, taking advantage of fold/reduce
- moved to Parquet (WIP to convert into Parquet automatically)
- read Parquet in parallel (one reader for each row-group), this granularity is sufficient for big enough datasets

This takes 30s for JOB 1D stats on my computer, vs 7:30min before.
Postgres takes 1:30min loading, and 22s for the stat gen. So we beat it, depending on how we view it.

On "real" datacenter hardware (i.e. 512 cores), we would **crush** it, we'll test that soon.

Finally coming together :-)