### PR TITLE
feat: infer equal columns from the query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4610,7 +4610,7 @@ checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 [[package]]
 name = "union-find"
 version = "0.1.0"
-source = "git+https://github.com/Gun9niR/union-find-rs.git?rev=31d2ed78c9ca6cd439bbba53b329bdbd7a52da4b#31d2ed78c9ca6cd439bbba53b329bdbd7a52da4b"
+source = "git+https://github.com/Gun9niR/union-find-rs.git?rev=3ffda352c2c3d9a74daed1546c0e71c97b732bf1#3ffda352c2c3d9a74daed1546c0e71c97b732bf1"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4610,7 +4610,7 @@ checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 [[package]]
 name = "union-find"
 version = "0.1.0"
-source = "git+https://github.com/Gun9niR/union-find-rs.git?rev=8ea75baced5e15ea0765f899930e21d8caf0dd17#8ea75baced5e15ea0765f899930e21d8caf0dd17"
+source = "git+https://github.com/Gun9niR/union-find-rs.git?rev=31d2ed78c9ca6cd439bbba53b329bdbd7a52da4b#31d2ed78c9ca6cd439bbba53b329bdbd7a52da4b"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2852,6 +2852,7 @@ dependencies = [
  "serde_with",
  "tracing",
  "tracing-subscriber",
+ "union-find",
 ]
 
 [[package]]
@@ -4605,6 +4606,11 @@ name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+
+[[package]]
+name = "union-find"
+version = "0.1.0"
+source = "git+https://github.com/Gun9niR/union-find-rs.git?rev=8ea75baced5e15ea0765f899930e21d8caf0dd17#8ea75baced5e15ea0765f899930e21d8caf0dd17"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4610,7 +4610,7 @@ checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 [[package]]
 name = "union-find"
 version = "0.1.0"
-source = "git+https://github.com/Gun9niR/union-find-rs.git?rev=3ffda352c2c3d9a74daed1546c0e71c97b732bf1#3ffda352c2c3d9a74daed1546c0e71c97b732bf1"
+source = "git+https://github.com/Gun9niR/union-find-rs.git?rev=794821514f7daefcbb8d5f38ef04e62fc18b5665#794821514f7daefcbb8d5f38ef04e62fc18b5665"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/optd-datafusion-repr/Cargo.toml
+++ b/optd-datafusion-repr/Cargo.toml
@@ -25,4 +25,4 @@ assert_approx_eq = "1.1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_with = {version = "3.7.0", features = ["json"]}
 bincode = "1.3.3"
-union-find = { git = "https://github.com/Gun9niR/union-find-rs.git", rev = "31d2ed78c9ca6cd439bbba53b329bdbd7a52da4b" }
+union-find = { git = "https://github.com/Gun9niR/union-find-rs.git", rev = "3ffda352c2c3d9a74daed1546c0e71c97b732bf1" }

--- a/optd-datafusion-repr/Cargo.toml
+++ b/optd-datafusion-repr/Cargo.toml
@@ -25,3 +25,4 @@ assert_approx_eq = "1.1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_with = {version = "3.7.0", features = ["json"]}
 bincode = "1.3.3"
+union-find = { git = "https://github.com/Gun9niR/union-find-rs.git", rev = "8ea75baced5e15ea0765f899930e21d8caf0dd17" }

--- a/optd-datafusion-repr/Cargo.toml
+++ b/optd-datafusion-repr/Cargo.toml
@@ -25,4 +25,4 @@ assert_approx_eq = "1.1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_with = {version = "3.7.0", features = ["json"]}
 bincode = "1.3.3"
-union-find = { git = "https://github.com/Gun9niR/union-find-rs.git", rev = "3ffda352c2c3d9a74daed1546c0e71c97b732bf1" }
+union-find = { git = "https://github.com/Gun9niR/union-find-rs.git", rev = "794821514f7daefcbb8d5f38ef04e62fc18b5665" }

--- a/optd-datafusion-repr/Cargo.toml
+++ b/optd-datafusion-repr/Cargo.toml
@@ -25,4 +25,4 @@ assert_approx_eq = "1.1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_with = {version = "3.7.0", features = ["json"]}
 bincode = "1.3.3"
-union-find = { git = "https://github.com/Gun9niR/union-find-rs.git", rev = "8ea75baced5e15ea0765f899930e21d8caf0dd17" }
+union-find = { git = "https://github.com/Gun9niR/union-find-rs.git", rev = "31d2ed78c9ca6cd439bbba53b329bdbd7a52da4b" }

--- a/optd-datafusion-repr/src/cost/base_cost.rs
+++ b/optd-datafusion-repr/src/cost/base_cost.rs
@@ -317,6 +317,7 @@ mod tests {
 
     pub const TABLE1_NAME: &str = "table1";
     pub const TABLE2_NAME: &str = "table2";
+    pub const TABLE3_NAME: &str = "table3";
 
     // one column is sufficient for all filter selectivity tests
     pub fn create_one_column_cost_model(per_column_stats: TestPerColumnStats) -> TestOptCostModel {
@@ -340,6 +341,41 @@ mod tests {
             tbl2_per_column_stats,
             100,
             100,
+        )
+    }
+
+    /// Two columns is sufficient for all join selectivity tests
+    pub fn create_three_table_cost_model(
+        tbl1_per_column_stats: TestPerColumnStats,
+        tbl2_per_column_stats: TestPerColumnStats,
+        tbl3_per_column_stats: TestPerColumnStats,
+    ) -> TestOptCostModel {
+        OptCostModel::new(
+            vec![
+                (
+                    String::from(TABLE1_NAME),
+                    TableStats::new(
+                        100,
+                        vec![(vec![0], tbl1_per_column_stats)].into_iter().collect(),
+                    ),
+                ),
+                (
+                    String::from(TABLE2_NAME),
+                    TableStats::new(
+                        100,
+                        vec![(vec![0], tbl2_per_column_stats)].into_iter().collect(),
+                    ),
+                ),
+                (
+                    String::from(TABLE3_NAME),
+                    TableStats::new(
+                        100,
+                        vec![(vec![0], tbl3_per_column_stats)].into_iter().collect(),
+                    ),
+                ),
+            ]
+            .into_iter()
+            .collect(),
         )
     }
 

--- a/optd-datafusion-repr/src/cost/base_cost.rs
+++ b/optd-datafusion-repr/src/cost/base_cost.rs
@@ -331,7 +331,7 @@ mod tests {
         )
     }
 
-    /// Two columns is sufficient for all join selectivity tests
+    /// Create a cost model with two columns, one for each table. Each column has 100 values.
     pub fn create_two_table_cost_model(
         tbl1_per_column_stats: TestPerColumnStats,
         tbl2_per_column_stats: TestPerColumnStats,
@@ -344,7 +344,7 @@ mod tests {
         )
     }
 
-    /// Two columns is sufficient for all join selectivity tests
+    /// Create a cost model with three columns, one for each table. Each column has 100 values.
     pub fn create_three_table_cost_model(
         tbl1_per_column_stats: TestPerColumnStats,
         tbl2_per_column_stats: TestPerColumnStats,

--- a/optd-datafusion-repr/src/cost/base_cost.rs
+++ b/optd-datafusion-repr/src/cost/base_cost.rs
@@ -4,7 +4,10 @@ mod join;
 mod limit;
 pub(crate) mod stats;
 
-use crate::{plan_nodes::OptRelNodeTyp, properties::column_ref::ColumnRef};
+use crate::{
+    plan_nodes::OptRelNodeTyp,
+    properties::column_ref::{BaseTableColumnRef, ColumnRef},
+};
 use itertools::Itertools;
 use optd_core::{
     cascades::{CascadesOptimizer, RelNodeContext},
@@ -207,7 +210,7 @@ impl<
         &self,
         col_ref: &ColumnRef,
     ) -> Option<&ColumnCombValueStats<M, D>> {
-        if let ColumnRef::BaseTableColumnRef { table, col_idx } = col_ref {
+        if let ColumnRef::BaseTableColumnRef(BaseTableColumnRef { table, col_idx }) = col_ref {
             self.get_column_comb_stats(table, &[*col_idx])
         } else {
             None

--- a/optd-datafusion-repr/src/cost/base_cost/agg.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/agg.rs
@@ -8,12 +8,12 @@ use optd_core::{
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
-    cost::{
-        base_cost::stats::{Distribution, MostCommonValues},
-        base_cost::DEFAULT_NUM_DISTINCT,
+    cost::base_cost::{
+        stats::{Distribution, MostCommonValues},
+        DEFAULT_NUM_DISTINCT,
     },
     plan_nodes::{ExprList, OptRelNode, OptRelNodeTyp},
-    properties::column_ref::{ColumnRef, ColumnRefPropertyBuilder},
+    properties::column_ref::{BaseTableColumnRef, ColumnRef, ColumnRefPropertyBuilder},
 };
 
 use super::{OptCostModel, DEFAULT_UNK_SEL};
@@ -68,7 +68,7 @@ impl<
                     .iter()
                     .take(group_by.len())
                     .map(|col_ref| match col_ref {
-                        ColumnRef::BaseTableColumnRef { table, col_idx } => {
+                        ColumnRef::BaseTableColumnRef(BaseTableColumnRef { table, col_idx }) => {
                             let table_stats = self.per_table_stats_map.get(table);
                             let column_stats = table_stats.and_then(|table_stats| {
                                 table_stats.column_comb_stats.get(&vec![*col_idx])

--- a/optd-datafusion-repr/src/cost/base_cost/agg.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/agg.rs
@@ -61,9 +61,10 @@ impl<
             } else {
                 // Multiply the n-distinct of all the group by columns.
                 // TODO: improve with multi-dimensional n-distinct
-                let base_table_col_refs = optimizer
+                let group_col_refs = optimizer
                     .get_property_by_group::<ColumnRefPropertyBuilder>(context.group_id, 1);
-                base_table_col_refs
+                group_col_refs
+                    .column_refs
                     .iter()
                     .take(group_by.len())
                     .map(|col_ref| match col_ref {

--- a/optd-datafusion-repr/src/cost/base_cost/agg.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/agg.rs
@@ -64,7 +64,7 @@ impl<
                 let group_col_refs = optimizer
                     .get_property_by_group::<ColumnRefPropertyBuilder>(context.group_id, 1);
                 group_col_refs
-                    .column_refs
+                    .column_refs()
                     .iter()
                     .take(group_by.len())
                     .map(|col_ref| match col_ref {

--- a/optd-datafusion-repr/src/cost/base_cost/filter.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/filter.rs
@@ -16,7 +16,9 @@ use crate::{
         BinOpType, ColumnRefExpr, ConstantType, InListExpr, LikeExpr, LogOpType, OptRelNode,
         OptRelNodeRef, OptRelNodeTyp, UnOpType,
     },
-    properties::column_ref::{ColumnRef, ColumnRefPropertyBuilder, GroupColumnRefs},
+    properties::column_ref::{
+        BaseTableColumnRef, ColumnRef, ColumnRefPropertyBuilder, GroupColumnRefs,
+    },
 };
 
 use super::{
@@ -232,7 +234,9 @@ impl<
                 .expect("we just checked that col_ref_exprs.len() == 1");
             let col_ref_idx = col_ref_expr.index();
 
-            if let ColumnRef::BaseTableColumnRef { table, col_idx } = &column_refs[col_ref_idx] {
+            if let ColumnRef::BaseTableColumnRef(BaseTableColumnRef { table, col_idx }) =
+                &column_refs[col_ref_idx]
+            {
                 let non_col_ref_expr = non_col_ref_exprs
                     .first()
                     .expect("non_col_ref_exprs should have a value since col_ref_exprs.len() == 1");
@@ -479,10 +483,10 @@ mod tests {
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), cnst(Value::Int32(1)));
         let expr_tree_rev = bin_op(BinOpType::Eq, cnst(Value::Int32(1)), col_ref(0));
         let column_refs = GroupColumnRefs::new(
-            vec![ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            }],
+            vec![ColumnRef::base_table_column_ref(
+                String::from(TABLE1_NAME),
+                0,
+            )],
             None,
         );
         assert_approx_eq::assert_approx_eq!(
@@ -506,10 +510,10 @@ mod tests {
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), cnst(Value::Int32(2)));
         let expr_tree_rev = bin_op(BinOpType::Eq, cnst(Value::Int32(2)), col_ref(0));
         let column_refs = GroupColumnRefs::new(
-            vec![ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            }],
+            vec![ColumnRef::base_table_column_ref(
+                String::from(TABLE1_NAME),
+                0,
+            )],
             None,
         );
         assert_approx_eq::assert_approx_eq!(
@@ -533,10 +537,10 @@ mod tests {
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), cnst(Value::Int32(2)));
         let expr_tree_rev = bin_op(BinOpType::Eq, cnst(Value::Int32(2)), col_ref(0));
         let column_refs = GroupColumnRefs::new(
-            vec![ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            }],
+            vec![ColumnRef::base_table_column_ref(
+                String::from(TABLE1_NAME),
+                0,
+            )],
             None,
         );
         assert_approx_eq::assert_approx_eq!(
@@ -561,10 +565,10 @@ mod tests {
         let expr_tree = bin_op(BinOpType::Neq, col_ref(0), cnst(Value::Int32(1)));
         let expr_tree_rev = bin_op(BinOpType::Neq, cnst(Value::Int32(1)), col_ref(0));
         let column_refs = GroupColumnRefs::new(
-            vec![ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            }],
+            vec![ColumnRef::base_table_column_ref(
+                String::from(TABLE1_NAME),
+                0,
+            )],
             None,
         );
         assert_approx_eq::assert_approx_eq!(
@@ -588,10 +592,10 @@ mod tests {
         let expr_tree = bin_op(BinOpType::Leq, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Gt, cnst(Value::Int32(15)), col_ref(0));
         let column_refs = GroupColumnRefs::new(
-            vec![ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            }],
+            vec![ColumnRef::base_table_column_ref(
+                String::from(TABLE1_NAME),
+                0,
+            )],
             None,
         );
         assert_approx_eq::assert_approx_eq!(
@@ -615,10 +619,10 @@ mod tests {
         let expr_tree = bin_op(BinOpType::Leq, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Gt, cnst(Value::Int32(15)), col_ref(0));
         let column_refs = GroupColumnRefs::new(
-            vec![ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            }],
+            vec![ColumnRef::base_table_column_ref(
+                String::from(TABLE1_NAME),
+                0,
+            )],
             None,
         );
         assert_approx_eq::assert_approx_eq!(
@@ -651,10 +655,10 @@ mod tests {
         let expr_tree = bin_op(BinOpType::Leq, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Gt, cnst(Value::Int32(15)), col_ref(0));
         let column_refs = GroupColumnRefs::new(
-            vec![ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            }],
+            vec![ColumnRef::base_table_column_ref(
+                String::from(TABLE1_NAME),
+                0,
+            )],
             None,
         );
         assert_approx_eq::assert_approx_eq!(
@@ -683,10 +687,10 @@ mod tests {
         let expr_tree = bin_op(BinOpType::Leq, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Gt, cnst(Value::Int32(15)), col_ref(0));
         let column_refs = GroupColumnRefs::new(
-            vec![ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            }],
+            vec![ColumnRef::base_table_column_ref(
+                String::from(TABLE1_NAME),
+                0,
+            )],
             None,
         );
         assert_approx_eq::assert_approx_eq!(
@@ -710,10 +714,10 @@ mod tests {
         let expr_tree = bin_op(BinOpType::Lt, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Geq, cnst(Value::Int32(15)), col_ref(0));
         let column_refs = GroupColumnRefs::new(
-            vec![ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            }],
+            vec![ColumnRef::base_table_column_ref(
+                String::from(TABLE1_NAME),
+                0,
+            )],
             None,
         );
         assert_approx_eq::assert_approx_eq!(
@@ -737,10 +741,10 @@ mod tests {
         let expr_tree = bin_op(BinOpType::Lt, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Geq, cnst(Value::Int32(15)), col_ref(0));
         let column_refs = GroupColumnRefs::new(
-            vec![ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            }],
+            vec![ColumnRef::base_table_column_ref(
+                String::from(TABLE1_NAME),
+                0,
+            )],
             None,
         );
         assert_approx_eq::assert_approx_eq!(
@@ -773,10 +777,10 @@ mod tests {
         let expr_tree = bin_op(BinOpType::Lt, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Geq, cnst(Value::Int32(15)), col_ref(0));
         let column_refs = GroupColumnRefs::new(
-            vec![ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            }],
+            vec![ColumnRef::base_table_column_ref(
+                String::from(TABLE1_NAME),
+                0,
+            )],
             None,
         );
         assert_approx_eq::assert_approx_eq!(
@@ -809,10 +813,10 @@ mod tests {
         let expr_tree = bin_op(BinOpType::Lt, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Geq, cnst(Value::Int32(15)), col_ref(0));
         let column_refs = GroupColumnRefs::new(
-            vec![ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            }],
+            vec![ColumnRef::base_table_column_ref(
+                String::from(TABLE1_NAME),
+                0,
+            )],
             None,
         );
         assert_approx_eq::assert_approx_eq!(
@@ -838,10 +842,10 @@ mod tests {
         let expr_tree = bin_op(BinOpType::Gt, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Leq, cnst(Value::Int32(15)), col_ref(0));
         let column_refs = GroupColumnRefs::new(
-            vec![ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            }],
+            vec![ColumnRef::base_table_column_ref(
+                String::from(TABLE1_NAME),
+                0,
+            )],
             None,
         );
         assert_approx_eq::assert_approx_eq!(
@@ -865,10 +869,10 @@ mod tests {
         let expr_tree = bin_op(BinOpType::Gt, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Leq, cnst(Value::Int32(15)), col_ref(0));
         let column_refs = GroupColumnRefs::new(
-            vec![ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            }],
+            vec![ColumnRef::base_table_column_ref(
+                String::from(TABLE1_NAME),
+                0,
+            )],
             None,
         );
         assert_approx_eq::assert_approx_eq!(
@@ -893,10 +897,10 @@ mod tests {
         let expr_tree = bin_op(BinOpType::Geq, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Lt, cnst(Value::Int32(15)), col_ref(0));
         let column_refs = GroupColumnRefs::new(
-            vec![ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            }],
+            vec![ColumnRef::base_table_column_ref(
+                String::from(TABLE1_NAME),
+                0,
+            )],
             None,
         );
         assert_approx_eq::assert_approx_eq!(
@@ -920,10 +924,10 @@ mod tests {
         let expr_tree = bin_op(BinOpType::Geq, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Lt, cnst(Value::Int32(15)), col_ref(0));
         let column_refs = GroupColumnRefs::new(
-            vec![ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            }],
+            vec![ColumnRef::base_table_column_ref(
+                String::from(TABLE1_NAME),
+                0,
+            )],
             None,
         );
         // we have to add 0.1 since it's Geq
@@ -960,10 +964,10 @@ mod tests {
         let expr_tree_shift1 = log_op(LogOpType::And, vec![eq5.clone(), eq8.clone(), eq1.clone()]);
         let expr_tree_shift2 = log_op(LogOpType::And, vec![eq8.clone(), eq1.clone(), eq5.clone()]);
         let column_refs = GroupColumnRefs::new(
-            vec![ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            }],
+            vec![ColumnRef::base_table_column_ref(
+                String::from(TABLE1_NAME),
+                0,
+            )],
             None,
         );
         assert_approx_eq::assert_approx_eq!(
@@ -1003,10 +1007,10 @@ mod tests {
         let expr_tree_shift1 = log_op(LogOpType::Or, vec![eq5.clone(), eq8.clone(), eq1.clone()]);
         let expr_tree_shift2 = log_op(LogOpType::Or, vec![eq8.clone(), eq1.clone(), eq5.clone()]);
         let column_refs = GroupColumnRefs::new(
-            vec![ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            }],
+            vec![ColumnRef::base_table_column_ref(
+                String::from(TABLE1_NAME),
+                0,
+            )],
             None,
         );
         assert_approx_eq::assert_approx_eq!(
@@ -1036,10 +1040,10 @@ mod tests {
             bin_op(BinOpType::Eq, col_ref(0), cnst(Value::Int32(1))),
         );
         let column_refs = GroupColumnRefs::new(
-            vec![ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            }],
+            vec![ColumnRef::base_table_column_ref(
+                String::from(TABLE1_NAME),
+                0,
+            )],
             None,
         );
         assert_approx_eq::assert_approx_eq!(
@@ -1061,10 +1065,10 @@ mod tests {
             bin_op(BinOpType::Eq, col_ref(0), cnst(Value::Int32(1))),
         );
         let column_refs = GroupColumnRefs::new(
-            vec![ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            }],
+            vec![ColumnRef::base_table_column_ref(
+                String::from(TABLE1_NAME),
+                0,
+            )],
             None,
         );
         // not doesn't care about nulls. it just reverses the selectivity

--- a/optd-datafusion-repr/src/cost/base_cost/filter.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/filter.rs
@@ -459,14 +459,14 @@ mod tests {
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_filter_selectivity(
                 cnst(Value::Bool(true)),
-                &GroupColumnRefs::new(vec![], None)
+                &GroupColumnRefs::new_test(vec![], None)
             ),
             1.0
         );
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_filter_selectivity(
                 cnst(Value::Bool(false)),
-                &GroupColumnRefs::new(vec![], None)
+                &GroupColumnRefs::new_test(vec![], None)
             ),
             0.0
         );
@@ -482,7 +482,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), cnst(Value::Int32(1)));
         let expr_tree_rev = bin_op(BinOpType::Eq, cnst(Value::Int32(1)), col_ref(0));
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
                 0,
@@ -509,7 +509,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), cnst(Value::Int32(2)));
         let expr_tree_rev = bin_op(BinOpType::Eq, cnst(Value::Int32(2)), col_ref(0));
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
                 0,
@@ -536,7 +536,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), cnst(Value::Int32(2)));
         let expr_tree_rev = bin_op(BinOpType::Eq, cnst(Value::Int32(2)), col_ref(0));
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
                 0,
@@ -564,7 +564,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Neq, col_ref(0), cnst(Value::Int32(1)));
         let expr_tree_rev = bin_op(BinOpType::Neq, cnst(Value::Int32(1)), col_ref(0));
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
                 0,
@@ -591,7 +591,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Leq, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Gt, cnst(Value::Int32(15)), col_ref(0));
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
                 0,
@@ -618,7 +618,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Leq, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Gt, cnst(Value::Int32(15)), col_ref(0));
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
                 0,
@@ -654,7 +654,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Leq, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Gt, cnst(Value::Int32(15)), col_ref(0));
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
                 0,
@@ -686,7 +686,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Leq, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Gt, cnst(Value::Int32(15)), col_ref(0));
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
                 0,
@@ -713,7 +713,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Lt, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Geq, cnst(Value::Int32(15)), col_ref(0));
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
                 0,
@@ -740,7 +740,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Lt, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Geq, cnst(Value::Int32(15)), col_ref(0));
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
                 0,
@@ -776,7 +776,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Lt, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Geq, cnst(Value::Int32(15)), col_ref(0));
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
                 0,
@@ -812,7 +812,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Lt, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Geq, cnst(Value::Int32(15)), col_ref(0));
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
                 0,
@@ -841,7 +841,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Gt, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Leq, cnst(Value::Int32(15)), col_ref(0));
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
                 0,
@@ -868,7 +868,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Gt, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Leq, cnst(Value::Int32(15)), col_ref(0));
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
                 0,
@@ -896,7 +896,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Geq, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Lt, cnst(Value::Int32(15)), col_ref(0));
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
                 0,
@@ -923,7 +923,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Geq, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Lt, cnst(Value::Int32(15)), col_ref(0));
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
                 0,
@@ -963,7 +963,7 @@ mod tests {
         let expr_tree = log_op(LogOpType::And, vec![eq1.clone(), eq5.clone(), eq8.clone()]);
         let expr_tree_shift1 = log_op(LogOpType::And, vec![eq5.clone(), eq8.clone(), eq1.clone()]);
         let expr_tree_shift2 = log_op(LogOpType::And, vec![eq8.clone(), eq1.clone(), eq5.clone()]);
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
                 0,
@@ -1006,7 +1006,7 @@ mod tests {
         let expr_tree = log_op(LogOpType::Or, vec![eq1.clone(), eq5.clone(), eq8.clone()]);
         let expr_tree_shift1 = log_op(LogOpType::Or, vec![eq5.clone(), eq8.clone(), eq1.clone()]);
         let expr_tree_shift2 = log_op(LogOpType::Or, vec![eq8.clone(), eq1.clone(), eq5.clone()]);
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
                 0,
@@ -1039,7 +1039,7 @@ mod tests {
             UnOpType::Not,
             bin_op(BinOpType::Eq, col_ref(0), cnst(Value::Int32(1))),
         );
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
                 0,
@@ -1064,7 +1064,7 @@ mod tests {
             UnOpType::Not,
             bin_op(BinOpType::Eq, col_ref(0), cnst(Value::Int32(1))),
         );
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
                 0,

--- a/optd-datafusion-repr/src/cost/base_cost/filter.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/filter.rs
@@ -446,18 +446,24 @@ mod tests {
     use crate::{
         cost::base_cost::tests::*,
         plan_nodes::{BinOpType, LogOpType, UnOpType},
-        properties::column_ref::ColumnRef,
+        properties::column_ref::{ColumnRef, GroupColumnRefs},
     };
 
     #[test]
     fn test_const() {
         let cost_model = create_one_column_cost_model(get_empty_per_col_stats());
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(cnst(Value::Bool(true)), &vec![]),
+            cost_model.get_filter_selectivity(
+                cnst(Value::Bool(true)),
+                &GroupColumnRefs::new(vec![], None)
+            ),
             1.0
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(cnst(Value::Bool(false)), &vec![]),
+            cost_model.get_filter_selectivity(
+                cnst(Value::Bool(false)),
+                &GroupColumnRefs::new(vec![], None)
+            ),
             0.0
         );
     }
@@ -472,10 +478,13 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), cnst(Value::Int32(1)));
         let expr_tree_rev = bin_op(BinOpType::Eq, cnst(Value::Int32(1)), col_ref(0));
-        let column_refs = vec![ColumnRef::BaseTableColumnRef {
-            table: String::from(TABLE1_NAME),
-            col_idx: 0,
-        }];
+        let column_refs = GroupColumnRefs::new(
+            vec![ColumnRef::BaseTableColumnRef {
+                table: String::from(TABLE1_NAME),
+                col_idx: 0,
+            }],
+            None,
+        );
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_filter_selectivity(expr_tree, &column_refs),
             0.3
@@ -496,10 +505,13 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), cnst(Value::Int32(2)));
         let expr_tree_rev = bin_op(BinOpType::Eq, cnst(Value::Int32(2)), col_ref(0));
-        let column_refs = vec![ColumnRef::BaseTableColumnRef {
-            table: String::from(TABLE1_NAME),
-            col_idx: 0,
-        }];
+        let column_refs = GroupColumnRefs::new(
+            vec![ColumnRef::BaseTableColumnRef {
+                table: String::from(TABLE1_NAME),
+                col_idx: 0,
+            }],
+            None,
+        );
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_filter_selectivity(expr_tree, &column_refs),
             0.12
@@ -520,10 +532,13 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), cnst(Value::Int32(2)));
         let expr_tree_rev = bin_op(BinOpType::Eq, cnst(Value::Int32(2)), col_ref(0));
-        let column_refs = vec![ColumnRef::BaseTableColumnRef {
-            table: String::from(TABLE1_NAME),
-            col_idx: 0,
-        }];
+        let column_refs = GroupColumnRefs::new(
+            vec![ColumnRef::BaseTableColumnRef {
+                table: String::from(TABLE1_NAME),
+                col_idx: 0,
+            }],
+            None,
+        );
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_filter_selectivity(expr_tree, &column_refs),
             0.11
@@ -545,10 +560,13 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Neq, col_ref(0), cnst(Value::Int32(1)));
         let expr_tree_rev = bin_op(BinOpType::Neq, cnst(Value::Int32(1)), col_ref(0));
-        let column_refs = vec![ColumnRef::BaseTableColumnRef {
-            table: String::from(TABLE1_NAME),
-            col_idx: 0,
-        }];
+        let column_refs = GroupColumnRefs::new(
+            vec![ColumnRef::BaseTableColumnRef {
+                table: String::from(TABLE1_NAME),
+                col_idx: 0,
+            }],
+            None,
+        );
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_filter_selectivity(expr_tree, &column_refs),
             1.0 - 0.3
@@ -569,10 +587,13 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Leq, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Gt, cnst(Value::Int32(15)), col_ref(0));
-        let column_refs = vec![ColumnRef::BaseTableColumnRef {
-            table: String::from(TABLE1_NAME),
-            col_idx: 0,
-        }];
+        let column_refs = GroupColumnRefs::new(
+            vec![ColumnRef::BaseTableColumnRef {
+                table: String::from(TABLE1_NAME),
+                col_idx: 0,
+            }],
+            None,
+        );
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_filter_selectivity(expr_tree, &column_refs),
             0.7
@@ -593,10 +614,13 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Leq, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Gt, cnst(Value::Int32(15)), col_ref(0));
-        let column_refs = vec![ColumnRef::BaseTableColumnRef {
-            table: String::from(TABLE1_NAME),
-            col_idx: 0,
-        }];
+        let column_refs = GroupColumnRefs::new(
+            vec![ColumnRef::BaseTableColumnRef {
+                table: String::from(TABLE1_NAME),
+                col_idx: 0,
+            }],
+            None,
+        );
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_filter_selectivity(expr_tree, &column_refs),
             0.7 * 0.9
@@ -626,10 +650,13 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Leq, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Gt, cnst(Value::Int32(15)), col_ref(0));
-        let column_refs = vec![ColumnRef::BaseTableColumnRef {
-            table: String::from(TABLE1_NAME),
-            col_idx: 0,
-        }];
+        let column_refs = GroupColumnRefs::new(
+            vec![ColumnRef::BaseTableColumnRef {
+                table: String::from(TABLE1_NAME),
+                col_idx: 0,
+            }],
+            None,
+        );
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_filter_selectivity(expr_tree, &column_refs),
             0.85
@@ -655,10 +682,13 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Leq, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Gt, cnst(Value::Int32(15)), col_ref(0));
-        let column_refs = vec![ColumnRef::BaseTableColumnRef {
-            table: String::from(TABLE1_NAME),
-            col_idx: 0,
-        }];
+        let column_refs = GroupColumnRefs::new(
+            vec![ColumnRef::BaseTableColumnRef {
+                table: String::from(TABLE1_NAME),
+                col_idx: 0,
+            }],
+            None,
+        );
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_filter_selectivity(expr_tree, &column_refs),
             0.93
@@ -679,10 +709,13 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Lt, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Geq, cnst(Value::Int32(15)), col_ref(0));
-        let column_refs = vec![ColumnRef::BaseTableColumnRef {
-            table: String::from(TABLE1_NAME),
-            col_idx: 0,
-        }];
+        let column_refs = GroupColumnRefs::new(
+            vec![ColumnRef::BaseTableColumnRef {
+                table: String::from(TABLE1_NAME),
+                col_idx: 0,
+            }],
+            None,
+        );
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_filter_selectivity(expr_tree, &column_refs),
             0.6
@@ -703,10 +736,13 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Lt, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Geq, cnst(Value::Int32(15)), col_ref(0));
-        let column_refs = vec![ColumnRef::BaseTableColumnRef {
-            table: String::from(TABLE1_NAME),
-            col_idx: 0,
-        }];
+        let column_refs = GroupColumnRefs::new(
+            vec![ColumnRef::BaseTableColumnRef {
+                table: String::from(TABLE1_NAME),
+                col_idx: 0,
+            }],
+            None,
+        );
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_filter_selectivity(expr_tree, &column_refs),
             0.6 * 0.9
@@ -736,10 +772,13 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Lt, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Geq, cnst(Value::Int32(15)), col_ref(0));
-        let column_refs = vec![ColumnRef::BaseTableColumnRef {
-            table: String::from(TABLE1_NAME),
-            col_idx: 0,
-        }];
+        let column_refs = GroupColumnRefs::new(
+            vec![ColumnRef::BaseTableColumnRef {
+                table: String::from(TABLE1_NAME),
+                col_idx: 0,
+            }],
+            None,
+        );
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_filter_selectivity(expr_tree, &column_refs),
             0.75
@@ -769,10 +808,13 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Lt, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Geq, cnst(Value::Int32(15)), col_ref(0));
-        let column_refs = vec![ColumnRef::BaseTableColumnRef {
-            table: String::from(TABLE1_NAME),
-            col_idx: 0,
-        }];
+        let column_refs = GroupColumnRefs::new(
+            vec![ColumnRef::BaseTableColumnRef {
+                table: String::from(TABLE1_NAME),
+                col_idx: 0,
+            }],
+            None,
+        );
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_filter_selectivity(expr_tree, &column_refs),
             0.85
@@ -795,10 +837,13 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Gt, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Leq, cnst(Value::Int32(15)), col_ref(0));
-        let column_refs = vec![ColumnRef::BaseTableColumnRef {
-            table: String::from(TABLE1_NAME),
-            col_idx: 0,
-        }];
+        let column_refs = GroupColumnRefs::new(
+            vec![ColumnRef::BaseTableColumnRef {
+                table: String::from(TABLE1_NAME),
+                col_idx: 0,
+            }],
+            None,
+        );
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_filter_selectivity(expr_tree, &column_refs),
             1.0 - 0.7
@@ -819,10 +864,13 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Gt, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Leq, cnst(Value::Int32(15)), col_ref(0));
-        let column_refs = vec![ColumnRef::BaseTableColumnRef {
-            table: String::from(TABLE1_NAME),
-            col_idx: 0,
-        }];
+        let column_refs = GroupColumnRefs::new(
+            vec![ColumnRef::BaseTableColumnRef {
+                table: String::from(TABLE1_NAME),
+                col_idx: 0,
+            }],
+            None,
+        );
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_filter_selectivity(expr_tree, &column_refs),
             (1.0 - 0.7) * 0.9
@@ -844,10 +892,13 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Geq, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Lt, cnst(Value::Int32(15)), col_ref(0));
-        let column_refs = vec![ColumnRef::BaseTableColumnRef {
-            table: String::from(TABLE1_NAME),
-            col_idx: 0,
-        }];
+        let column_refs = GroupColumnRefs::new(
+            vec![ColumnRef::BaseTableColumnRef {
+                table: String::from(TABLE1_NAME),
+                col_idx: 0,
+            }],
+            None,
+        );
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_filter_selectivity(expr_tree, &column_refs),
             1.0 - 0.6
@@ -868,10 +919,13 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Geq, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Lt, cnst(Value::Int32(15)), col_ref(0));
-        let column_refs = vec![ColumnRef::BaseTableColumnRef {
-            table: String::from(TABLE1_NAME),
-            col_idx: 0,
-        }];
+        let column_refs = GroupColumnRefs::new(
+            vec![ColumnRef::BaseTableColumnRef {
+                table: String::from(TABLE1_NAME),
+                col_idx: 0,
+            }],
+            None,
+        );
         // we have to add 0.1 since it's Geq
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_filter_selectivity(expr_tree, &column_refs),
@@ -905,10 +959,13 @@ mod tests {
         let expr_tree = log_op(LogOpType::And, vec![eq1.clone(), eq5.clone(), eq8.clone()]);
         let expr_tree_shift1 = log_op(LogOpType::And, vec![eq5.clone(), eq8.clone(), eq1.clone()]);
         let expr_tree_shift2 = log_op(LogOpType::And, vec![eq8.clone(), eq1.clone(), eq5.clone()]);
-        let column_refs = vec![ColumnRef::BaseTableColumnRef {
-            table: String::from(TABLE1_NAME),
-            col_idx: 0,
-        }];
+        let column_refs = GroupColumnRefs::new(
+            vec![ColumnRef::BaseTableColumnRef {
+                table: String::from(TABLE1_NAME),
+                col_idx: 0,
+            }],
+            None,
+        );
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_filter_selectivity(expr_tree, &column_refs),
             0.03
@@ -945,10 +1002,13 @@ mod tests {
         let expr_tree = log_op(LogOpType::Or, vec![eq1.clone(), eq5.clone(), eq8.clone()]);
         let expr_tree_shift1 = log_op(LogOpType::Or, vec![eq5.clone(), eq8.clone(), eq1.clone()]);
         let expr_tree_shift2 = log_op(LogOpType::Or, vec![eq8.clone(), eq1.clone(), eq5.clone()]);
-        let column_refs = vec![ColumnRef::BaseTableColumnRef {
-            table: String::from(TABLE1_NAME),
-            col_idx: 0,
-        }];
+        let column_refs = GroupColumnRefs::new(
+            vec![ColumnRef::BaseTableColumnRef {
+                table: String::from(TABLE1_NAME),
+                col_idx: 0,
+            }],
+            None,
+        );
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_filter_selectivity(expr_tree, &column_refs),
             0.72
@@ -975,10 +1035,13 @@ mod tests {
             UnOpType::Not,
             bin_op(BinOpType::Eq, col_ref(0), cnst(Value::Int32(1))),
         );
-        let column_refs = vec![ColumnRef::BaseTableColumnRef {
-            table: String::from(TABLE1_NAME),
-            col_idx: 0,
-        }];
+        let column_refs = GroupColumnRefs::new(
+            vec![ColumnRef::BaseTableColumnRef {
+                table: String::from(TABLE1_NAME),
+                col_idx: 0,
+            }],
+            None,
+        );
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_filter_selectivity(expr_tree, &column_refs),
             0.7
@@ -997,10 +1060,13 @@ mod tests {
             UnOpType::Not,
             bin_op(BinOpType::Eq, col_ref(0), cnst(Value::Int32(1))),
         );
-        let column_refs = vec![ColumnRef::BaseTableColumnRef {
-            table: String::from(TABLE1_NAME),
-            col_idx: 0,
-        }];
+        let column_refs = GroupColumnRefs::new(
+            vec![ColumnRef::BaseTableColumnRef {
+                table: String::from(TABLE1_NAME),
+                col_idx: 0,
+            }],
+            None,
+        );
         // not doesn't care about nulls. it just reverses the selectivity
         // for instance, != _will not_ include nulls but "NOT ==" _will_ include nulls
         assert_approx_eq::assert_approx_eq!(

--- a/optd-datafusion-repr/src/cost/base_cost/filter/in_list.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/filter/in_list.rs
@@ -95,7 +95,7 @@ mod tests {
             0.0,
             Some(TestDistribution::empty()),
         ));
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
                 0,

--- a/optd-datafusion-repr/src/cost/base_cost/filter/in_list.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/filter/in_list.rs
@@ -9,7 +9,7 @@ use crate::{
         OptCostModel,
     },
     plan_nodes::{ColumnRefExpr, ConstantExpr, InListExpr, OptRelNode, OptRelNodeTyp},
-    properties::column_ref::{ColumnRef, GroupColumnRefs},
+    properties::column_ref::{BaseTableColumnRef, ColumnRef, GroupColumnRefs},
 };
 
 impl<
@@ -53,7 +53,9 @@ impl<
             .collect::<Vec<_>>();
         let negated = expr.negated();
 
-        if let ColumnRef::BaseTableColumnRef { table, col_idx } = &column_refs[col_ref_idx] {
+        if let ColumnRef::BaseTableColumnRef(BaseTableColumnRef { table, col_idx }) =
+            &column_refs[col_ref_idx]
+        {
             let in_sel = list_exprs
                 .iter()
                 .map(|expr| {
@@ -94,10 +96,10 @@ mod tests {
             Some(TestDistribution::empty()),
         ));
         let column_refs = GroupColumnRefs::new(
-            vec![ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            }],
+            vec![ColumnRef::base_table_column_ref(
+                String::from(TABLE1_NAME),
+                0,
+            )],
             None,
         );
         assert_approx_eq::assert_approx_eq!(

--- a/optd-datafusion-repr/src/cost/base_cost/filter/in_list.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/filter/in_list.rs
@@ -82,7 +82,7 @@ mod tests {
             create_one_column_cost_model, in_list, TestDistribution, TestMostCommonValues,
             TestPerColumnStats, TABLE1_NAME,
         },
-        properties::column_ref::ColumnRef,
+        properties::column_ref::{ColumnRef, GroupColumnRefs},
     };
 
     #[test]
@@ -93,10 +93,13 @@ mod tests {
             0.0,
             Some(TestDistribution::empty()),
         ));
-        let column_refs = vec![ColumnRef::BaseTableColumnRef {
-            table: String::from(TABLE1_NAME),
-            col_idx: 0,
-        }];
+        let column_refs = GroupColumnRefs::new(
+            vec![ColumnRef::BaseTableColumnRef {
+                table: String::from(TABLE1_NAME),
+                col_idx: 0,
+            }],
+            None,
+        );
         assert_approx_eq::assert_approx_eq!(
             cost_model
                 .get_in_list_selectivity(&in_list(0, vec![Value::Int32(1)], false), &column_refs),

--- a/optd-datafusion-repr/src/cost/base_cost/filter/like.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/filter/like.rs
@@ -137,7 +137,7 @@ mod tests {
             0.0,
             Some(TestDistribution::empty()),
         ));
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
                 0,
@@ -167,7 +167,7 @@ mod tests {
             null_frac,
             Some(TestDistribution::empty()),
         ));
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
                 0,

--- a/optd-datafusion-repr/src/cost/base_cost/filter/like.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/filter/like.rs
@@ -121,7 +121,7 @@ mod tests {
                 TestPerColumnStats, TABLE1_NAME,
             },
         },
-        properties::column_ref::ColumnRef,
+        properties::column_ref::{ColumnRef, GroupColumnRefs},
     };
 
     #[test]
@@ -135,10 +135,13 @@ mod tests {
             0.0,
             Some(TestDistribution::empty()),
         ));
-        let column_refs = vec![ColumnRef::BaseTableColumnRef {
-            table: String::from(TABLE1_NAME),
-            col_idx: 0,
-        }];
+        let column_refs = GroupColumnRefs::new(
+            vec![ColumnRef::BaseTableColumnRef {
+                table: String::from(TABLE1_NAME),
+                col_idx: 0,
+            }],
+            None,
+        );
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_like_selectivity(&like(0, "%abcd%", false), &column_refs),
             0.1 + FULL_WILDCARD_SEL_FACTOR.powi(2) * FIXED_CHAR_SEL_FACTOR.powi(4)
@@ -162,10 +165,13 @@ mod tests {
             null_frac,
             Some(TestDistribution::empty()),
         ));
-        let column_refs = vec![ColumnRef::BaseTableColumnRef {
-            table: String::from(TABLE1_NAME),
-            col_idx: 0,
-        }];
+        let column_refs = GroupColumnRefs::new(
+            vec![ColumnRef::BaseTableColumnRef {
+                table: String::from(TABLE1_NAME),
+                col_idx: 0,
+            }],
+            None,
+        );
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_like_selectivity(&like(0, "%abcd%", false), &column_refs),
             (0.1 + FULL_WILDCARD_SEL_FACTOR.powi(2) * FIXED_CHAR_SEL_FACTOR.powi(4)) * null_frac

--- a/optd-datafusion-repr/src/cost/base_cost/filter/like.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/filter/like.rs
@@ -10,7 +10,7 @@ use crate::{
         OptCostModel,
     },
     plan_nodes::{ColumnRefExpr, ConstantExpr, LikeExpr, OptRelNode, OptRelNodeTyp},
-    properties::column_ref::{ColumnRef, GroupColumnRefs},
+    properties::column_ref::{BaseTableColumnRef, ColumnRef, GroupColumnRefs},
 };
 
 // Used for estimating pattern selectivity character-by-character. These numbers
@@ -59,7 +59,9 @@ impl<
             .unwrap()
             .index();
 
-        if let ColumnRef::BaseTableColumnRef { table, col_idx } = &column_refs[col_ref_idx] {
+        if let ColumnRef::BaseTableColumnRef(BaseTableColumnRef { table, col_idx }) =
+            &column_refs[col_ref_idx]
+        {
             let pattern = ConstantExpr::from_rel_node(pattern.into_rel_node())
                 .expect("we already checked pattern is a constant")
                 .value()
@@ -136,10 +138,10 @@ mod tests {
             Some(TestDistribution::empty()),
         ));
         let column_refs = GroupColumnRefs::new(
-            vec![ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            }],
+            vec![ColumnRef::base_table_column_ref(
+                String::from(TABLE1_NAME),
+                0,
+            )],
             None,
         );
         assert_approx_eq::assert_approx_eq!(
@@ -166,10 +168,10 @@ mod tests {
             Some(TestDistribution::empty()),
         ));
         let column_refs = GroupColumnRefs::new(
-            vec![ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            }],
+            vec![ColumnRef::base_table_column_ref(
+                String::from(TABLE1_NAME),
+                0,
+            )],
             None,
         );
         assert_approx_eq::assert_approx_eq!(

--- a/optd-datafusion-repr/src/cost/base_cost/join.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/join.rs
@@ -347,7 +347,7 @@ impl<
         let mut sorted_predicates = predicates
             .into_iter()
             .map(|p| {
-                let sel = self.get_join_selectivity_from_on_col_ref_pair(
+                let sel: f64 = self.get_join_selectivity_from_on_col_ref_pair(
                     &p.left.clone().into(),
                     &p.right.clone().into(),
                 );
@@ -363,7 +363,7 @@ impl<
                 disjoint_sets.make_set(p.right.clone()).unwrap();
             }
             if !disjoint_sets.same_set(&p.left, &p.right).unwrap() {
-                acc_sel = acc_sel * sel;
+                acc_sel *= sel;
                 num_picked_predicates += 1;
             }
             if num_picked_predicates == num_cols - 1 {
@@ -447,15 +447,18 @@ impl<
                 if let (ColumnRef::BaseTableColumnRef(left), ColumnRef::BaseTableColumnRef(right)) =
                     (left_col_ref, right_col_ref)
                 {
+                    let predicate = EqPredicate::new(left.clone(), right.clone());
                     if past_eq_columns.is_eq(left, right) {
                         return self.get_join_selectivity_from_redundant_predicate(
-                            EqPredicate::new(left.clone(), right.clone()),
+                            predicate,
                             &mut past_eq_columns,
                         );
+                    } else {
+                        past_eq_columns.add_predicate(predicate);
                     }
                 }
 
-                self.get_join_selectivity_from_on_col_ref_pair(&left_col_ref, &right_col_ref)
+                self.get_join_selectivity_from_on_col_ref_pair(left_col_ref, right_col_ref)
             })
             .product()
     }
@@ -468,7 +471,10 @@ mod tests {
     use crate::{
         cost::base_cost::{tests::*, DEFAULT_EQ_SEL},
         plan_nodes::{BinOpType, JoinType, LogOpType, OptRelNodeRef},
-        properties::column_ref::{ColumnRef, GroupColumnRefs},
+        properties::column_ref::{
+            BaseTableColumnRef, ColumnRef, EqBaseTableColumnSets, EqPredicate, GroupColumnRefs,
+            SemanticCorrelation,
+        },
     };
 
     /// A wrapper around get_join_selectivity_from_expr_tree that extracts the table row counts from the cost model
@@ -1076,6 +1082,64 @@ mod tests {
             &column_refs,
             0.25,
             0.02,
+        );
+    }
+
+    #[test]
+    fn test_inner_redundant_predicate() {
+        let cost_model = create_three_table_cost_model(
+            TestPerColumnStats::new(
+                TestMostCommonValues::empty(),
+                2,
+                0.0,
+                Some(TestDistribution::empty()),
+            ),
+            TestPerColumnStats::new(
+                TestMostCommonValues::empty(),
+                4,
+                0.0,
+                Some(TestDistribution::empty()),
+            ),
+            TestPerColumnStats::new(
+                TestMostCommonValues::empty(),
+                5,
+                0.0,
+                Some(TestDistribution::empty()),
+            ),
+        );
+        let col01_sel = 0.25;
+        let col02_sel = 0.2;
+        let col12_sel = 0.2;
+        let col0_base_ref = BaseTableColumnRef {
+            table: String::from(TABLE1_NAME),
+            col_idx: 0,
+        };
+        let col1_base_ref = BaseTableColumnRef {
+            table: String::from(TABLE2_NAME),
+            col_idx: 0,
+        };
+        let col2_base_ref = BaseTableColumnRef {
+            table: String::from(TABLE3_NAME),
+            col_idx: 0,
+        };
+        let col0_ref: ColumnRef = col0_base_ref.clone().into();
+        let col1_ref: ColumnRef = col1_base_ref.clone().into();
+        let col2_ref: ColumnRef = col2_base_ref.clone().into();
+
+        let mut eq_columns = EqBaseTableColumnSets::new();
+        eq_columns.add_predicate(EqPredicate::new(col0_base_ref, col1_base_ref));
+        let semantic_correlation = SemanticCorrelation::new(eq_columns);
+        let column_refs = GroupColumnRefs::new_test(
+            vec![col0_ref.clone(), col1_ref.clone(), col2_ref.clone()],
+            Some(semantic_correlation),
+        );
+
+        let eq0and2 = bin_op(BinOpType::Eq, col_ref(0), col_ref(2));
+        let eq1and2 = bin_op(BinOpType::Eq, col_ref(1), col_ref(2));
+        let expr_tree = log_op(LogOpType::And, vec![eq0and2, eq1and2]);
+        assert_approx_eq::assert_approx_eq!(
+            test_get_join_selectivity(&cost_model, false, JoinType::Inner, expr_tree, &column_refs),
+            col02_sel * (col02_sel * col12_sel) / (col01_sel * col12_sel)
         );
     }
 }

--- a/optd-datafusion-repr/src/cost/base_cost/join.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/join.rs
@@ -1,9 +1,12 @@
+use std::ops::ControlFlow;
+
 use itertools::Itertools;
 use optd_core::{
     cascades::{CascadesOptimizer, RelNodeContext},
     cost::Cost,
 };
 use serde::{de::DeserializeOwned, Serialize};
+use union_find::{disjoint_sets::DisjointSets, union_find::UnionFind};
 
 use crate::{
     cost::base_cost::{
@@ -15,7 +18,8 @@ use crate::{
         OptRelNodeRef, OptRelNodeTyp,
     },
     properties::column_ref::{
-        BaseTableColumnRef, ColumnRef, ColumnRefPropertyBuilder, EqPredicate, GroupColumnRefs,
+        BaseTableColumnRef, ColumnRef, ColumnRefPropertyBuilder, EqBaseTableColumnSets,
+        EqPredicate, GroupColumnRefs,
     },
 };
 
@@ -306,9 +310,121 @@ impl<
         }
     }
 
+    /// Get the selectivity of one column eq predicate, e.g. colA = colB.
+    fn get_join_selectivity_from_on_col_ref_pair(
+        &self,
+        left: &ColumnRef,
+        right: &ColumnRef,
+    ) -> f64 {
+        // the formula for each pair is min(1 / ndistinct1, 1 / ndistinct2) (see https://postgrespro.com/blog/pgsql/5969618)
+        let ndistincts = vec![left, right].into_iter().map(|col_ref| {
+            match self.get_single_column_stats_from_col_ref(col_ref) {
+                Some(per_col_stats) => per_col_stats.ndistinct,
+                None => DEFAULT_NUM_DISTINCT,
+            }
+        });
+        // using reduce(f64::min) is the idiomatic workaround to min() because f64 does not implement Ord due to NaN
+        let selectivity = ndistincts.map(|ndistinct| 1.0 / ndistinct as f64).reduce(f64::min).expect("reduce() only returns None if the iterator is empty, which is impossible since col_ref_exprs.len() == 2");
+        assert!(
+            !selectivity.is_nan(),
+            "it should be impossible for selectivity to be NaN since n-distinct is never 0"
+        );
+        selectivity
+    }
+
+    /// Given a set of predicates P that define N equal columns, find the selectivity of
+    /// the most selective N - 1 predicates that "touches" all the columns using MST.
+    fn get_join_selecitivity_from_most_selective_predicates(
+        &self,
+        predicates: Vec<EqPredicate>,
+        num_cols: usize,
+    ) -> f64 {
+        let mut acc_sel = 1.0;
+        let mut num_picked_predicates = 0;
+        let mut disjoint_sets = DisjointSets::new();
+
+        // Sort predicates by selectivity in ascending order.
+        let mut sorted_predicates = predicates
+            .into_iter()
+            .map(|p| {
+                let sel = self.get_join_selectivity_from_on_col_ref_pair(
+                    &p.left.clone().into(),
+                    &p.right.clone().into(),
+                );
+                (p, sel)
+            })
+            .sorted_by(|(_, sel1), (_, sel2)| sel1.partial_cmp(sel2).unwrap());
+
+        sorted_predicates.try_for_each(|(p, sel)| {
+            if !disjoint_sets.contains(&p.left) {
+                disjoint_sets.make_set(p.left.clone()).unwrap();
+            }
+            if !disjoint_sets.contains(&p.right) {
+                disjoint_sets.make_set(p.right.clone()).unwrap();
+            }
+            if !disjoint_sets.same_set(&p.left, &p.right).unwrap() {
+                acc_sel = acc_sel * sel;
+                num_picked_predicates += 1;
+            }
+            if num_picked_predicates == num_cols - 1 {
+                ControlFlow::Break(())
+            } else {
+                ControlFlow::Continue(())
+            }
+        });
+        assert!(
+            num_picked_predicates == num_cols - 1,
+            "we should have picked N - 1 predicates"
+        );
+        acc_sel
+    }
+
+    /// See `get_join_on_selectivity` for details.
+    fn get_join_selectivity_from_redundant_predicate(
+        &self,
+        predicate: EqPredicate,
+        past_eq_columns: &mut EqBaseTableColumnSets,
+    ) -> f64 {
+        let left = predicate.left.clone();
+        // Compute the selectivity of the most selective N - 1 predicates.
+        let children_pred_sel = {
+            let predicates = past_eq_columns.find_predicates_for_eq_column_set(&left);
+            self.get_join_selecitivity_from_most_selective_predicates(
+                predicates,
+                past_eq_columns.num_eq_columns(&left),
+            )
+        };
+        // Add predicate to past_eq_columns.
+        past_eq_columns.add_predicate(predicate);
+        // Repeat the same process with the new predicate.
+        let new_pred_sel = {
+            let predicates = past_eq_columns.find_predicates_for_eq_column_set(&left);
+            self.get_join_selecitivity_from_most_selective_predicates(
+                predicates,
+                past_eq_columns.num_eq_columns(&left),
+            )
+        };
+
+        // Compute division of MSTs as the selectivity.
+        new_pred_sel / children_pred_sel
+    }
+
     /// Get the selectivity of the on conditions.
     ///
     /// Note that the selectivity of the on conditions does not depend on join type. Join type is accounted for separately in get_join_selectivity_core().
+    ///
+    /// We also check if each predicate is correlated with any of the previous predicates.
+    ///
+    /// More specifically, we are checking if the predicate can be expressed with other existing predicates.
+    /// E.g. if we have a predicate like A = B and B = C, we can express A = C is redundant.
+    //
+    /// However, we don't just throw away A = C, because we want to pick the most selective predicates.
+    ///
+    /// More generally, if we have N columns that are equal, and the set of predicates P that make them equal (|P| >= N - 1),
+    /// we select compute the MST of the graph where the columns are nodes and the predicates are edges.
+    ///
+    /// Then the selecitivy of such "redundant" predicate p is the MST of the graph with p (minimum as in having
+    /// the smallest product of selectivities) divided by the MST of the graph without p.
     fn get_join_on_selectivity(
         &self,
         on_col_ref_pairs: &[(ColumnRefExpr, ColumnRefExpr)],
@@ -320,52 +436,28 @@ impl<
             .unwrap()
             .eq_base_table_columns()
             .clone();
+
         // multiply the selectivities of all individual conditions together
-        on_col_ref_pairs.iter().map(|on_col_ref_pair| {
-            // Check if the predicate is correlated with any of the previous predicates. 
-            //
-            // More specifically, we are checking if the predicate can be expressed with other existing predicates.
-            // E.g. if we have a predicate like A = B and B = C, we can express A = C is redundant.
-            //
-            // However, we don't just throw away A = C, because we want to pick the most selective predicates.
-            //
-            // More generally, if we have N columns that are equal, and the set of predicates P that make them equal (|P| >= N - 1),
-            // we select compute the MST of the graph where the columns are nodes and the predicates are edges.
-            //
-            // Then the selecitivy of such "redundant" predicate p is the MST of the graph with p (minimum as in having 
-            // the smallest product of selectivities) divided by the MST of the graph without p.
-            let left_col_ref = &column_refs[on_col_ref_pair.0.index()];
-            let right_col_ref = &column_refs[on_col_ref_pair.1.index() + right_col_ref_offset];
-            if let (ColumnRef::BaseTableColumnRef(left_col_ref), ColumnRef::BaseTableColumnRef(right_col_ref)) = (left_col_ref, right_col_ref) {
-                if past_eq_columns.is_eq(left_col_ref, right_col_ref) {
-                    // Find the predicates in the same set.
-                    // Construct a graph using the predicates.
-                    // Compute MST.
+        on_col_ref_pairs
+            .iter()
+            .map(|on_col_ref_pair| {
+                let left_col_ref = &column_refs[on_col_ref_pair.0.index()];
+                let right_col_ref = &column_refs[on_col_ref_pair.1.index() + right_col_ref_offset];
 
-                    // Add predicate to past_eq_columns.
-                    past_eq_columns.add_predicate(EqPredicate::new(left_col_ref.clone(), right_col_ref.clone()));
-                    // Construct the new graph.
-                    // Compute MST.
-
-                    // Compute division of MSTs as the selectivity.
-
+                if let (ColumnRef::BaseTableColumnRef(left), ColumnRef::BaseTableColumnRef(right)) =
+                    (left_col_ref, right_col_ref)
+                {
+                    if past_eq_columns.is_eq(left, right) {
+                        return self.get_join_selectivity_from_redundant_predicate(
+                            EqPredicate::new(left.clone(), right.clone()),
+                            &mut past_eq_columns,
+                        );
+                    }
                 }
-            }
 
-            // the formula for each pair is min(1 / ndistinct1, 1 / ndistinct2) (see https://postgrespro.com/blog/pgsql/5969618)
-            let ndistincts = vec![left_col_ref, right_col_ref].into_iter().map(|col_ref| {
-                match self.get_single_column_stats_from_col_ref(col_ref) {
-                    Some(per_col_stats) => {
-                        per_col_stats.ndistinct
-                    },
-                    None => DEFAULT_NUM_DISTINCT,
-                }
-            });
-            // using reduce(f64::min) is the idiomatic workaround to min() because f64 does not implement Ord due to NaN
-            let selectivity = ndistincts.map(|ndistinct| 1.0 / ndistinct as f64).reduce(f64::min).expect("reduce() only returns None if the iterator is empty, which is impossible since col_ref_exprs.len() == 2");
-            assert!(!selectivity.is_nan(), "it should be impossible for selectivity to be NaN since n-distinct is never 0");
-            selectivity
-        }).product()
+                self.get_join_selectivity_from_on_col_ref_pair(&left_col_ref, &right_col_ref)
+            })
+            .product()
     }
 }
 

--- a/optd-datafusion-repr/src/cost/base_cost/join.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/join.rs
@@ -74,6 +74,7 @@ impl<
             let right_keys_group_id = context.children_group_ids[3];
             let left_col_cnt = optimizer
                 .get_property_by_group::<ColumnRefPropertyBuilder>(context.children_group_ids[0], 1)
+                .column_refs
                 .len();
             let left_keys_list = optimizer.get_all_group_bindings(left_keys_group_id, false);
             let right_keys_list = optimizer.get_all_group_bindings(right_keys_group_id, false);
@@ -159,10 +160,6 @@ impl<
     ) -> f64 {
         let join_on_selectivity =
             self.get_join_on_selectivity(&on_col_ref_pairs, column_refs, right_col_ref_offset);
-        println!(
-            "l: {:.2}, r: {:.2}, sel: {:.2}",
-            left_row_cnt, right_row_cnt, join_on_selectivity
-        );
         // Currently, there is no difference in how we handle a join filter and a select filter, so we use the same function
         // One difference (that we *don't* care about right now) is that join filters can contain expressions from multiple
         //   different tables. Currently, this doesn't affect the get_filter_selectivity() function, but this may change in
@@ -320,7 +317,6 @@ impl<
         on_col_ref_pairs.iter().map(|on_col_ref_pair| {
             // the formula for each pair is min(1 / ndistinct1, 1 / ndistinct2) (see https://postgrespro.com/blog/pgsql/5969618)
             let ndistincts = vec![on_col_ref_pair.0.index(), on_col_ref_pair.1.index() + right_col_ref_offset].into_iter().map(|col_index| {
-                println!("col: {:?}", column_refs[col_index]);
                 match self.get_single_column_stats_from_col_ref(&column_refs[col_index]) {
                     Some(per_col_stats) => {
                         per_col_stats.ndistinct
@@ -383,7 +379,7 @@ mod tests {
             cost_model.get_join_selectivity_from_expr_tree(
                 JoinType::Inner,
                 cnst(Value::Bool(true)),
-                &vec![],
+                &GroupColumnRefs::new(vec![], None),
                 f64::NAN,
                 f64::NAN
             ),
@@ -393,7 +389,7 @@ mod tests {
             cost_model.get_join_selectivity_from_expr_tree(
                 JoinType::Inner,
                 cnst(Value::Bool(false)),
-                &vec![],
+                &GroupColumnRefs::new(vec![], None),
                 f64::NAN,
                 f64::NAN
             ),
@@ -419,16 +415,19 @@ mod tests {
         );
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), col_ref(1));
         let expr_tree_rev = bin_op(BinOpType::Eq, col_ref(1), col_ref(0));
-        let column_refs = vec![
-            ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            },
-            ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE2_NAME),
-                col_idx: 0,
-            },
-        ];
+        let column_refs = GroupColumnRefs::new(
+            vec![
+                ColumnRef::BaseTableColumnRef {
+                    table: String::from(TABLE1_NAME),
+                    col_idx: 0,
+                },
+                ColumnRef::BaseTableColumnRef {
+                    table: String::from(TABLE2_NAME),
+                    col_idx: 0,
+                },
+            ],
+            None,
+        );
         assert_approx_eq::assert_approx_eq!(
             test_get_join_selectivity(&cost_model, false, JoinType::Inner, expr_tree, &column_refs),
             0.2
@@ -439,7 +438,7 @@ mod tests {
                 false,
                 JoinType::Inner,
                 expr_tree_rev,
-                &column_refs
+                &column_refs,
             ),
             0.2
         );
@@ -465,16 +464,19 @@ mod tests {
         let eq1and0 = bin_op(BinOpType::Eq, col_ref(1), col_ref(0));
         let expr_tree = log_op(LogOpType::And, vec![eq0and1.clone(), eq1and0.clone()]);
         let expr_tree_rev = log_op(LogOpType::And, vec![eq1and0.clone(), eq0and1.clone()]);
-        let column_refs = vec![
-            ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            },
-            ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE2_NAME),
-                col_idx: 0,
-            },
-        ];
+        let column_refs = GroupColumnRefs::new(
+            vec![
+                ColumnRef::BaseTableColumnRef {
+                    table: String::from(TABLE1_NAME),
+                    col_idx: 0,
+                },
+                ColumnRef::BaseTableColumnRef {
+                    table: String::from(TABLE2_NAME),
+                    col_idx: 0,
+                },
+            ],
+            None,
+        );
         assert_approx_eq::assert_approx_eq!(
             test_get_join_selectivity(&cost_model, false, JoinType::Inner, expr_tree, &column_refs),
             0.04
@@ -511,16 +513,19 @@ mod tests {
         let eq100 = bin_op(BinOpType::Eq, col_ref(1), cnst(Value::Int32(100)));
         let expr_tree = log_op(LogOpType::And, vec![eq0and1.clone(), eq100.clone()]);
         let expr_tree_rev = log_op(LogOpType::And, vec![eq100.clone(), eq0and1.clone()]);
-        let column_refs = vec![
-            ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            },
-            ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE2_NAME),
-                col_idx: 0,
-            },
-        ];
+        let column_refs = GroupColumnRefs::new(
+            vec![
+                ColumnRef::BaseTableColumnRef {
+                    table: String::from(TABLE1_NAME),
+                    col_idx: 0,
+                },
+                ColumnRef::BaseTableColumnRef {
+                    table: String::from(TABLE2_NAME),
+                    col_idx: 0,
+                },
+            ],
+            None,
+        );
         assert_approx_eq::assert_approx_eq!(
             test_get_join_selectivity(&cost_model, false, JoinType::Inner, expr_tree, &column_refs),
             0.05
@@ -557,16 +562,19 @@ mod tests {
         let eq100 = bin_op(BinOpType::Eq, col_ref(1), cnst(Value::Int32(100)));
         let expr_tree = log_op(LogOpType::And, vec![neq12.clone(), eq100.clone()]);
         let expr_tree_rev = log_op(LogOpType::And, vec![eq100.clone(), neq12.clone()]);
-        let column_refs = vec![
-            ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            },
-            ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE2_NAME),
-                col_idx: 0,
-            },
-        ];
+        let column_refs = GroupColumnRefs::new(
+            vec![
+                ColumnRef::BaseTableColumnRef {
+                    table: String::from(TABLE1_NAME),
+                    col_idx: 0,
+                },
+                ColumnRef::BaseTableColumnRef {
+                    table: String::from(TABLE2_NAME),
+                    col_idx: 0,
+                },
+            ],
+            None,
+        );
         assert_approx_eq::assert_approx_eq!(
             test_get_join_selectivity(&cost_model, false, JoinType::Inner, expr_tree, &column_refs),
             0.2
@@ -600,16 +608,19 @@ mod tests {
             ),
         );
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), col_ref(0));
-        let column_refs = vec![
-            ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            },
-            ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE2_NAME),
-                col_idx: 0,
-            },
-        ];
+        let column_refs = GroupColumnRefs::new(
+            vec![
+                ColumnRef::BaseTableColumnRef {
+                    table: String::from(TABLE1_NAME),
+                    col_idx: 0,
+                },
+                ColumnRef::BaseTableColumnRef {
+                    table: String::from(TABLE2_NAME),
+                    col_idx: 0,
+                },
+            ],
+            None,
+        );
         assert_approx_eq::assert_approx_eq!(
             test_get_join_selectivity(&cost_model, false, JoinType::Inner, expr_tree, &column_refs),
             DEFAULT_EQ_SEL
@@ -735,16 +746,19 @@ mod tests {
         // the left/right of the join refers to the tables, not the order of columns in the predicate
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), col_ref(1));
         let expr_tree_rev = bin_op(BinOpType::Eq, col_ref(1), col_ref(0));
-        let column_refs = vec![
-            ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            },
-            ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE2_NAME),
-                col_idx: 0,
-            },
-        ];
+        let column_refs = GroupColumnRefs::new(
+            vec![
+                ColumnRef::BaseTableColumnRef {
+                    table: String::from(TABLE1_NAME),
+                    col_idx: 0,
+                },
+                ColumnRef::BaseTableColumnRef {
+                    table: String::from(TABLE2_NAME),
+                    col_idx: 0,
+                },
+            ],
+            None,
+        );
         // sanity check the expected inner sel
         let expected_inner_sel = 0.2;
         assert_approx_eq::assert_approx_eq!(
@@ -801,16 +815,19 @@ mod tests {
         // the left/right of the join refers to the tables, not the order of columns in the predicate
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), col_ref(1));
         let expr_tree_rev = bin_op(BinOpType::Eq, col_ref(1), col_ref(0));
-        let column_refs = vec![
-            ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            },
-            ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE2_NAME),
-                col_idx: 0,
-            },
-        ];
+        let column_refs = GroupColumnRefs::new(
+            vec![
+                ColumnRef::BaseTableColumnRef {
+                    table: String::from(TABLE1_NAME),
+                    col_idx: 0,
+                },
+                ColumnRef::BaseTableColumnRef {
+                    table: String::from(TABLE2_NAME),
+                    col_idx: 0,
+                },
+            ],
+            None,
+        );
         // sanity check the expected inner sel
         let expected_inner_sel = 0.2;
         assert_approx_eq::assert_approx_eq!(
@@ -868,16 +885,19 @@ mod tests {
         // the left/right of the join refers to the tables, not the order of columns in the predicate
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), col_ref(1));
         let expr_tree_rev = bin_op(BinOpType::Eq, col_ref(1), col_ref(0));
-        let column_refs = vec![
-            ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            },
-            ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE2_NAME),
-                col_idx: 0,
-            },
-        ];
+        let column_refs = GroupColumnRefs::new(
+            vec![
+                ColumnRef::BaseTableColumnRef {
+                    table: String::from(TABLE1_NAME),
+                    col_idx: 0,
+                },
+                ColumnRef::BaseTableColumnRef {
+                    table: String::from(TABLE2_NAME),
+                    col_idx: 0,
+                },
+            ],
+            None,
+        );
         // sanity check the expected inner sel
         let expected_inner_sel = 0.1;
         assert_approx_eq::assert_approx_eq!(
@@ -939,16 +959,19 @@ mod tests {
         let expr_tree = log_op(LogOpType::And, vec![eq0and1, filter.clone()]);
         // inner rev means its the inner expr (the eq op) whose children are being reversed, as opposed to the and op
         let expr_tree_inner_rev = log_op(LogOpType::And, vec![eq1and0, filter.clone()]);
-        let column_refs = vec![
-            ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE1_NAME),
-                col_idx: 0,
-            },
-            ColumnRef::BaseTableColumnRef {
-                table: String::from(TABLE2_NAME),
-                col_idx: 0,
-            },
-        ];
+        let column_refs = GroupColumnRefs::new(
+            vec![
+                ColumnRef::BaseTableColumnRef {
+                    table: String::from(TABLE1_NAME),
+                    col_idx: 0,
+                },
+                ColumnRef::BaseTableColumnRef {
+                    table: String::from(TABLE2_NAME),
+                    col_idx: 0,
+                },
+            ],
+            None,
+        );
         // sanity check the expected inner sel
         let expected_inner_sel = 0.008;
         assert_approx_eq::assert_approx_eq!(

--- a/optd-datafusion-repr/src/cost/base_cost/join.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/join.rs
@@ -401,6 +401,11 @@ impl<
             1,
             "all columns should be connected by the predicates"
         );
+        debug_assert_eq!(
+            disjoint_sets.num_items(),
+            num_cols,
+            "all columns should be connected by the predicates"
+        );
         acc_sel
     }
 

--- a/optd-datafusion-repr/src/cost/base_cost/join.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/join.rs
@@ -396,6 +396,11 @@ impl<
             num_cols - 1,
             "we should have picked N - 1 predicates"
         );
+        debug_assert_eq!(
+            disjoint_sets.num_sets(),
+            1,
+            "all columns should be connected by the predicates"
+        );
         acc_sel
     }
 

--- a/optd-datafusion-repr/src/cost/base_cost/join.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/join.rs
@@ -15,7 +15,7 @@ use crate::{
         OptRelNodeRef, OptRelNodeTyp,
     },
     properties::column_ref::{
-        BaseTableColumnRef, ColumnRef, ColumnRefPropertyBuilder, GroupColumnRefs,
+        BaseTableColumnRef, ColumnRef, ColumnRefPropertyBuilder, EqPredicate, GroupColumnRefs,
     },
 };
 
@@ -315,11 +315,46 @@ impl<
         column_refs: &GroupColumnRefs,
         right_col_ref_offset: usize,
     ) -> f64 {
+        let mut past_eq_columns = column_refs
+            .input_correlation()
+            .unwrap()
+            .eq_base_table_columns()
+            .clone();
         // multiply the selectivities of all individual conditions together
         on_col_ref_pairs.iter().map(|on_col_ref_pair| {
+            // Check if the predicate is correlated with any of the previous predicates. 
+            //
+            // More specifically, we are checking if the predicate can be expressed with other existing predicates.
+            // E.g. if we have a predicate like A = B and B = C, we can express A = C is redundant.
+            //
+            // However, we don't just throw away A = C, because we want to pick the most selective predicates.
+            //
+            // More generally, if we have N columns that are equal, and the set of predicates P that make them equal (|P| >= N - 1),
+            // we select compute the MST of the graph where the columns are nodes and the predicates are edges.
+            //
+            // Then the selecitivy of such "redundant" predicate p is the MST of the graph with p (minimum as in having 
+            // the smallest product of selectivities) divided by the MST of the graph without p.
+            let left_col_ref = &column_refs[on_col_ref_pair.0.index()];
+            let right_col_ref = &column_refs[on_col_ref_pair.1.index() + right_col_ref_offset];
+            if let (ColumnRef::BaseTableColumnRef(left_col_ref), ColumnRef::BaseTableColumnRef(right_col_ref)) = (left_col_ref, right_col_ref) {
+                if past_eq_columns.is_eq(left_col_ref, right_col_ref) {
+                    // Find the predicates in the same set.
+                    // Construct a graph using the predicates.
+                    // Compute MST.
+
+                    // Add predicate to past_eq_columns.
+                    past_eq_columns.add_predicate(EqPredicate::new(left_col_ref.clone(), right_col_ref.clone()));
+                    // Construct the new graph.
+                    // Compute MST.
+
+                    // Compute division of MSTs as the selectivity.
+
+                }
+            }
+
             // the formula for each pair is min(1 / ndistinct1, 1 / ndistinct2) (see https://postgrespro.com/blog/pgsql/5969618)
-            let ndistincts = vec![on_col_ref_pair.0.index(), on_col_ref_pair.1.index() + right_col_ref_offset].into_iter().map(|col_index| {
-                match self.get_single_column_stats_from_col_ref(&column_refs[col_index]) {
+            let ndistincts = vec![left_col_ref, right_col_ref].into_iter().map(|col_ref| {
+                match self.get_single_column_stats_from_col_ref(col_ref) {
                     Some(per_col_stats) => {
                         per_col_stats.ndistinct
                     },

--- a/optd-datafusion-repr/src/cost/base_cost/join.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/join.rs
@@ -14,7 +14,9 @@ use crate::{
         BinOpType, ColumnRefExpr, Expr, ExprList, JoinType, LogOpExpr, LogOpType, OptRelNode,
         OptRelNodeRef, OptRelNodeTyp,
     },
-    properties::column_ref::{ColumnRef, ColumnRefPropertyBuilder, GroupColumnRefs},
+    properties::column_ref::{
+        BaseTableColumnRef, ColumnRef, ColumnRefPropertyBuilder, GroupColumnRefs,
+    },
 };
 
 use super::{OptCostModel, DEFAULT_UNK_SEL};
@@ -279,12 +281,12 @@ impl<
                 let left_col_ref = &column_refs[left_col_ref_expr.index()];
                 let right_col_ref = &column_refs[right_col_ref_expr.index()];
                 let is_same_table = if let (
-                    ColumnRef::BaseTableColumnRef {
+                    ColumnRef::BaseTableColumnRef(BaseTableColumnRef {
                         table: left_table, ..
-                    },
-                    ColumnRef::BaseTableColumnRef {
+                    }),
+                    ColumnRef::BaseTableColumnRef(BaseTableColumnRef {
                         table: right_table, ..
-                    },
+                    }),
                 ) = (left_col_ref, right_col_ref)
                 {
                     left_table == right_table
@@ -417,14 +419,8 @@ mod tests {
         let expr_tree_rev = bin_op(BinOpType::Eq, col_ref(1), col_ref(0));
         let column_refs = GroupColumnRefs::new(
             vec![
-                ColumnRef::BaseTableColumnRef {
-                    table: String::from(TABLE1_NAME),
-                    col_idx: 0,
-                },
-                ColumnRef::BaseTableColumnRef {
-                    table: String::from(TABLE2_NAME),
-                    col_idx: 0,
-                },
+                ColumnRef::base_table_column_ref(String::from(TABLE1_NAME), 0),
+                ColumnRef::base_table_column_ref(String::from(TABLE2_NAME), 0),
             ],
             None,
         );
@@ -466,14 +462,8 @@ mod tests {
         let expr_tree_rev = log_op(LogOpType::And, vec![eq1and0.clone(), eq0and1.clone()]);
         let column_refs = GroupColumnRefs::new(
             vec![
-                ColumnRef::BaseTableColumnRef {
-                    table: String::from(TABLE1_NAME),
-                    col_idx: 0,
-                },
-                ColumnRef::BaseTableColumnRef {
-                    table: String::from(TABLE2_NAME),
-                    col_idx: 0,
-                },
+                ColumnRef::base_table_column_ref(String::from(TABLE1_NAME), 0),
+                ColumnRef::base_table_column_ref(String::from(TABLE2_NAME), 0),
             ],
             None,
         );
@@ -515,14 +505,8 @@ mod tests {
         let expr_tree_rev = log_op(LogOpType::And, vec![eq100.clone(), eq0and1.clone()]);
         let column_refs = GroupColumnRefs::new(
             vec![
-                ColumnRef::BaseTableColumnRef {
-                    table: String::from(TABLE1_NAME),
-                    col_idx: 0,
-                },
-                ColumnRef::BaseTableColumnRef {
-                    table: String::from(TABLE2_NAME),
-                    col_idx: 0,
-                },
+                ColumnRef::base_table_column_ref(String::from(TABLE1_NAME), 0),
+                ColumnRef::base_table_column_ref(String::from(TABLE2_NAME), 0),
             ],
             None,
         );
@@ -564,14 +548,8 @@ mod tests {
         let expr_tree_rev = log_op(LogOpType::And, vec![eq100.clone(), neq12.clone()]);
         let column_refs = GroupColumnRefs::new(
             vec![
-                ColumnRef::BaseTableColumnRef {
-                    table: String::from(TABLE1_NAME),
-                    col_idx: 0,
-                },
-                ColumnRef::BaseTableColumnRef {
-                    table: String::from(TABLE2_NAME),
-                    col_idx: 0,
-                },
+                ColumnRef::base_table_column_ref(String::from(TABLE1_NAME), 0),
+                ColumnRef::base_table_column_ref(String::from(TABLE2_NAME), 0),
             ],
             None,
         );
@@ -610,14 +588,8 @@ mod tests {
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), col_ref(0));
         let column_refs = GroupColumnRefs::new(
             vec![
-                ColumnRef::BaseTableColumnRef {
-                    table: String::from(TABLE1_NAME),
-                    col_idx: 0,
-                },
-                ColumnRef::BaseTableColumnRef {
-                    table: String::from(TABLE2_NAME),
-                    col_idx: 0,
-                },
+                ColumnRef::base_table_column_ref(String::from(TABLE1_NAME), 0),
+                ColumnRef::base_table_column_ref(String::from(TABLE2_NAME), 0),
             ],
             None,
         );
@@ -748,14 +720,8 @@ mod tests {
         let expr_tree_rev = bin_op(BinOpType::Eq, col_ref(1), col_ref(0));
         let column_refs = GroupColumnRefs::new(
             vec![
-                ColumnRef::BaseTableColumnRef {
-                    table: String::from(TABLE1_NAME),
-                    col_idx: 0,
-                },
-                ColumnRef::BaseTableColumnRef {
-                    table: String::from(TABLE2_NAME),
-                    col_idx: 0,
-                },
+                ColumnRef::base_table_column_ref(String::from(TABLE1_NAME), 0),
+                ColumnRef::base_table_column_ref(String::from(TABLE2_NAME), 0),
             ],
             None,
         );
@@ -817,14 +783,8 @@ mod tests {
         let expr_tree_rev = bin_op(BinOpType::Eq, col_ref(1), col_ref(0));
         let column_refs = GroupColumnRefs::new(
             vec![
-                ColumnRef::BaseTableColumnRef {
-                    table: String::from(TABLE1_NAME),
-                    col_idx: 0,
-                },
-                ColumnRef::BaseTableColumnRef {
-                    table: String::from(TABLE2_NAME),
-                    col_idx: 0,
-                },
+                ColumnRef::base_table_column_ref(String::from(TABLE1_NAME), 0),
+                ColumnRef::base_table_column_ref(String::from(TABLE2_NAME), 0),
             ],
             None,
         );
@@ -887,14 +847,8 @@ mod tests {
         let expr_tree_rev = bin_op(BinOpType::Eq, col_ref(1), col_ref(0));
         let column_refs = GroupColumnRefs::new(
             vec![
-                ColumnRef::BaseTableColumnRef {
-                    table: String::from(TABLE1_NAME),
-                    col_idx: 0,
-                },
-                ColumnRef::BaseTableColumnRef {
-                    table: String::from(TABLE2_NAME),
-                    col_idx: 0,
-                },
+                ColumnRef::base_table_column_ref(String::from(TABLE1_NAME), 0),
+                ColumnRef::base_table_column_ref(String::from(TABLE2_NAME), 0),
             ],
             None,
         );
@@ -961,14 +915,8 @@ mod tests {
         let expr_tree_inner_rev = log_op(LogOpType::And, vec![eq1and0, filter.clone()]);
         let column_refs = GroupColumnRefs::new(
             vec![
-                ColumnRef::BaseTableColumnRef {
-                    table: String::from(TABLE1_NAME),
-                    col_idx: 0,
-                },
-                ColumnRef::BaseTableColumnRef {
-                    table: String::from(TABLE2_NAME),
-                    col_idx: 0,
-                },
+                ColumnRef::base_table_column_ref(String::from(TABLE1_NAME), 0),
+                ColumnRef::base_table_column_ref(String::from(TABLE2_NAME), 0),
             ],
             None,
         );

--- a/optd-datafusion-repr/src/cost/base_cost/join.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/join.rs
@@ -356,7 +356,8 @@ impl<
         let mut num_picked_predicates = 0;
         let mut disjoint_sets = DisjointSets::new();
 
-        // Sort predicates by selectivity in ascending order.
+        // Use Kruskal to compute MST.
+        // Step 1: sort predicates by selectivity in ascending order.
         let mut sorted_predicates = predicates
             .into_iter()
             .map(|p| {
@@ -368,6 +369,7 @@ impl<
             })
             .sorted_by(|(_, sel1), (_, sel2)| sel1.partial_cmp(sel2).unwrap());
 
+        // Step 2: pick predicates until all columns are "connected" by the predicates.
         sorted_predicates.try_for_each(|(p, sel)| {
             if !disjoint_sets.contains(&p.left) {
                 disjoint_sets.make_set(p.left.clone()).unwrap();
@@ -378,6 +380,7 @@ impl<
             if !disjoint_sets.same_set(&p.left, &p.right).unwrap() {
                 acc_sel *= sel;
                 num_picked_predicates += 1;
+                disjoint_sets.union(&p.left, &p.right).unwrap();
             }
             if num_picked_predicates == num_cols - 1 {
                 ControlFlow::Break(())
@@ -385,15 +388,16 @@ impl<
                 ControlFlow::Continue(())
             }
         });
-        assert!(
-            num_picked_predicates == num_cols - 1,
+        debug_assert_eq!(
+            num_picked_predicates,
+            num_cols - 1,
             "we should have picked N - 1 predicates"
         );
         acc_sel
     }
 
     /// See `get_join_on_selectivity` for details.
-    fn get_join_selectivity_from_redundant_predicate(
+    fn get_join_selectivity_from_redundant_predicates(
         &self,
         predicate: EqPredicate,
         past_eq_columns: &mut EqBaseTableColumnSets,
@@ -438,7 +442,7 @@ impl<
     /// defines the equality (|P| >= N - 1), we select compute the MST of the graph where the
     /// columns are nodes and the predicates are edges.
     ///
-    /// Then the selecitivy of such "redundant" predicate p is the MST of the graph with p (minimum
+    /// Then the selectiviy of such "redundant" predicate p is the MST of the graph with p (minimum
     /// as in having the smallest product of selectivities) divided by the MST of the graph without p.
     fn get_join_on_selectivity(
         &self,
@@ -464,7 +468,7 @@ impl<
                 {
                     let predicate = EqPredicate::new(left.clone(), right.clone());
                     if past_eq_columns.is_eq(left, right) {
-                        return self.get_join_selectivity_from_redundant_predicate(
+                        return self.get_join_selectivity_from_redundant_predicates(
                             predicate,
                             &mut past_eq_columns,
                         );
@@ -1102,6 +1106,11 @@ mod tests {
         );
     }
 
+    // Ensure that in `select t1, t2, t3 where t1.a = t2.a and t2.a = t3.a and t1.a = t3.a`,
+    // even if the first join picks the most selective predicate (which should have been discarded,
+    // since we need to ensure the most selective N - 1 predicates are picked), the selectivity is
+    // adjusted in the second join so that the final selectivity is the product of the
+    // selectivities of the 2 most selective redicates.
     #[test]
     fn test_inner_redundant_predicate() {
         let cost_model = create_three_table_cost_model(

--- a/optd-datafusion-repr/src/cost/base_cost/join.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/join.rs
@@ -399,7 +399,18 @@ impl<
         acc_sel
     }
 
-    /// See `get_join_on_selectivity` for details.
+    /// A set of predicates contains "redundant" some of them can be expressed with the rest.
+    /// E.g. In { A = B, B = C, A = C }, one of the predicates is redundant.
+    /// In this case, we want to pick the most selective predicates that touch all the columns
+    /// that this set of predicates touches.
+    ///
+    /// If we have N columns that are equal, and the set of equality predicates P that defines the
+    /// equality (|P| >= N - 1), we compute the MST of the graph where the columns are nodes
+    /// and the predicates are edges (see `get_join_selecitivity_from_most_selective_predicates`
+    /// for MST implementation).
+    ///
+    /// Then the selectiviy of such "redundant" predicate p is the MST of the graph with p (minimum
+    /// as in having the smallest product of selectivities) divided by the MST of the graph without p.
     fn get_join_selectivity_from_redundant_predicates(
         &self,
         predicate: EqPredicate,
@@ -437,16 +448,10 @@ impl<
     /// We also check if each predicate is correlated with any of the previous predicates.
     ///
     /// More specifically, we are checking if the predicate can be expressed with other existing predicates.
-    /// E.g. if we have a predicate like A = B and B = C, we can express A = C is redundant.
+    /// E.g. if we have a predicate like A = B and B = C is equivalent to A = C.
     //
     /// However, we don't just throw away A = C, because we want to pick the most selective predicates.
-    ///
-    /// More generally, if we have N columns that are equal, and the set of predicates P that
-    /// defines the equality (|P| >= N - 1), we select compute the MST of the graph where the
-    /// columns are nodes and the predicates are edges.
-    ///
-    /// Then the selectiviy of such "redundant" predicate p is the MST of the graph with p (minimum
-    /// as in having the smallest product of selectivities) divided by the MST of the graph without p.
+    /// For details on how we do this, see `get_join_selectivity_from_redundant_predicates`.
     fn get_join_on_selectivity(
         &self,
         on_col_ref_pairs: &[(ColumnRefExpr, ColumnRefExpr)],

--- a/optd-datafusion-repr/src/cost/base_cost/join.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/join.rs
@@ -345,8 +345,11 @@ impl<
         selectivity
     }
 
-    /// Given a set of predicates P that define N equal columns, find the selectivity of
-    /// the most selective N - 1 predicates that "touches" all the columns using MST.
+    /// Given a set of equality predicates P that define N equal columns, find the selectivity of
+    /// the most selective N - 1 predicates that "touches" all the columns.
+    ///
+    /// We solve the problem using MST (Minimum Spanning Tree), where the columns are nodes and the
+    /// predicates are undirected edges. Since all the columns are equal, the graph is connected.
     fn get_join_selecitivity_from_most_selective_predicates(
         &self,
         predicates: Vec<EqPredicate>,

--- a/optd-datafusion-repr/src/cost/base_cost/join.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/join.rs
@@ -399,19 +399,24 @@ impl<
         acc_sel
     }
 
-    /// A set of predicates contains "redundant" some of them can be expressed with the rest.
+    /// A predicate set contains "redundant" predicates if some of them can be expressed with the rest.
     /// E.g. In { A = B, B = C, A = C }, one of the predicates is redundant.
     /// In this case, we want to pick the most selective predicates that touch all the columns
     /// that this set of predicates touches.
     ///
     /// If we have N columns that are equal, and the set of equality predicates P that defines the
-    /// equality (|P| >= N - 1), we compute the MST of the graph where the columns are nodes
-    /// and the predicates are edges (see `get_join_selecitivity_from_most_selective_predicates`
-    /// for MST implementation).
+    /// equalities (|P| >= N - 1), we pick the N - 1 most selective predicates (denoted P') that
+    /// define the equalities by computing the MST of the graph where the columns are nodes and the
+    /// predicates are edges (see `get_join_selecitivity_from_most_selective_predicates` for
+    /// implementation).
     ///
-    /// Then the selectiviy of such "redundant" predicate p is the MST of the graph with p (minimum
-    /// as in having the smallest product of selectivities) divided by the MST of the graph without p.
-    fn get_join_selectivity_from_redundant_predicates(
+    /// But since child has already picked some predicates which might not be the most selective
+    /// (because it has not seen the most selective ones), when we encounter a potentially more
+    /// selective `predicate` (in the parameter) and a set of previously seen predicates
+    /// `past_eq_columns`, `predicate` produces a selectivity adjustment factor, which is the
+    /// multiplied selectivity of the most selective N - 1 predicate among `past_eq_columns` union
+    /// `predicate` divided by the selectivity of the `past_eq_columns`.
+    fn get_join_selectivity_adjustment_from_redundant_predicates(
         &self,
         predicate: EqPredicate,
         past_eq_columns: &mut EqBaseTableColumnSets,
@@ -476,7 +481,7 @@ impl<
                 {
                     let predicate = EqPredicate::new(left.clone(), right.clone());
                     if past_eq_columns.is_eq(left, right) {
-                        return self.get_join_selectivity_from_redundant_predicates(
+                        return self.get_join_selectivity_adjustment_from_redundant_predicates(
                             predicate,
                             &mut past_eq_columns,
                         );

--- a/optd-datafusion-repr/src/cost/base_cost/join.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/join.rs
@@ -45,7 +45,8 @@ impl<
                 optimizer.get_property_by_group::<ColumnRefPropertyBuilder>(context.group_id, 1);
             let expr_group_id = context.children_group_ids[2];
             let expr_trees = optimizer.get_all_group_bindings(expr_group_id, false);
-            // there may be more than one expression tree in a group. see comment in OptRelNodeTyp::PhysicalFilter(_) for more information
+            // there may be more than one expression tree in a group.
+            // see comment in OptRelNodeTyp::PhysicalFilter(_) for more information
             let expr_tree = expr_trees.first().expect("expression missing");
             self.get_join_selectivity_from_expr_tree(
                 join_typ,
@@ -84,7 +85,8 @@ impl<
                 .len();
             let left_keys_list = optimizer.get_all_group_bindings(left_keys_group_id, false);
             let right_keys_list = optimizer.get_all_group_bindings(right_keys_group_id, false);
-            // there may be more than one expression tree in a group. see comment in OptRelNodeTyp::PhysicalFilter(_) for more information
+            // there may be more than one expression tree in a group.
+            // see comment in OptRelNodeTyp::PhysicalFilter(_) for more information
             let left_keys = left_keys_list.first().expect("left keys missing");
             let right_keys = right_keys_list.first().expect("right keys missing");
             self.get_join_selectivity_from_keys(
@@ -121,7 +123,8 @@ impl<
         left_col_cnt: usize,
     ) -> f64 {
         assert!(left_keys.len() == right_keys.len());
-        // I assume that the keys are already in the right order s.t. the ith key of left_keys corresponds with the ith key of right_keys
+        // I assume that the keys are already in the right order
+        // s.t. the ith key of left_keys corresponds with the ith key of right_keys
         let on_col_ref_pairs = left_keys
             .to_vec()
             .into_iter()
@@ -146,13 +149,18 @@ impl<
         )
     }
 
-    /// The core logic of join selectivity which assumes we've already separated the expression into the on conditions and the filters
-    /// Hash join and NLJ reference right table columns differently, hence the `right_col_ref_offset` parameter.
+    /// The core logic of join selectivity which assumes we've already separated the expression
+    /// into the on conditions and the filters.
+    ///
+    /// Hash join and NLJ reference right table columns differently, hence the
+    /// `right_col_ref_offset` parameter.
+    ///
     /// For hash join, the right table columns indices are with respect to the right table,
-    ///   which means #0 is the first column of the right table.
+    /// which means #0 is the first column of the right table.
+    ///
     /// For NLJ, the right table columns indices are with respect to the output of the join.
-    ///   For example, if the left table has 3 columns, the first column of the right table
-    ///   is #3 instead of #0.
+    /// For example, if the left table has 3 columns, the first column of the right table
+    /// is #3 instead of #0.
     #[allow(clippy::too_many_arguments)]
     fn get_join_selectivity_core(
         &self,
@@ -166,10 +174,12 @@ impl<
     ) -> f64 {
         let join_on_selectivity =
             self.get_join_on_selectivity(&on_col_ref_pairs, column_refs, right_col_ref_offset);
-        // Currently, there is no difference in how we handle a join filter and a select filter, so we use the same function
+        // Currently, there is no difference in how we handle a join filter and a select filter,
+        // so we use the same function.
+        //
         // One difference (that we *don't* care about right now) is that join filters can contain expressions from multiple
-        //   different tables. Currently, this doesn't affect the get_filter_selectivity() function, but this may change in
-        //   the future
+        // different tables. Currently, this doesn't affect the get_filter_selectivity() function, but this may change in
+        // the future.
         let join_filter_selectivity = match filter_expr_tree {
             Some(filter_expr_tree) => self.get_filter_selectivity(filter_expr_tree, column_refs),
             None => 1.0,
@@ -190,9 +200,10 @@ impl<
         }
     }
 
-    /// The expr_tree input must be a "mixed expression tree", just like with get_filter_selectivity()
-    /// This is a "wrapper" to separate the equality conditions from the filter conditions before calling
-    ///   the "main" get_join_selectivity_core() function.
+    /// The expr_tree input must be a "mixed expression tree", just like with `get_filter_selectivity`.
+    ///
+    /// This is a "wrapper" to separate the equality conditions from the filter conditions before
+    /// calling the "main" `get_join_selectivity_core` function.
     fn get_join_selectivity_from_expr_tree(
         &self,
         join_typ: JoinType,
@@ -316,14 +327,16 @@ impl<
         left: &ColumnRef,
         right: &ColumnRef,
     ) -> f64 {
-        // the formula for each pair is min(1 / ndistinct1, 1 / ndistinct2) (see https://postgrespro.com/blog/pgsql/5969618)
+        // the formula for each pair is min(1 / ndistinct1, 1 / ndistinct2)
+        // (see https://postgrespro.com/blog/pgsql/5969618)
         let ndistincts = vec![left, right].into_iter().map(|col_ref| {
             match self.get_single_column_stats_from_col_ref(col_ref) {
                 Some(per_col_stats) => per_col_stats.ndistinct,
                 None => DEFAULT_NUM_DISTINCT,
             }
         });
-        // using reduce(f64::min) is the idiomatic workaround to min() because f64 does not implement Ord due to NaN
+        // using reduce(f64::min) is the idiomatic workaround to min() because
+        // f64 does not implement Ord due to NaN
         let selectivity = ndistincts.map(|ndistinct| 1.0 / ndistinct as f64).reduce(f64::min).expect("reduce() only returns None if the iterator is empty, which is impossible since col_ref_exprs.len() == 2");
         assert!(
             !selectivity.is_nan(),
@@ -411,7 +424,8 @@ impl<
 
     /// Get the selectivity of the on conditions.
     ///
-    /// Note that the selectivity of the on conditions does not depend on join type. Join type is accounted for separately in get_join_selectivity_core().
+    /// Note that the selectivity of the on conditions does not depend on join type.
+    /// Join type is accounted for separately in get_join_selectivity_core().
     ///
     /// We also check if each predicate is correlated with any of the previous predicates.
     ///
@@ -420,11 +434,12 @@ impl<
     //
     /// However, we don't just throw away A = C, because we want to pick the most selective predicates.
     ///
-    /// More generally, if we have N columns that are equal, and the set of predicates P that make them equal (|P| >= N - 1),
-    /// we select compute the MST of the graph where the columns are nodes and the predicates are edges.
+    /// More generally, if we have N columns that are equal, and the set of predicates P that
+    /// defines the equality (|P| >= N - 1), we select compute the MST of the graph where the
+    /// columns are nodes and the predicates are edges.
     ///
-    /// Then the selecitivy of such "redundant" predicate p is the MST of the graph with p (minimum as in having
-    /// the smallest product of selectivities) divided by the MST of the graph without p.
+    /// Then the selecitivy of such "redundant" predicate p is the MST of the graph with p (minimum
+    /// as in having the smallest product of selectivities) divided by the MST of the graph without p.
     fn get_join_on_selectivity(
         &self,
         on_col_ref_pairs: &[(ColumnRefExpr, ColumnRefExpr)],
@@ -477,7 +492,8 @@ mod tests {
         },
     };
 
-    /// A wrapper around get_join_selectivity_from_expr_tree that extracts the table row counts from the cost model
+    /// A wrapper around get_join_selectivity_from_expr_tree that extracts the
+    /// table row counts from the cost model.
     fn test_get_join_selectivity(
         cost_model: &TestOptCostModel,
         reverse_tables: bool,
@@ -1019,7 +1035,8 @@ mod tests {
 
     /// Unique oncond means an oncondition on columns which are unique in both tables
     /// Filter means we're adding a join filter
-    /// There's only one case if both columns are unique and there's a filter: the inner will be < 1 / row count of both tables
+    /// There's only one case if both columns are unique and there's a filter:
+    /// the inner will be < 1 / row count of both tables
     #[test]
     fn test_outer_unique_oncond_filter() {
         let cost_model = create_two_table_cost_model_custom_row_cnts(

--- a/optd-datafusion-repr/src/cost/base_cost/join.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/join.rs
@@ -19,7 +19,7 @@ use crate::{
     },
     properties::column_ref::{
         BaseTableColumnRef, ColumnRef, ColumnRefPropertyBuilder, EqBaseTableColumnSets,
-        EqPredicate, GroupColumnRefs,
+        EqPredicate, GroupColumnRefs, SemanticCorrelation,
     },
 };
 
@@ -448,9 +448,9 @@ impl<
     ) -> f64 {
         let mut past_eq_columns = column_refs
             .input_correlation()
-            .unwrap()
-            .eq_base_table_columns()
-            .clone();
+            .map(SemanticCorrelation::eq_base_table_columns)
+            .cloned()
+            .unwrap_or_default();
 
         // multiply the selectivities of all individual conditions together
         on_col_ref_pairs
@@ -617,7 +617,7 @@ mod tests {
         );
         assert_approx_eq::assert_approx_eq!(
             test_get_join_selectivity(&cost_model, false, JoinType::Inner, expr_tree, &column_refs),
-            0.04
+            0.2
         );
         assert_approx_eq::assert_approx_eq!(
             test_get_join_selectivity(
@@ -627,7 +627,7 @@ mod tests {
                 expr_tree_rev,
                 &column_refs
             ),
-            0.04
+            0.2
         );
     }
 

--- a/optd-datafusion-repr/src/cost/base_cost/join.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/join.rs
@@ -76,7 +76,7 @@ impl<
             let right_keys_group_id = context.children_group_ids[3];
             let left_col_cnt = optimizer
                 .get_property_by_group::<ColumnRefPropertyBuilder>(context.children_group_ids[0], 1)
-                .column_refs
+                .column_refs()
                 .len();
             let left_keys_list = optimizer.get_all_group_bindings(left_keys_group_id, false);
             let right_keys_list = optimizer.get_all_group_bindings(right_keys_group_id, false);
@@ -380,7 +380,7 @@ mod tests {
             cost_model.get_join_selectivity_from_expr_tree(
                 JoinType::Inner,
                 cnst(Value::Bool(true)),
-                &GroupColumnRefs::new(vec![], None),
+                &GroupColumnRefs::new_test(vec![], None),
                 f64::NAN,
                 f64::NAN
             ),
@@ -390,7 +390,7 @@ mod tests {
             cost_model.get_join_selectivity_from_expr_tree(
                 JoinType::Inner,
                 cnst(Value::Bool(false)),
-                &GroupColumnRefs::new(vec![], None),
+                &GroupColumnRefs::new_test(vec![], None),
                 f64::NAN,
                 f64::NAN
             ),
@@ -416,7 +416,7 @@ mod tests {
         );
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), col_ref(1));
         let expr_tree_rev = bin_op(BinOpType::Eq, col_ref(1), col_ref(0));
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![
                 ColumnRef::base_table_column_ref(String::from(TABLE1_NAME), 0),
                 ColumnRef::base_table_column_ref(String::from(TABLE2_NAME), 0),
@@ -459,7 +459,7 @@ mod tests {
         let eq1and0 = bin_op(BinOpType::Eq, col_ref(1), col_ref(0));
         let expr_tree = log_op(LogOpType::And, vec![eq0and1.clone(), eq1and0.clone()]);
         let expr_tree_rev = log_op(LogOpType::And, vec![eq1and0.clone(), eq0and1.clone()]);
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![
                 ColumnRef::base_table_column_ref(String::from(TABLE1_NAME), 0),
                 ColumnRef::base_table_column_ref(String::from(TABLE2_NAME), 0),
@@ -502,7 +502,7 @@ mod tests {
         let eq100 = bin_op(BinOpType::Eq, col_ref(1), cnst(Value::Int32(100)));
         let expr_tree = log_op(LogOpType::And, vec![eq0and1.clone(), eq100.clone()]);
         let expr_tree_rev = log_op(LogOpType::And, vec![eq100.clone(), eq0and1.clone()]);
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![
                 ColumnRef::base_table_column_ref(String::from(TABLE1_NAME), 0),
                 ColumnRef::base_table_column_ref(String::from(TABLE2_NAME), 0),
@@ -545,7 +545,7 @@ mod tests {
         let eq100 = bin_op(BinOpType::Eq, col_ref(1), cnst(Value::Int32(100)));
         let expr_tree = log_op(LogOpType::And, vec![neq12.clone(), eq100.clone()]);
         let expr_tree_rev = log_op(LogOpType::And, vec![eq100.clone(), neq12.clone()]);
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![
                 ColumnRef::base_table_column_ref(String::from(TABLE1_NAME), 0),
                 ColumnRef::base_table_column_ref(String::from(TABLE2_NAME), 0),
@@ -585,7 +585,7 @@ mod tests {
             ),
         );
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), col_ref(0));
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![
                 ColumnRef::base_table_column_ref(String::from(TABLE1_NAME), 0),
                 ColumnRef::base_table_column_ref(String::from(TABLE2_NAME), 0),
@@ -717,7 +717,7 @@ mod tests {
         // the left/right of the join refers to the tables, not the order of columns in the predicate
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), col_ref(1));
         let expr_tree_rev = bin_op(BinOpType::Eq, col_ref(1), col_ref(0));
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![
                 ColumnRef::base_table_column_ref(String::from(TABLE1_NAME), 0),
                 ColumnRef::base_table_column_ref(String::from(TABLE2_NAME), 0),
@@ -780,7 +780,7 @@ mod tests {
         // the left/right of the join refers to the tables, not the order of columns in the predicate
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), col_ref(1));
         let expr_tree_rev = bin_op(BinOpType::Eq, col_ref(1), col_ref(0));
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![
                 ColumnRef::base_table_column_ref(String::from(TABLE1_NAME), 0),
                 ColumnRef::base_table_column_ref(String::from(TABLE2_NAME), 0),
@@ -844,7 +844,7 @@ mod tests {
         // the left/right of the join refers to the tables, not the order of columns in the predicate
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), col_ref(1));
         let expr_tree_rev = bin_op(BinOpType::Eq, col_ref(1), col_ref(0));
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![
                 ColumnRef::base_table_column_ref(String::from(TABLE1_NAME), 0),
                 ColumnRef::base_table_column_ref(String::from(TABLE2_NAME), 0),
@@ -912,7 +912,7 @@ mod tests {
         let expr_tree = log_op(LogOpType::And, vec![eq0and1, filter.clone()]);
         // inner rev means its the inner expr (the eq op) whose children are being reversed, as opposed to the and op
         let expr_tree_inner_rev = log_op(LogOpType::And, vec![eq1and0, filter.clone()]);
-        let column_refs = GroupColumnRefs::new(
+        let column_refs = GroupColumnRefs::new_test(
             vec![
                 ColumnRef::base_table_column_ref(String::from(TABLE1_NAME), 0),
                 ColumnRef::base_table_column_ref(String::from(TABLE2_NAME), 0),

--- a/optd-datafusion-repr/src/cost/base_cost/join.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/join.rs
@@ -328,7 +328,6 @@ impl<
             });
             // using reduce(f64::min) is the idiomatic workaround to min() because f64 does not implement Ord due to NaN
             let selectivity = ndistincts.map(|ndistinct| 1.0 / ndistinct as f64).reduce(f64::min).expect("reduce() only returns None if the iterator is empty, which is impossible since col_ref_exprs.len() == 2");
-            println!("selectivity: {:?}", selectivity);
             assert!(!selectivity.is_nan(), "it should be impossible for selectivity to be NaN since n-distinct is never 0");
             selectivity
         }).product()

--- a/optd-datafusion-repr/src/cost/base_cost/join.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/join.rs
@@ -416,6 +416,8 @@ impl<
     /// `past_eq_columns`, `predicate` produces a selectivity adjustment factor, which is the
     /// multiplied selectivity of the most selective N - 1 predicate among `past_eq_columns` union
     /// `predicate` divided by the selectivity of the `past_eq_columns`.
+    ///
+    /// NOTE: This function modifies `past_eq_columns` by adding `predicate` to it.
     fn get_join_selectivity_adjustment_from_redundant_predicates(
         &self,
         predicate: EqPredicate,

--- a/optd-datafusion-repr/src/properties/column_ref.rs
+++ b/optd-datafusion-repr/src/properties/column_ref.rs
@@ -97,7 +97,7 @@ impl EqPredicate {
 
 /// A disjoint set of base table columns with equal values in the same row,
 /// along with the predicates that define the equalities.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct EqBaseTableColumnSets {
     disjoint_eq_col_sets: DisjointSets<BaseTableColumnRef>,
     eq_predicates: HashSet<EqPredicate>,

--- a/optd-datafusion-repr/src/properties/column_ref.rs
+++ b/optd-datafusion-repr/src/properties/column_ref.rs
@@ -11,7 +11,7 @@ use crate::plan_nodes::{BinOpType, EmptyRelationData, JoinType, LogOpType, OptRe
 use super::schema::Catalog;
 use super::DEFAULT_NAME;
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
 pub struct BaseTableColumnRef {
     pub table: String,
     pub col_idx: usize,
@@ -35,6 +35,12 @@ impl ColumnRef {
 
     pub fn child_column_ref(col_idx: usize) -> Self {
         ColumnRef::ChildColumnRef { col_idx }
+    }
+}
+
+impl From<BaseTableColumnRef> for ColumnRef {
+    fn from(col: BaseTableColumnRef) -> Self {
+        ColumnRef::BaseTableColumnRef(col)
     }
 }
 
@@ -72,21 +78,13 @@ pub enum EqColumns {
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct EqPredicate {
-    left: BaseTableColumnRef,
-    right: BaseTableColumnRef,
+    pub left: BaseTableColumnRef,
+    pub right: BaseTableColumnRef,
 }
 
 impl EqPredicate {
     pub fn new(left: BaseTableColumnRef, right: BaseTableColumnRef) -> Self {
         Self { left, right }
-    }
-
-    pub fn left(&self) -> &BaseTableColumnRef {
-        &self.left
-    }
-
-    pub fn right(&self) -> &BaseTableColumnRef {
-        &self.right
     }
 }
 
@@ -107,8 +105,8 @@ impl EqBaseTableColumnSets {
     }
 
     pub fn add_predicate(&mut self, predicate: EqPredicate) {
-        let left = predicate.left();
-        let right = predicate.right();
+        let left = &predicate.left;
+        let right = &predicate.right;
 
         // Add the indices to the set if they do not exist.
         if !self.disjoint_eq_col_sets.contains(left) {
@@ -132,7 +130,13 @@ impl EqBaseTableColumnSets {
 
     /// Determine if two columns are equal.
     pub fn is_eq(&mut self, left: &BaseTableColumnRef, right: &BaseTableColumnRef) -> bool {
-        self.disjoint_eq_col_sets.same_set(left, right).unwrap()
+        self.disjoint_eq_col_sets
+            .same_set(left, right)
+            .unwrap_or(false)
+    }
+
+    pub fn num_eq_columns(&mut self, col: &BaseTableColumnRef) -> usize {
+        self.disjoint_eq_col_sets.set_size(col).unwrap()
     }
 
     /// Find the set of predicates that define the equality of the set of columns `col` belongs to.
@@ -142,8 +146,8 @@ impl EqBaseTableColumnSets {
     ) -> Vec<EqPredicate> {
         let mut predicates = Vec::new();
         for predicate in &self.eq_predicates {
-            let left = predicate.left();
-            let right = predicate.right();
+            let left = &predicate.left;
+            let right = &predicate.right;
             if (left != col && self.disjoint_eq_col_sets.same_set(col, left).unwrap())
                 || (right != col && self.disjoint_eq_col_sets.same_set(col, right).unwrap())
             {
@@ -392,10 +396,6 @@ impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
                     }
                     _ => None,
                 };
-                println!(
-                    "left: {:?}\n right: {:?}\n join condition: {:?}\n input correlation: {:#?} \n output correlation: {:#?}",
-                    children[0], children[1], children[2], input_correlation, output_correlation
-                );
                 GroupColumnRefs::new(column_refs, output_correlation, input_correlation)
             }
             OptRelNodeTyp::Agg => {

--- a/optd-datafusion-repr/src/properties/column_ref.rs
+++ b/optd-datafusion-repr/src/properties/column_ref.rs
@@ -1,6 +1,10 @@
+use std::collections::HashSet;
+use std::ops::Index;
 use std::{ops::Deref, sync::Arc};
 
 use optd_core::property::PropertyBuilder;
+use union_find::disjoint_sets::DisjointSets;
+use union_find::union_find::UnionFind;
 
 use crate::plan_nodes::{EmptyRelationData, OptRelNodeTyp};
 
@@ -9,12 +13,103 @@ use super::DEFAULT_NAME;
 
 #[derive(Clone, Debug)]
 pub enum ColumnRef {
-    BaseTableColumnRef { table: String, col_idx: usize },
-    ChildColumnRef { col_idx: usize },
+    BaseTableColumnRef {
+        table: String,
+        col_idx: usize,
+    },
+    /// This variant is only used when building the property. It should NEVER
+    /// be used when computing cost.
+    ChildColumnRef {
+        col_idx: usize,
+    },
     Derived,
 }
 
-pub type GroupColumnRefs = Vec<ColumnRef>;
+/// `SemanticCorrelation` represents the semantic correlation between columns in a
+/// query. "Semantic" means that the columns are correlated based on the
+/// semantics of the query, not the statistics.
+#[derive(Clone, Debug, Default)]
+pub struct SemanticCorrelation {
+    eq_column_sets: EqColumnSets,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct EqPredicate {
+    left: usize,
+    right: usize,
+}
+
+impl EqPredicate {
+    pub fn new(left: usize, right: usize) -> Self {
+        Self {
+            left: left.min(right),
+            right: left.max(right),
+        }
+    }
+
+    pub fn left(&self) -> usize {
+        self.left
+    }
+
+    pub fn right(&self) -> usize {
+        self.right
+    }
+}
+
+/// A disjoint set of columns with equal values in the same row, along with the
+/// predicates that define the equality.
+#[derive(Clone, Debug, Default)]
+pub struct EqColumnSets {
+    eq_cols: DisjointSets<usize>,
+    eq_predicates: HashSet<EqPredicate>,
+}
+
+impl EqColumnSets {
+    pub fn add_predicate(&mut self, predicate: EqPredicate) {
+        self.eq_predicates.insert(predicate);
+
+        let left = predicate.left();
+        let right = predicate.right();
+        // Add the indices to the set if they do not exist.
+        if !self.eq_cols.contains(left) {
+            self.eq_cols
+                .make_set(left)
+                .expect("just checked left column index does not exist");
+        }
+        if !self.eq_cols.contains(right) {
+            self.eq_cols
+                .make_set(right)
+                .expect("just checked right column index does not exist");
+        }
+        // Union the columns.
+        self.eq_cols
+            .union(left, right)
+            .expect("both column indices should exist");
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct GroupColumnRefs {
+    pub column_refs: Vec<ColumnRef>,
+    pub correlation: Option<SemanticCorrelation>,
+}
+
+impl GroupColumnRefs {
+    pub fn new(column_refs: Vec<ColumnRef>, correlation: Option<SemanticCorrelation>) -> Self {
+        Self {
+            column_refs,
+            correlation,
+        }
+    }
+}
+
+impl Index<usize> for GroupColumnRefs {
+    type Output = ColumnRef;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.column_refs[index]
+    }
+}
 
 pub struct ColumnRefPropertyBuilder {
     catalog: Arc<dyn Catalog>,
@@ -25,8 +120,13 @@ impl ColumnRefPropertyBuilder {
         Self { catalog }
     }
 
-    fn concat_children_properties(children: &[&GroupColumnRefs]) -> GroupColumnRefs {
-        children.iter().flat_map(Deref::deref).cloned().collect()
+    fn concat_children_col_refs(children: &[&GroupColumnRefs]) -> Vec<ColumnRef> {
+        children
+            .iter()
+            .map(|c| &c.column_refs)
+            .flat_map(Deref::deref)
+            .cloned()
+            .collect()
     }
 }
 
@@ -45,12 +145,13 @@ impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
                 let table_name = data.unwrap().as_str().to_string();
                 let schema = self.catalog.get(&table_name);
                 let column_cnt = schema.fields.len();
-                (0..column_cnt)
+                let column_refs = (0..column_cnt)
                     .map(|i| ColumnRef::BaseTableColumnRef {
                         table: table_name.clone(),
                         col_idx: i,
                     })
-                    .collect()
+                    .collect();
+                GroupColumnRefs::new(column_refs, None)
             }
             OptRelNodeTyp::EmptyRelation => {
                 let data = data.unwrap().as_slice();
@@ -58,58 +159,74 @@ impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
                     bincode::deserialize(data.as_ref()).unwrap();
                 let schema = empty_relation_data.schema;
                 let column_cnt = schema.fields.len();
-                (0..column_cnt)
+                let column_refs = (0..column_cnt)
                     .map(|i| ColumnRef::BaseTableColumnRef {
                         table: DEFAULT_NAME.to_string(),
                         col_idx: i,
                     })
-                    .collect()
+                    .collect();
+                GroupColumnRefs::new(column_refs, None)
             }
             OptRelNodeTyp::ColumnRef => {
                 let col_ref_idx = data.unwrap().as_u64();
                 // this is always safe since col_ref_idx was initially a usize in ColumnRefExpr::new()
                 let usize_col_ref_idx = col_ref_idx as usize;
-                vec![ColumnRef::ChildColumnRef {
+                let column_refs = vec![ColumnRef::ChildColumnRef {
                     col_idx: usize_col_ref_idx,
-                }]
+                }];
+                GroupColumnRefs::new(column_refs, None)
             }
             OptRelNodeTyp::List => {
-                // Concatentate the children properties.
-                Self::concat_children_properties(children)
+                // Concatentate the children column refs.
+                let column_refs = Self::concat_children_col_refs(children);
+                GroupColumnRefs::new(column_refs, None)
             }
             OptRelNodeTyp::LogOp(_) => {
-                // Concatentate the children properties.
-                Self::concat_children_properties(children)
+                // Concatentate the children column refs.
+                let column_refs = Self::concat_children_col_refs(children);
+                GroupColumnRefs::new(column_refs, None)
             }
-            OptRelNodeTyp::Projection => children[1]
-                .iter()
-                .map(|p| match p {
-                    ColumnRef::ChildColumnRef { col_idx } => children[0][*col_idx].clone(),
-                    ColumnRef::Derived => ColumnRef::Derived,
-                    _ => panic!("projection expr must be Derived or ChildColumnRef"),
-                })
-                .collect(),
+            OptRelNodeTyp::Projection => {
+                let child = children[0];
+                let exprs = children[1];
+                let column_refs = exprs
+                    .column_refs
+                    .iter()
+                    .map(|p| match p {
+                        ColumnRef::ChildColumnRef { col_idx } => {
+                            children[0].column_refs[*col_idx].clone()
+                        }
+                        ColumnRef::Derived => ColumnRef::Derived,
+                        _ => panic!("projection expr must be Derived or ChildColumnRef"),
+                    })
+                    .collect();
+                // Projection keeps the semantic correlations of the children.
+                GroupColumnRefs::new(column_refs, child.correlation.clone())
+            }
             // Should account for all physical join types.
             OptRelNodeTyp::Join(_) => {
-                // Concatenate left and right children properties.
-                Self::concat_children_properties(&children[0..2])
+                // Concatenate left and right children column refs.
+                let column_refs = Self::concat_children_col_refs(&children[0..2]);
+                GroupColumnRefs::new(column_refs, None)
             }
             OptRelNodeTyp::Agg => {
                 // Group by columns first.
                 let mut group_by_col_refs: Vec<_> = children[2]
+                    .column_refs
                     .iter()
                     .map(|p| {
                         let col_idx = match p {
                             ColumnRef::ChildColumnRef { col_idx } => *col_idx,
                             _ => panic!("group by expr must be ColumnRef"),
                         };
-                        children[0][col_idx].clone()
+                        children[0].column_refs[col_idx].clone()
                     })
                     .collect();
                 // Then the aggregate expressions. These columns, (e.g. SUM, COUNT, etc.) are derived columns.
-                let agg_expr_cnt = children[1].len();
+                let agg_expr_cnt = children[1].column_refs.len();
                 group_by_col_refs.extend((0..agg_expr_cnt).map(|_| ColumnRef::Derived));
-                group_by_col_refs
+                // Aggregation clears all semantic correlations.
+                GroupColumnRefs::new(group_by_col_refs, None)
             }
             OptRelNodeTyp::Filter
             | OptRelNodeTyp::Sort
@@ -125,9 +242,7 @@ impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
             | OptRelNodeTyp::DataType(_)
             | OptRelNodeTyp::Between
             | OptRelNodeTyp::Like
-            | OptRelNodeTyp::InList => {
-                vec![ColumnRef::Derived]
-            }
+            | OptRelNodeTyp::InList => GroupColumnRefs::new(vec![ColumnRef::Derived], None),
             _ => unimplemented!("Unsupported rel node type {:?}", typ),
         }
     }

--- a/optd-datafusion-repr/src/properties/column_ref.rs
+++ b/optd-datafusion-repr/src/properties/column_ref.rs
@@ -132,16 +132,46 @@ impl EqBaseTableColumnSets {
 
 #[derive(Clone, Debug)]
 pub struct GroupColumnRefs {
-    pub column_refs: Vec<ColumnRef>,
-    pub correlation: Option<SemanticCorrelation>,
+    column_refs: Vec<ColumnRef>,
+    /// Correlation of the output of the group. Used to build the logical property.
+    output_correlation: Option<SemanticCorrelation>,
+    /// Correlation of the input of the group. It can only be `Some` for plan nodes.
+    input_correlation: Option<SemanticCorrelation>,
 }
 
 impl GroupColumnRefs {
-    pub fn new(column_refs: Vec<ColumnRef>, correlation: Option<SemanticCorrelation>) -> Self {
+    pub fn new(
+        column_refs: Vec<ColumnRef>,
+        output_correlation: Option<SemanticCorrelation>,
+        input_correlation: Option<SemanticCorrelation>,
+    ) -> Self {
         Self {
             column_refs,
-            correlation,
+            output_correlation,
+            input_correlation,
         }
+    }
+
+    #[cfg(test)]
+    // There's no need for `output_correlation` in tests, since it's only used
+    // when driving the property from children.
+    pub fn new_test(
+        column_refs: Vec<ColumnRef>,
+        input_correlation: Option<SemanticCorrelation>,
+    ) -> Self {
+        Self {
+            column_refs,
+            output_correlation: None,
+            input_correlation,
+        }
+    }
+
+    pub fn column_refs(&self) -> &[ColumnRef] {
+        &self.column_refs
+    }
+
+    pub fn input_correlation(&self) -> Option<&SemanticCorrelation> {
+        self.input_correlation.as_ref()
     }
 }
 
@@ -190,7 +220,7 @@ impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
                 let column_refs = (0..column_cnt)
                     .map(|i| ColumnRef::base_table_column_ref(table_name.clone(), i))
                     .collect();
-                GroupColumnRefs::new(column_refs, None)
+                GroupColumnRefs::new(column_refs, None, None)
             }
             OptRelNodeTyp::EmptyRelation => {
                 let data = data.unwrap().as_slice();
@@ -201,7 +231,7 @@ impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
                 let column_refs = (0..column_cnt)
                     .map(|i| ColumnRef::base_table_column_ref(DEFAULT_NAME.to_string(), i))
                     .collect();
-                GroupColumnRefs::new(column_refs, None)
+                GroupColumnRefs::new(column_refs, None, None)
             }
             OptRelNodeTyp::ColumnRef => {
                 let col_ref_idx = data.unwrap().as_u64();
@@ -210,12 +240,12 @@ impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
                 let column_refs = vec![ColumnRef::ChildColumnRef {
                     col_idx: usize_col_ref_idx,
                 }];
-                GroupColumnRefs::new(column_refs, None)
+                GroupColumnRefs::new(column_refs, None, None)
             }
             OptRelNodeTyp::List => {
                 // Concatentate the children column refs.
                 let column_refs = Self::concat_children_col_refs(children);
-                GroupColumnRefs::new(column_refs, None)
+                GroupColumnRefs::new(column_refs, None, None)
             }
             OptRelNodeTyp::LogOp(op_type) => {
                 let column_refs = vec![ColumnRef::Derived];
@@ -227,7 +257,7 @@ impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
                             for child in children {
                                 if let Some(SemanticCorrelation {
                                     eq_column: EqColumns::EqColumnIdxPairs(pairs),
-                                }) = &child.correlation
+                                }) = &child.output_correlation
                                 {
                                     eq_column_idx_pairs.extend(pairs.iter());
                                 }
@@ -239,7 +269,7 @@ impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
                         _ => None,
                     }
                 };
-                GroupColumnRefs::new(column_refs, correlation)
+                GroupColumnRefs::new(column_refs, correlation, None)
             }
             OptRelNodeTyp::Projection => {
                 let child = children[0];
@@ -256,47 +286,59 @@ impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
                     })
                     .collect();
                 // Projection keeps the semantic correlations of the children.
-                GroupColumnRefs::new(column_refs, child.correlation.clone())
+                GroupColumnRefs::new(
+                    column_refs,
+                    child.output_correlation.clone(),
+                    child.output_correlation.clone(),
+                )
             }
             // Should account for all physical join types.
             OptRelNodeTyp::Join(join_type) => {
                 // Concatenate left and right children column refs.
                 let column_refs = Self::concat_children_col_refs(&children[0..2]);
-                let correlation = match join_type {
+                // Merge the equal columns of two children as input correlation.
+                let children_eq_columns = {
+                    let left = children[0].output_correlation.as_ref();
+                    let right = children[1].output_correlation.as_ref();
+                    match (left, right) {
+                        (
+                            Some(SemanticCorrelation {
+                                eq_column: EqColumns::EqBaseTableColumnSets(left),
+                            }),
+                            Some(SemanticCorrelation {
+                                eq_column: EqColumns::EqBaseTableColumnSets(right),
+                            }),
+                        ) => EqBaseTableColumnSets::union(left, right),
+                        (
+                            Some(SemanticCorrelation {
+                                eq_column: EqColumns::EqBaseTableColumnSets(left),
+                            }),
+                            None,
+                        ) => left.clone(),
+                        (
+                            None,
+                            Some(SemanticCorrelation {
+                                eq_column: EqColumns::EqBaseTableColumnSets(right),
+                            }),
+                        ) => right.clone(),
+                        _ => EqBaseTableColumnSets::new(),
+                    }
+                };
+                let mut eq_columns = children_eq_columns.clone();
+                let input_correlation = Some(SemanticCorrelation {
+                    eq_column: EqColumns::EqBaseTableColumnSets(children_eq_columns),
+                });
+
+                // If the join type is inner or cross, merge the equal columns in the join condition
+                // into the those from the children.
+                //
+                // Otherwise be conservative and discard all correlations.
+                let output_correlation = match join_type {
                     JoinType::Inner | JoinType::Cross => {
                         // Merge the equal columns in the join condition into the those from the children.
-                        // Step 1: merge the equal columns of two children.
-                        let mut eq_columns = {
-                            let left = children[0].correlation.as_ref();
-                            let right = children[1].correlation.as_ref();
-                            match (left, right) {
-                                (
-                                    Some(SemanticCorrelation {
-                                        eq_column: EqColumns::EqBaseTableColumnSets(left),
-                                    }),
-                                    Some(SemanticCorrelation {
-                                        eq_column: EqColumns::EqBaseTableColumnSets(right),
-                                    }),
-                                ) => EqBaseTableColumnSets::union(left, right),
-                                (
-                                    Some(SemanticCorrelation {
-                                        eq_column: EqColumns::EqBaseTableColumnSets(left),
-                                    }),
-                                    None,
-                                ) => left.clone(),
-                                (
-                                    None,
-                                    Some(SemanticCorrelation {
-                                        eq_column: EqColumns::EqBaseTableColumnSets(right),
-                                    }),
-                                ) => right.clone(),
-                                _ => EqBaseTableColumnSets::new(),
-                            }
-                        };
-                        // Step 2: merge join condition into children's equal columns.
                         if let Some(SemanticCorrelation {
                             eq_column: EqColumns::EqColumnIdxPairs(pairs),
-                        }) = &children[2].correlation
+                        }) = &children[2].output_correlation
                         {
                             for (l_col_idx, r_col_idx) in pairs {
                                 let l_col_ref = &column_refs[*l_col_idx];
@@ -317,13 +359,14 @@ impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
                     }
                     _ => None,
                 };
-                // println!(
-                //     "left: {:#?}, right: {:#?}, join condition: {:#?}, new correlation: {:#?}",
-                //     children[0], children[1], children[2], correlation
-                // );
-                GroupColumnRefs::new(column_refs, correlation)
+                println!(
+                    "left: {:?}\n right: {:?}\n join condition: {:?}\n input correlation: {:#?} \n output correlation: {:#?}",
+                    children[0], children[1], children[2], input_correlation, output_correlation
+                );
+                GroupColumnRefs::new(column_refs, output_correlation, input_correlation)
             }
             OptRelNodeTyp::Agg => {
+                let child = children[0];
                 // Group by columns first.
                 let mut group_by_col_refs: Vec<_> = children[2]
                     .column_refs
@@ -333,14 +376,14 @@ impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
                             ColumnRef::ChildColumnRef { col_idx } => *col_idx,
                             _ => panic!("group by expr must be ColumnRef"),
                         };
-                        children[0].column_refs[col_idx].clone()
+                        child.column_refs[col_idx].clone()
                     })
                     .collect();
                 // Then the aggregate expressions. These columns, (e.g. SUM, COUNT, etc.) are derived columns.
                 let agg_expr_cnt = children[1].column_refs.len();
                 group_by_col_refs.extend((0..agg_expr_cnt).map(|_| ColumnRef::Derived));
                 // Aggregation clears all semantic correlations.
-                GroupColumnRefs::new(group_by_col_refs, None)
+                GroupColumnRefs::new(group_by_col_refs, None, child.output_correlation.clone())
             }
             OptRelNodeTyp::Filter
             | OptRelNodeTyp::Sort
@@ -375,14 +418,14 @@ impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
                     }
                     _ => None,
                 };
-                GroupColumnRefs::new(column_refs, correlation)
+                GroupColumnRefs::new(column_refs, correlation, None)
             }
             OptRelNodeTyp::Constant(_)
             | OptRelNodeTyp::Func(_)
             | OptRelNodeTyp::DataType(_)
             | OptRelNodeTyp::Between
             | OptRelNodeTyp::Like
-            | OptRelNodeTyp::InList => GroupColumnRefs::new(vec![ColumnRef::Derived], None),
+            | OptRelNodeTyp::InList => GroupColumnRefs::new(vec![ColumnRef::Derived], None, None),
             _ => unimplemented!("Unsupported rel node type {:?}", typ),
         }
     }

--- a/optd-datafusion-repr/src/properties/column_ref.rs
+++ b/optd-datafusion-repr/src/properties/column_ref.rs
@@ -53,6 +53,13 @@ pub struct SemanticCorrelation {
 }
 
 impl SemanticCorrelation {
+    #[cfg(test)]
+    pub fn new(eq_columns: EqBaseTableColumnSets) -> Self {
+        Self {
+            eq_columns: EqColumns::EqBaseTableColumnSets(eq_columns),
+        }
+    }
+
     pub fn eq_base_table_columns(&self) -> &EqBaseTableColumnSets {
         if let EqColumns::EqBaseTableColumnSets(eq_columns) = &self.eq_columns {
             eq_columns
@@ -97,7 +104,7 @@ pub struct EqBaseTableColumnSets {
 }
 
 impl EqBaseTableColumnSets {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             disjoint_eq_col_sets: DisjointSets::new(),
             eq_predicates: HashSet::new(),

--- a/optd-datafusion-repr/src/properties/column_ref.rs
+++ b/optd-datafusion-repr/src/properties/column_ref.rs
@@ -12,17 +12,30 @@ use super::schema::Catalog;
 use super::DEFAULT_NAME;
 
 #[derive(Clone, Debug)]
+pub struct BaseTableColumnRef {
+    pub table: String,
+    pub col_idx: usize,
+}
+
+#[derive(Clone, Debug)]
 pub enum ColumnRef {
-    BaseTableColumnRef {
-        table: String,
-        col_idx: usize,
-    },
+    BaseTableColumnRef(BaseTableColumnRef),
     /// This variant is only used when building the property. It should NEVER
     /// be used when computing cost.
     ChildColumnRef {
         col_idx: usize,
     },
     Derived,
+}
+
+impl ColumnRef {
+    pub fn base_table_column_ref(table: String, col_idx: usize) -> Self {
+        ColumnRef::BaseTableColumnRef(BaseTableColumnRef { table, col_idx })
+    }
+
+    pub fn child_column_ref(col_idx: usize) -> Self {
+        ColumnRef::ChildColumnRef { col_idx }
+    }
 }
 
 /// `SemanticCorrelation` represents the semantic correlation between columns in a
@@ -146,10 +159,7 @@ impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
                 let schema = self.catalog.get(&table_name);
                 let column_cnt = schema.fields.len();
                 let column_refs = (0..column_cnt)
-                    .map(|i| ColumnRef::BaseTableColumnRef {
-                        table: table_name.clone(),
-                        col_idx: i,
-                    })
+                    .map(|i| ColumnRef::base_table_column_ref(table_name.clone(), i))
                     .collect();
                 GroupColumnRefs::new(column_refs, None)
             }
@@ -160,10 +170,7 @@ impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
                 let schema = empty_relation_data.schema;
                 let column_cnt = schema.fields.len();
                 let column_refs = (0..column_cnt)
-                    .map(|i| ColumnRef::BaseTableColumnRef {
-                        table: DEFAULT_NAME.to_string(),
-                        col_idx: i,
-                    })
+                    .map(|i| ColumnRef::base_table_column_ref(DEFAULT_NAME.to_string(), i))
                     .collect();
                 GroupColumnRefs::new(column_refs, None)
             }

--- a/optd-datafusion-repr/src/properties/column_ref.rs
+++ b/optd-datafusion-repr/src/properties/column_ref.rs
@@ -6,12 +6,12 @@ use optd_core::property::PropertyBuilder;
 use union_find::disjoint_sets::DisjointSets;
 use union_find::union_find::UnionFind;
 
-use crate::plan_nodes::{EmptyRelationData, OptRelNodeTyp};
+use crate::plan_nodes::{BinOpType, EmptyRelationData, JoinType, LogOpType, OptRelNodeTyp};
 
 use super::schema::Catalog;
 use super::DEFAULT_NAME;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct BaseTableColumnRef {
     pub table: String,
     pub col_idx: usize,
@@ -41,63 +41,92 @@ impl ColumnRef {
 /// `SemanticCorrelation` represents the semantic correlation between columns in a
 /// query. "Semantic" means that the columns are correlated based on the
 /// semantics of the query, not the statistics.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct SemanticCorrelation {
-    eq_column_sets: EqColumnSets,
+    eq_column: EqColumns,
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug)]
+pub enum EqColumns {
+    /// Equal columns denoted by sets of base table columns,
+    /// e.g. t1.c1 = t2.c2 = t3.c3.
+    EqBaseTableColumnSets(EqBaseTableColumnSets),
+    /// Equal columns denoted by pairs of column indices. This is for keeping
+    /// track of the column indices in the filter/join predicates, which only
+    /// contains relative column indices.
+    ///
+    /// It is only used when building the property. It should NEVER be used when
+    /// computing cost.
+    EqColumnIdxPairs(Vec<(usize, usize)>),
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct EqPredicate {
-    left: usize,
-    right: usize,
+    left: BaseTableColumnRef,
+    right: BaseTableColumnRef,
 }
 
 impl EqPredicate {
-    pub fn new(left: usize, right: usize) -> Self {
-        Self {
-            left: left.min(right),
-            right: left.max(right),
-        }
+    pub fn new(left: BaseTableColumnRef, right: BaseTableColumnRef) -> Self {
+        Self { left, right }
     }
 
-    pub fn left(&self) -> usize {
-        self.left
+    pub fn left(&self) -> &BaseTableColumnRef {
+        &self.left
     }
 
-    pub fn right(&self) -> usize {
-        self.right
+    pub fn right(&self) -> &BaseTableColumnRef {
+        &self.right
     }
 }
 
-/// A disjoint set of columns with equal values in the same row, along with the
-/// predicates that define the equality.
-#[derive(Clone, Debug, Default)]
-pub struct EqColumnSets {
-    eq_cols: DisjointSets<usize>,
+/// A disjoint set of base table columns with equal values in the same row,
+/// along with the predicates that define the equality.
+#[derive(Clone, Debug)]
+pub struct EqBaseTableColumnSets {
+    disjoint_eq_col_sets: DisjointSets<BaseTableColumnRef>,
     eq_predicates: HashSet<EqPredicate>,
 }
 
-impl EqColumnSets {
-    pub fn add_predicate(&mut self, predicate: EqPredicate) {
-        self.eq_predicates.insert(predicate);
+impl EqBaseTableColumnSets {
+    fn new() -> Self {
+        Self {
+            disjoint_eq_col_sets: DisjointSets::new(),
+            eq_predicates: HashSet::new(),
+        }
+    }
 
+    pub fn add_predicate(&mut self, predicate: EqPredicate) {
         let left = predicate.left();
         let right = predicate.right();
+
         // Add the indices to the set if they do not exist.
-        if !self.eq_cols.contains(left) {
-            self.eq_cols
-                .make_set(left)
+        if !self.disjoint_eq_col_sets.contains(left) {
+            self.disjoint_eq_col_sets
+                .make_set(left.clone())
                 .expect("just checked left column index does not exist");
         }
-        if !self.eq_cols.contains(right) {
-            self.eq_cols
-                .make_set(right)
+        if !self.disjoint_eq_col_sets.contains(right) {
+            self.disjoint_eq_col_sets
+                .make_set(right.clone())
                 .expect("just checked right column index does not exist");
         }
         // Union the columns.
-        self.eq_cols
+        self.disjoint_eq_col_sets
             .union(left, right)
             .expect("both column indices should exist");
+
+        // Keep track of the predicate.
+        self.eq_predicates.insert(predicate);
+    }
+
+    pub fn union(x: &EqBaseTableColumnSets, y: &EqBaseTableColumnSets) -> EqBaseTableColumnSets {
+        let mut eq_col_sets = Self::new();
+        // TODO: one redundant clone here.
+        for predicate in x.eq_predicates.union(&y.eq_predicates).cloned() {
+            eq_col_sets.add_predicate(predicate);
+        }
+        eq_col_sets
     }
 }
 
@@ -188,10 +217,29 @@ impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
                 let column_refs = Self::concat_children_col_refs(children);
                 GroupColumnRefs::new(column_refs, None)
             }
-            OptRelNodeTyp::LogOp(_) => {
-                // Concatentate the children column refs.
-                let column_refs = Self::concat_children_col_refs(children);
-                GroupColumnRefs::new(column_refs, None)
+            OptRelNodeTyp::LogOp(op_type) => {
+                let column_refs = vec![ColumnRef::Derived];
+                // For AND, combine the eq columns of each child expression.
+                let correlation = {
+                    match op_type {
+                        LogOpType::And => {
+                            let mut eq_column_idx_pairs = Vec::new();
+                            for child in children {
+                                if let Some(SemanticCorrelation {
+                                    eq_column: EqColumns::EqColumnIdxPairs(pairs),
+                                }) = &child.correlation
+                                {
+                                    eq_column_idx_pairs.extend(pairs.iter());
+                                }
+                            }
+                            Some(SemanticCorrelation {
+                                eq_column: EqColumns::EqColumnIdxPairs(eq_column_idx_pairs),
+                            })
+                        }
+                        _ => None,
+                    }
+                };
+                GroupColumnRefs::new(column_refs, correlation)
             }
             OptRelNodeTyp::Projection => {
                 let child = children[0];
@@ -211,10 +259,69 @@ impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
                 GroupColumnRefs::new(column_refs, child.correlation.clone())
             }
             // Should account for all physical join types.
-            OptRelNodeTyp::Join(_) => {
+            OptRelNodeTyp::Join(join_type) => {
                 // Concatenate left and right children column refs.
                 let column_refs = Self::concat_children_col_refs(&children[0..2]);
-                GroupColumnRefs::new(column_refs, None)
+                let correlation = match join_type {
+                    JoinType::Inner | JoinType::Cross => {
+                        // Merge the equal columns in the join condition into the those from the children.
+                        // Step 1: merge the equal columns of two children.
+                        let mut eq_columns = {
+                            let left = children[0].correlation.as_ref();
+                            let right = children[1].correlation.as_ref();
+                            match (left, right) {
+                                (
+                                    Some(SemanticCorrelation {
+                                        eq_column: EqColumns::EqBaseTableColumnSets(left),
+                                    }),
+                                    Some(SemanticCorrelation {
+                                        eq_column: EqColumns::EqBaseTableColumnSets(right),
+                                    }),
+                                ) => EqBaseTableColumnSets::union(left, right),
+                                (
+                                    Some(SemanticCorrelation {
+                                        eq_column: EqColumns::EqBaseTableColumnSets(left),
+                                    }),
+                                    None,
+                                ) => left.clone(),
+                                (
+                                    None,
+                                    Some(SemanticCorrelation {
+                                        eq_column: EqColumns::EqBaseTableColumnSets(right),
+                                    }),
+                                ) => right.clone(),
+                                _ => EqBaseTableColumnSets::new(),
+                            }
+                        };
+                        // Step 2: merge join condition into children's equal columns.
+                        if let Some(SemanticCorrelation {
+                            eq_column: EqColumns::EqColumnIdxPairs(pairs),
+                        }) = &children[2].correlation
+                        {
+                            for (l_col_idx, r_col_idx) in pairs {
+                                let l_col_ref = &column_refs[*l_col_idx];
+                                let r_col_ref = &column_refs[*r_col_idx];
+                                if let (
+                                    ColumnRef::BaseTableColumnRef(l),
+                                    ColumnRef::BaseTableColumnRef(r),
+                                ) = (l_col_ref, r_col_ref)
+                                {
+                                    eq_columns
+                                        .add_predicate(EqPredicate::new(l.clone(), r.clone()));
+                                }
+                            }
+                        };
+                        Some(SemanticCorrelation {
+                            eq_column: EqColumns::EqBaseTableColumnSets(eq_columns),
+                        })
+                    }
+                    _ => None,
+                };
+                // println!(
+                //     "left: {:#?}, right: {:#?}, join condition: {:#?}, new correlation: {:#?}",
+                //     children[0], children[1], children[2], correlation
+                // );
+                GroupColumnRefs::new(column_refs, correlation)
             }
             OptRelNodeTyp::Agg => {
                 // Group by columns first.
@@ -243,9 +350,35 @@ impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
                 // FIXME: we just assume the column value does not change.
                 children[0].clone()
             }
+            OptRelNodeTyp::BinOp(op_type) => {
+                let column_refs = vec![ColumnRef::Derived];
+                // For correlation, we only handle the column = column case, e.g. #0 = #1.
+                let correlation = match op_type {
+                    BinOpType::Eq => {
+                        let l_col_ref = &children[0].column_refs;
+                        let r_col_ref = &children[1].column_refs;
+                        if l_col_ref.len() != 1 || r_col_ref.len() != 1 {
+                            None
+                        } else {
+                            match (&l_col_ref[0], &r_col_ref[0]) {
+                                (
+                                    ColumnRef::ChildColumnRef { col_idx: l_col_idx },
+                                    ColumnRef::ChildColumnRef { col_idx: r_col_idx },
+                                ) => Some(SemanticCorrelation {
+                                    eq_column: EqColumns::EqColumnIdxPairs(vec![(
+                                        *l_col_idx, *r_col_idx,
+                                    )]),
+                                }),
+                                _ => None,
+                            }
+                        }
+                    }
+                    _ => None,
+                };
+                GroupColumnRefs::new(column_refs, correlation)
+            }
             OptRelNodeTyp::Constant(_)
             | OptRelNodeTyp::Func(_)
-            | OptRelNodeTyp::BinOp(_)
             | OptRelNodeTyp::DataType(_)
             | OptRelNodeTyp::Between
             | OptRelNodeTyp::Like

--- a/optd-datafusion-repr/src/properties/column_ref.rs
+++ b/optd-datafusion-repr/src/properties/column_ref.rs
@@ -43,7 +43,17 @@ impl ColumnRef {
 /// semantics of the query, not the statistics.
 #[derive(Clone, Debug)]
 pub struct SemanticCorrelation {
-    eq_column: EqColumns,
+    eq_columns: EqColumns,
+}
+
+impl SemanticCorrelation {
+    pub fn eq_base_table_columns(&self) -> &EqBaseTableColumnSets {
+        if let EqColumns::EqBaseTableColumnSets(eq_columns) = &self.eq_columns {
+            eq_columns
+        } else {
+            panic!("not EqBaseTableColumnSets");
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -118,6 +128,29 @@ impl EqBaseTableColumnSets {
 
         // Keep track of the predicate.
         self.eq_predicates.insert(predicate);
+    }
+
+    /// Determine if two columns are equal.
+    pub fn is_eq(&mut self, left: &BaseTableColumnRef, right: &BaseTableColumnRef) -> bool {
+        self.disjoint_eq_col_sets.same_set(left, right).unwrap()
+    }
+
+    /// Find the set of predicates that define the equality of the set of columns `col` belongs to.
+    pub fn find_predicates_for_eq_column_set(
+        &mut self,
+        col: &BaseTableColumnRef,
+    ) -> Vec<EqPredicate> {
+        let mut predicates = Vec::new();
+        for predicate in &self.eq_predicates {
+            let left = predicate.left();
+            let right = predicate.right();
+            if (left != col && self.disjoint_eq_col_sets.same_set(col, left).unwrap())
+                || (right != col && self.disjoint_eq_col_sets.same_set(col, right).unwrap())
+            {
+                predicates.push(predicate.clone());
+            }
+        }
+        predicates
     }
 
     pub fn union(x: &EqBaseTableColumnSets, y: &EqBaseTableColumnSets) -> EqBaseTableColumnSets {
@@ -256,14 +289,14 @@ impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
                             let mut eq_column_idx_pairs = Vec::new();
                             for child in children {
                                 if let Some(SemanticCorrelation {
-                                    eq_column: EqColumns::EqColumnIdxPairs(pairs),
+                                    eq_columns: EqColumns::EqColumnIdxPairs(pairs),
                                 }) = &child.output_correlation
                                 {
                                     eq_column_idx_pairs.extend(pairs.iter());
                                 }
                             }
                             Some(SemanticCorrelation {
-                                eq_column: EqColumns::EqColumnIdxPairs(eq_column_idx_pairs),
+                                eq_columns: EqColumns::EqColumnIdxPairs(eq_column_idx_pairs),
                             })
                         }
                         _ => None,
@@ -303,22 +336,22 @@ impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
                     match (left, right) {
                         (
                             Some(SemanticCorrelation {
-                                eq_column: EqColumns::EqBaseTableColumnSets(left),
+                                eq_columns: EqColumns::EqBaseTableColumnSets(left),
                             }),
                             Some(SemanticCorrelation {
-                                eq_column: EqColumns::EqBaseTableColumnSets(right),
+                                eq_columns: EqColumns::EqBaseTableColumnSets(right),
                             }),
                         ) => EqBaseTableColumnSets::union(left, right),
                         (
                             Some(SemanticCorrelation {
-                                eq_column: EqColumns::EqBaseTableColumnSets(left),
+                                eq_columns: EqColumns::EqBaseTableColumnSets(left),
                             }),
                             None,
                         ) => left.clone(),
                         (
                             None,
                             Some(SemanticCorrelation {
-                                eq_column: EqColumns::EqBaseTableColumnSets(right),
+                                eq_columns: EqColumns::EqBaseTableColumnSets(right),
                             }),
                         ) => right.clone(),
                         _ => EqBaseTableColumnSets::new(),
@@ -326,7 +359,7 @@ impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
                 };
                 let mut eq_columns = children_eq_columns.clone();
                 let input_correlation = Some(SemanticCorrelation {
-                    eq_column: EqColumns::EqBaseTableColumnSets(children_eq_columns),
+                    eq_columns: EqColumns::EqBaseTableColumnSets(children_eq_columns),
                 });
 
                 // If the join type is inner or cross, merge the equal columns in the join condition
@@ -337,7 +370,7 @@ impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
                     JoinType::Inner | JoinType::Cross => {
                         // Merge the equal columns in the join condition into the those from the children.
                         if let Some(SemanticCorrelation {
-                            eq_column: EqColumns::EqColumnIdxPairs(pairs),
+                            eq_columns: EqColumns::EqColumnIdxPairs(pairs),
                         }) = &children[2].output_correlation
                         {
                             for (l_col_idx, r_col_idx) in pairs {
@@ -354,7 +387,7 @@ impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
                             }
                         };
                         Some(SemanticCorrelation {
-                            eq_column: EqColumns::EqBaseTableColumnSets(eq_columns),
+                            eq_columns: EqColumns::EqBaseTableColumnSets(eq_columns),
                         })
                     }
                     _ => None,
@@ -408,7 +441,7 @@ impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
                                     ColumnRef::ChildColumnRef { col_idx: l_col_idx },
                                     ColumnRef::ChildColumnRef { col_idx: r_col_idx },
                                 ) => Some(SemanticCorrelation {
-                                    eq_column: EqColumns::EqColumnIdxPairs(vec![(
+                                    eq_columns: EqColumns::EqColumnIdxPairs(vec![(
                                         *l_col_idx, *r_col_idx,
                                     )]),
                                 }),
@@ -432,5 +465,64 @@ impl PropertyBuilder<OptRelNodeTyp> for ColumnRefPropertyBuilder {
 
     fn property_name(&self) -> &'static str {
         "column_ref"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_eq_base_table_column_sets() {
+        let col1 = BaseTableColumnRef {
+            table: "t1".to_string(),
+            col_idx: 1,
+        };
+        let col2 = BaseTableColumnRef {
+            table: "t2".to_string(),
+            col_idx: 2,
+        };
+        let col3 = BaseTableColumnRef {
+            table: "t3".to_string(),
+            col_idx: 3,
+        };
+        let col4 = BaseTableColumnRef {
+            table: "t4".to_string(),
+            col_idx: 4,
+        };
+        let pred1 = EqPredicate::new(col1.clone(), col2.clone());
+        let pred2 = EqPredicate::new(col3.clone(), col4.clone());
+        let pred3 = EqPredicate::new(col1.clone(), col3.clone());
+
+        let mut eq_col_sets = EqBaseTableColumnSets::new();
+
+        // (1, 2)
+        eq_col_sets.add_predicate(pred1.clone());
+        assert!(eq_col_sets.is_eq(&col1, &col2));
+
+        // (1, 2), (3, 4)
+        eq_col_sets.add_predicate(pred2.clone());
+        assert!(eq_col_sets.is_eq(&col3, &col4));
+        assert!(!eq_col_sets.is_eq(&col2, &col3));
+
+        let predicates = eq_col_sets.find_predicates_for_eq_column_set(&col1);
+        assert_eq!(predicates.len(), 1);
+        assert!(predicates.contains(&pred1));
+
+        let predicates = eq_col_sets.find_predicates_for_eq_column_set(&col3);
+        assert_eq!(predicates.len(), 1);
+        assert!(predicates.contains(&pred2));
+
+        // (1, 2, 3, 4)
+        eq_col_sets.add_predicate(pred3.clone());
+        assert!(eq_col_sets.is_eq(&col1, &col3));
+        assert!(eq_col_sets.is_eq(&col2, &col4));
+        assert!(eq_col_sets.is_eq(&col1, &col4));
+
+        let predicates = eq_col_sets.find_predicates_for_eq_column_set(&col1);
+        assert_eq!(predicates.len(), 3);
+        assert!(predicates.contains(&pred1));
+        assert!(predicates.contains(&pred2));
+        assert!(predicates.contains(&pred3));
     }
 }

--- a/optd-datafusion-repr/src/properties/column_ref.rs
+++ b/optd-datafusion-repr/src/properties/column_ref.rs
@@ -71,15 +71,15 @@ impl SemanticCorrelation {
 
 #[derive(Clone, Debug)]
 pub enum EqColumns {
-    /// Equal columns denoted by sets of base table columns,
-    /// e.g. t1.c1 = t2.c2 = t3.c3.
+    /// Equal columns denoted by disjoint sets of base table columns,
+    /// e.g. {{ t1.c1 = t2.c1 = t3.c1 }, { t1.c2 = t2.c2 }}.
     EqBaseTableColumnSets(EqBaseTableColumnSets),
     /// Equal columns denoted by pairs of column indices. This is for keeping
     /// track of the column indices in the filter/join predicates, which only
     /// contains relative column indices.
     ///
-    /// It is only used when building the property. It should NEVER be used when
-    /// computing cost.
+    /// It is only used when building the property. It should NEVER be used in
+    /// cost computation.
     EqColumnIdxPairs(Vec<(usize, usize)>),
 }
 
@@ -96,7 +96,7 @@ impl EqPredicate {
 }
 
 /// A disjoint set of base table columns with equal values in the same row,
-/// along with the predicates that define the equality.
+/// along with the predicates that define the equalities.
 #[derive(Clone, Debug)]
 pub struct EqBaseTableColumnSets {
     disjoint_eq_col_sets: DisjointSets<BaseTableColumnRef>,
@@ -142,6 +142,7 @@ impl EqBaseTableColumnSets {
             .unwrap_or(false)
     }
 
+    /// Get the number of columns that are equal to `col`, including `col` itself.
     pub fn num_eq_columns(&mut self, col: &BaseTableColumnRef) -> usize {
         self.disjoint_eq_col_sets.set_size(col).unwrap()
     }
@@ -164,6 +165,7 @@ impl EqBaseTableColumnSets {
         predicates
     }
 
+    /// Union two `EqBaseTableColumnSets` to produce a new disjoint sets.
     pub fn union(x: &EqBaseTableColumnSets, y: &EqBaseTableColumnSets) -> EqBaseTableColumnSets {
         let mut eq_col_sets = Self::new();
         // TODO: one redundant clone here.
@@ -177,9 +179,9 @@ impl EqBaseTableColumnSets {
 #[derive(Clone, Debug)]
 pub struct GroupColumnRefs {
     column_refs: Vec<ColumnRef>,
-    /// Correlation of the output of the group. Used to build the logical property.
+    /// Correlation of the output columns of the group. Only used to build the logical property.
     output_correlation: Option<SemanticCorrelation>,
-    /// Correlation of the input of the group. It can only be `Some` for plan nodes.
+    /// Correlation of the input columns of the group. It can only be `Some` for plan nodes.
     input_correlation: Option<SemanticCorrelation>,
 }
 
@@ -196,9 +198,9 @@ impl GroupColumnRefs {
         }
     }
 
-    #[cfg(test)]
     // There's no need for `output_correlation` in tests, since it's only used
-    // when driving the property from children.
+    // when deriving the property from children.
+    #[cfg(test)]
     pub fn new_test(
         column_refs: Vec<ColumnRef>,
         input_correlation: Option<SemanticCorrelation>,


### PR DESCRIPTION
## Background

An investigation of JOB revealed that the reason optd output 1 for all queries was that the selectivities of redundant predicates are all evaluated. A set of predicate contains redundant predicates if some of them can be expressed by others. For example, consider query 1a.

```sql
SELECT mc.note AS production_note,
       t.title AS movie_title,
       t.production_year AS movie_year
FROM company_type AS ct,
     info_type AS it,
     movie_companies AS mc,
     movie_info_idx AS mi_idx,
     title AS t
WHERE ct.kind = 'production companies'
  AND it.info = 'top 250 rank'
  AND mc.note NOT LIKE '%(as Metro-Goldwyn-Mayer Pictures)%'
  AND (mc.note LIKE '%(co-production)%'
       OR mc.note LIKE '%(presents)%')
  AND ct.id = mc.company_type_id
  AND t.id = mc.movie_id
  AND t.id = mi_idx.movie_id
  AND mc.movie_id = mi_idx.movie_id
  AND it.id = mi_idx.info_type_id;
```

In the join plan node with `t` as one of the input tables, the predicates would contain both `t.id = mc.movie_id` and `t.id = mi_idx.movie_id`. But since there's already `mc.movie_id = mi_idx.movie_id`, one of these three predicates is redundant.

## Goal

Given a set of predicates `P` that define the equality of `N` predicates, we want to pick `N - 1` most selective predicates `P'` and remove the rest.

## Implementation

### Identifying Equal Columns

We identify the set of predicates in `GroupColumnRefs` logical property using union find, because this way we can reuse the logic of base table column ref to identify which columns are equal. 

❗ ***However, `BaseTableColumnRef` does not handle table alias, so if `t1` and `t2` are both aliases for `t`, `t1.a = t2.b` and `t1.b = t2.a` will be treated as the same predicate.***

### Computing Selecitivty for `P'`

The difficulty is that we don't get to see all the predicates all at once. Instead, we see those predicates gradually as we move up the plan tree, and the child might have already picked some predicate that is not among `P'`. E.g. in the above example, even if `mc.movie_id = mi_idx.movie_id` (denoted `p3`) is the most selective predicate and thus should have been eliminated, it will be picked by `mc` join `mi_idx` because it's the only predicate it sees.

Therefore, the two predicates involving `t` (denote `t.id = mc.movie_id` as `p1` and `t.id = mi_idx.movie_id` as `p2`) should introduce some "selectivity adjustment factor". More specifically, if we see `p1` first we can just pick it, since `p1` and `p3` are not redundant. When we see `p2`, we need to pick two of the three predicates, but remember `p3` and `p1` are already picked. So in this case instead of just multiplying the total selectivity with `p2`'s, `p2` provides some sort of selectivity adjustment factor which can be computed by `MSP({p1, p2, p3}) / MSP({p1, p3})`, where `MSP` is the multiplied selectivies of the Most Selective Predicates that define the equality of the columns. `MSP` is computed using Kruskal.

This idea can be generalized to more predicates.

## Results

This features significantly improves q-error for the JOB benchmark. Before this PR, the estimated cardinalities for all columns are just `1`.

