### PR TITLE
feat: cost model handles cast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,8 +964,10 @@ checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets 0.48.5",
 ]
 
@@ -2802,6 +2804,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arrow-schema",
+ "chrono",
  "itertools 0.11.0",
  "num-derive",
  "num-traits",
@@ -2840,6 +2843,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "camelpaste",
+ "chrono",
  "datafusion",
  "datafusion-expr",
  "itertools 0.11.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2801,6 +2801,7 @@ name = "optd-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arrow-schema",
  "itertools 0.11.0",
  "num-derive",
  "num-traits",

--- a/optd-core/Cargo.toml
+++ b/optd-core/Cargo.toml
@@ -16,3 +16,4 @@ pretty-xmlish = "0.1"
 itertools = "0.11"
 serde = {version = "1.0", features = ["derive", "rc"]}
 arrow-schema = "47.0.0"
+chrono = "0.4"

--- a/optd-core/Cargo.toml
+++ b/optd-core/Cargo.toml
@@ -15,3 +15,4 @@ tracing-subscriber = "0.3"
 pretty-xmlish = "0.1"
 itertools = "0.11"
 serde = {version = "1.0", features = ["derive", "rc"]}
+arrow-schema = "47.0.0"

--- a/optd-core/src/rel_node.rs
+++ b/optd-core/src/rel_node.rs
@@ -96,7 +96,7 @@ impl std::fmt::Display for Value {
 
 /// The `as_*()` functions do not perform conversions. This is *unlike* the `as`
 /// keyword in rust.
-/// 
+///
 /// If you want to perform conversions, use the `to_*()` functions.
 impl Value {
     pub fn as_u8(&self) -> u8 {
@@ -192,27 +192,23 @@ impl Value {
 
     pub fn convert_to_type(&self, typ: DataType) -> Value {
         match typ {
-            DataType::Int32 => {
-                Value::Int32(match self {
-                    Value::Int32(i32) => *i32,
-                    Value::Int64(i64) => (*i64).try_into().unwrap(),
-                    _ => panic!("{self} could not be converted into an Int32"),
-                })
-            },
-            DataType::Date32 => {
-                Value::Date32(match self {
-                    Value::Date32(date32) => *date32,
-                    Value::String(str) => {
-                        let date = NaiveDate::parse_from_str(str, "%Y-%m-%d").unwrap();
-                        let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
-                        let duration_since_epoch = date.signed_duration_since(epoch);
-                        let days_since_epoch: i32 = duration_since_epoch.num_days() as i32;
-                        days_since_epoch
-                    },
-                    _ => panic!("{self} could not be converted into an Date32"),
-                })
-            }
-            _ => unimplemented!("Have not implemented convert_to_type for DataType {typ}")
+            DataType::Int32 => Value::Int32(match self {
+                Value::Int32(i32) => *i32,
+                Value::Int64(i64) => (*i64).try_into().unwrap(),
+                _ => panic!("{self} could not be converted into an Int32"),
+            }),
+            DataType::Date32 => Value::Date32(match self {
+                Value::Date32(date32) => *date32,
+                Value::String(str) => {
+                    let date = NaiveDate::parse_from_str(str, "%Y-%m-%d").unwrap();
+                    let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
+                    let duration_since_epoch = date.signed_duration_since(epoch);
+                    let days_since_epoch: i32 = duration_since_epoch.num_days() as i32;
+                    days_since_epoch
+                }
+                _ => panic!("{self} could not be converted into an Date32"),
+            }),
+            _ => unimplemented!("Have not implemented convert_to_type for DataType {typ}"),
         }
     }
 }

--- a/optd-core/src/rel_node.rs
+++ b/optd-core/src/rel_node.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use arrow_schema::DataType;
+use chrono::NaiveDate;
 use ordered_float::OrderedFloat;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -193,12 +194,25 @@ impl Value {
         match typ {
             DataType::Int32 => {
                 Value::Int32(match self {
-                    Value::Int32(i) => *i,
-                    Value::Int64(i) => (*i).try_into().unwrap(),
-                    _ => panic!("Value can not be converted into an i32"),
+                    Value::Int32(i32) => *i32,
+                    Value::Int64(i64) => (*i64).try_into().unwrap(),
+                    _ => panic!("{self} could not be converted into an Int32"),
+                })
+            },
+            DataType::Date32 => {
+                Value::Date32(match self {
+                    Value::Date32(date32) => *date32,
+                    Value::String(str) => {
+                        let date = NaiveDate::parse_from_str(str, "%Y-%m-%d").unwrap();
+                        let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
+                        let duration_since_epoch = date.signed_duration_since(epoch);
+                        let days_since_epoch: i32 = duration_since_epoch.num_days() as i32;
+                        days_since_epoch
+                    },
+                    _ => panic!("{self} could not be converted into an Date32"),
                 })
             }
-            _ => unimplemented!("Have not implemented convert_to_type for type {}", typ)
+            _ => unimplemented!("Have not implemented convert_to_type for DataType {typ}")
         }
     }
 }

--- a/optd-core/src/rel_node.rs
+++ b/optd-core/src/rel_node.rs
@@ -73,20 +73,20 @@ pub enum Value {
 impl std::fmt::Display for Value {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::UInt8(x) => write!(f, "{x}"),
-            Self::UInt16(x) => write!(f, "{x}"),
-            Self::UInt32(x) => write!(f, "{x}"),
-            Self::UInt64(x) => write!(f, "{x}"),
-            Self::Int8(x) => write!(f, "{x}"),
-            Self::Int16(x) => write!(f, "{x}"),
-            Self::Int32(x) => write!(f, "{x}"),
-            Self::Int64(x) => write!(f, "{x}"),
-            Self::Int128(x) => write!(f, "{x}"),
-            Self::Float(x) => write!(f, "{}", x.0),
+            Self::UInt8(x) => write!(f, "{x}(u8)"),
+            Self::UInt16(x) => write!(f, "{x}(u16)"),
+            Self::UInt32(x) => write!(f, "{x}(u32)"),
+            Self::UInt64(x) => write!(f, "{x}(u64)"),
+            Self::Int8(x) => write!(f, "{x}(i8)"),
+            Self::Int16(x) => write!(f, "{x}(i16)"),
+            Self::Int32(x) => write!(f, "{x}(i32)"),
+            Self::Int64(x) => write!(f, "{x}(i64)"),
+            Self::Int128(x) => write!(f, "{x}(i128)"),
+            Self::Float(x) => write!(f, "{}(float)", x.0),
             Self::String(x) => write!(f, "\"{x}\""),
             Self::Bool(x) => write!(f, "{x}"),
-            Self::Date32(x) => write!(f, "{x}"),
-            Self::Decimal128(x) => write!(f, "{x}"),
+            Self::Date32(x) => write!(f, "{x}(date32)"),
+            Self::Decimal128(x) => write!(f, "{x}(decimal128)"),
             Self::Serialized(x) => write!(f, "<len:{}>", x.len()),
         }
     }

--- a/optd-core/src/rel_node.rs
+++ b/optd-core/src/rel_node.rs
@@ -8,6 +8,7 @@ use std::{
     sync::Arc,
 };
 
+use arrow_schema::DataType;
 use ordered_float::OrderedFloat;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -92,6 +93,10 @@ impl std::fmt::Display for Value {
     }
 }
 
+/// The `as_*()` functions do not perform conversions. This is *unlike* the `as`
+/// keyword in rust.
+/// 
+/// If you want to perform conversions, use the `to_*()` functions.
 impl Value {
     pub fn as_u8(&self) -> u8 {
         match self {
@@ -181,6 +186,19 @@ impl Value {
         match self {
             Value::Serialized(i) => i.clone(),
             _ => panic!("Value is not a serialized"),
+        }
+    }
+
+    pub fn convert_to_type(&self, typ: DataType) -> Value {
+        match typ {
+            DataType::Int32 => {
+                Value::Int32(match self {
+                    Value::Int32(i) => *i,
+                    Value::Int64(i) => (*i).try_into().unwrap(),
+                    _ => panic!("Value can not be converted into an i32"),
+                })
+            }
+            _ => unimplemented!("Have not implemented convert_to_type for type {}", typ)
         }
     }
 }

--- a/optd-datafusion-bridge/src/from_optd.rs
+++ b/optd-datafusion-bridge/src/from_optd.rs
@@ -34,9 +34,6 @@ use optd_datafusion_repr::{
 
 use crate::{physical_collector::CollectorExec, OptdPlanContext};
 
-// TODO: current DataType and ConstantType are not 1 to 1 mapping
-// optd schema stores constantType from data type in catalog.get
-// for decimal128, the precision is lost
 fn from_optd_schema(optd_schema: OptdSchema) -> Schema {
     let match_type = |typ: &ConstantType| typ.into_data_type();
     let mut fields = Vec::with_capacity(optd_schema.len());

--- a/optd-datafusion-bridge/src/from_optd.rs
+++ b/optd-datafusion-bridge/src/from_optd.rs
@@ -1,10 +1,9 @@
 use std::{collections::HashMap, sync::Arc};
 
 use anyhow::{bail, Context, Result};
-use arrow_schema::IntervalUnit;
 use async_recursion::async_recursion;
 use datafusion::{
-    arrow::datatypes::{DataType, Field, Schema, SchemaRef},
+    arrow::datatypes::{Field, Schema, SchemaRef},
     datasource::source_as_provider,
     logical_expr::Operator,
     physical_expr,
@@ -39,23 +38,7 @@ use crate::{physical_collector::CollectorExec, OptdPlanContext};
 // optd schema stores constantType from data type in catalog.get
 // for decimal128, the precision is lost
 fn from_optd_schema(optd_schema: OptdSchema) -> Schema {
-    let match_type = |typ: &ConstantType| match typ {
-        ConstantType::Any => unimplemented!(),
-        ConstantType::Bool => DataType::Boolean,
-        ConstantType::UInt8 => DataType::UInt8,
-        ConstantType::UInt16 => DataType::UInt16,
-        ConstantType::UInt32 => DataType::UInt32,
-        ConstantType::UInt64 => DataType::UInt64,
-        ConstantType::Int8 => DataType::Int8,
-        ConstantType::Int16 => DataType::Int16,
-        ConstantType::Int32 => DataType::Int32,
-        ConstantType::Int64 => DataType::Int64,
-        ConstantType::Float64 => DataType::Float64,
-        ConstantType::Date => DataType::Date32,
-        ConstantType::IntervalMonthDateNano => DataType::Interval(IntervalUnit::MonthDayNano),
-        ConstantType::Decimal => DataType::Float64,
-        ConstantType::Utf8String => DataType::Utf8,
-    };
+    let match_type = |typ: &ConstantType| typ.into_data_type();
     let mut fields = Vec::with_capacity(optd_schema.len());
     for field in optd_schema.fields {
         fields.push(Field::new(

--- a/optd-datafusion-repr/Cargo.toml
+++ b/optd-datafusion-repr/Cargo.toml
@@ -27,3 +27,4 @@ serde_with = {version = "3.7.0", features = ["json"]}
 bincode = "1.3.3"
 union-find = { git = "https://github.com/Gun9niR/union-find-rs.git", rev = "794821514f7daefcbb8d5f38ef04e62fc18b5665" }
 test-case = "3.3"
+chrono = "0.4"

--- a/optd-datafusion-repr/src/cost/base_cost.rs
+++ b/optd-datafusion-repr/src/cost/base_cost.rs
@@ -242,7 +242,9 @@ mod tests {
     use crate::{
         cost::base_cost::stats::*,
         plan_nodes::{
-            BinOpExpr, BinOpType, CastExpr, ColumnRefExpr, ConstantExpr, Expr, ExprList, InListExpr, LikeExpr, LogOpExpr, LogOpType, OptRelNode, OptRelNodeRef, UnOpExpr, UnOpType
+            BinOpExpr, BinOpType, CastExpr, ColumnRefExpr, ConstantExpr, Expr, ExprList,
+            InListExpr, LikeExpr, LogOpExpr, LogOpType, OptRelNode, OptRelNodeRef, UnOpExpr,
+            UnOpType,
         },
     };
 
@@ -463,7 +465,11 @@ mod tests {
     }
 
     pub fn cast(child: OptRelNodeRef, cast_type: DataType) -> OptRelNodeRef {
-        CastExpr::new(Expr::from_rel_node(child).expect("child should be an Expr"), cast_type).into_rel_node()
+        CastExpr::new(
+            Expr::from_rel_node(child).expect("child should be an Expr"),
+            cast_type,
+        )
+        .into_rel_node()
     }
 
     pub fn bin_op(op_type: BinOpType, left: OptRelNodeRef, right: OptRelNodeRef) -> OptRelNodeRef {

--- a/optd-datafusion-repr/src/cost/base_cost.rs
+++ b/optd-datafusion-repr/src/cost/base_cost.rs
@@ -233,6 +233,7 @@ impl<
 /// and optd-datafusion-repr
 #[cfg(test)]
 mod tests {
+    use arrow_schema::DataType;
     use itertools::Itertools;
     use optd_core::rel_node::Value;
     use serde::{Deserialize, Serialize};
@@ -241,8 +242,7 @@ mod tests {
     use crate::{
         cost::base_cost::stats::*,
         plan_nodes::{
-            BinOpExpr, BinOpType, ColumnRefExpr, ConstantExpr, Expr, ExprList, InListExpr,
-            LikeExpr, LogOpExpr, LogOpType, OptRelNode, OptRelNodeRef, UnOpExpr, UnOpType,
+            BinOpExpr, BinOpType, CastExpr, ColumnRefExpr, ConstantExpr, Expr, ExprList, InListExpr, LikeExpr, LogOpExpr, LogOpType, OptRelNode, OptRelNodeRef, UnOpExpr, UnOpType
         },
     };
 
@@ -460,6 +460,10 @@ mod tests {
 
     pub fn cnst(value: Value) -> OptRelNodeRef {
         ConstantExpr::new(value).into_rel_node()
+    }
+
+    pub fn cast(child: OptRelNodeRef, cast_type: DataType) -> OptRelNodeRef {
+        CastExpr::new(Expr::from_rel_node(child).expect("child should be an Expr"), cast_type).into_rel_node()
     }
 
     pub fn bin_op(op_type: BinOpType, left: OptRelNodeRef, right: OptRelNodeRef) -> OptRelNodeRef {

--- a/optd-datafusion-repr/src/cost/base_cost/filter.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/filter.rs
@@ -190,39 +190,75 @@ impl<
         let mut non_col_ref_exprs = vec![];
         let is_left_col_ref;
 
-        // TODO(phw2): factor is_left_col_ref out of this function
+        // Recursively unwrap casts
+        let mut uncasted_left = left;
+        let mut uncasted_right = right;
+        loop {
+            if uncasted_left.as_ref().typ == OptRelNodeTyp::Cast && uncasted_right.as_ref().typ == OptRelNodeTyp::Cast {
+                let left_cast_expr = CastExpr::from_rel_node(uncasted_left).expect("we already checked that the type is Cast");
+                let right_cast_expr = CastExpr::from_rel_node(uncasted_right).expect("we already checked that the type is Cast");
+                assert!(left_cast_expr.cast_to() == right_cast_expr.cast_to());
+                uncasted_left = left_cast_expr.child().into_rel_node();
+                uncasted_right = right_cast_expr.child().into_rel_node();
+            } else if uncasted_left.as_ref().typ == OptRelNodeTyp::Cast || uncasted_right.as_ref().typ == OptRelNodeTyp::Cast {
+                let is_left_cast = uncasted_left.as_ref().typ == OptRelNodeTyp::Cast;
+                let (mut cast_node, mut non_cast_node) = if is_left_cast {
+                    (uncasted_left, uncasted_right)
+                } else {
+                    (uncasted_right, uncasted_left)
+                };
 
-        // I intentionally performed moves on left and right. This way, we don't accidentally use them after this block
-        // We always want to use "col_ref_expr" and "non_col_ref_expr" instead of "left" or "right"
-        match left.as_ref().typ {
+                let cast_expr = CastExpr::from_rel_node(cast_node).expect("we already checked that the type is Cast");
+                let cast_expr_child = cast_expr.child().into_rel_node();
+                let cast_expr_cast_to = cast_expr.cast_to();
+
+                match cast_expr_child.typ {
+                    OptRelNodeTyp::Constant(_) => {
+                        cast_node = ConstantExpr::new(ConstantExpr::from_rel_node(cast_expr_child).expect("we already checked that the type is Constant").value().convert_to_type(cast_expr_cast_to)).into_rel_node()
+                    }
+                    _ => todo!()
+                }
+
+                (uncasted_left, uncasted_right) = if is_left_cast {
+                    (cast_node, non_cast_node)
+                } else {
+                    (non_cast_node, cast_node)
+                }
+            } else {
+                break;
+            }
+        }
+
+        // Sort nodes into col_ref_exprs, values, and non_col_ref_exprs
+        match uncasted_left.as_ref().typ {
             OptRelNodeTyp::ColumnRef => {
                 is_left_col_ref = true;
                 col_ref_exprs.push(
-                    ColumnRefExpr::from_rel_node(left)
+                    ColumnRefExpr::from_rel_node(uncasted_left)
                         .expect("we already checked that the type is ColumnRef"),
                 );
             },
             OptRelNodeTyp::Constant(_) => {
                 is_left_col_ref = false;
-                values.push(ConstantExpr::from_rel_node(left).expect("we already checked that the type is Constant").value())
+                values.push(ConstantExpr::from_rel_node(uncasted_left).expect("we already checked that the type is Constant").value())
             }
             _ => {
                 is_left_col_ref = false;
-                non_col_ref_exprs.push(left);
+                non_col_ref_exprs.push(uncasted_left);
             }
         }
-        match right.as_ref().typ {
+        match uncasted_right.as_ref().typ {
             OptRelNodeTyp::ColumnRef => {
                 col_ref_exprs.push(
-                    ColumnRefExpr::from_rel_node(right)
+                    ColumnRefExpr::from_rel_node(uncasted_right)
                         .expect("we already checked that the type is ColumnRef"),
                 );
             },
             OptRelNodeTyp::Constant(_) => {
-                values.push(ConstantExpr::from_rel_node(right).expect("we already checked that the type is Constant").value())
+                values.push(ConstantExpr::from_rel_node(uncasted_right).expect("we already checked that the type is Constant").value())
             }
             _ => {
-                non_col_ref_exprs.push(right);
+                non_col_ref_exprs.push(uncasted_right);
             }
         }
 
@@ -462,6 +498,7 @@ impl<
 
 #[cfg(test)]
 mod tests {
+    use arrow_schema::DataType;
     use optd_core::rel_node::Value;
 
     use crate::{
@@ -1097,4 +1134,53 @@ mod tests {
     }
 
     // I didn't test any non-unique cases with filter. The non-unique tests without filter should cover that
+
+    #[test]
+    fn test_cast_value() {
+        let cost_model = create_one_column_cost_model(TestPerColumnStats::new(
+            TestMostCommonValues::new(vec![(Value::Int32(1), 0.3)]),
+            0,
+            0.1,
+            Some(TestDistribution::empty()),
+        ));
+        let expr_tree = bin_op(BinOpType::Eq, col_ref(0), cast(cnst(Value::Int64(1)), DataType::Int32));
+        let expr_tree_rev = bin_op(BinOpType::Eq, cast(cnst(Value::Int64(1)), DataType::Int32), col_ref(0));
+        let column_refs = GroupColumnRefs::new_test(
+            vec![ColumnRef::base_table_column_ref(
+                String::from(TABLE1_NAME),
+                0,
+            )],
+            None,
+        );
+        assert_approx_eq::assert_approx_eq!(
+            cost_model.get_filter_selectivity(expr_tree, &column_refs),
+            0.3
+        );
+        assert_approx_eq::assert_approx_eq!(
+            cost_model.get_filter_selectivity(expr_tree_rev, &column_refs),
+            0.3
+        );
+    }
+
+    #[test]
+    fn test_cast_colref() {
+        let cost_model = create_one_column_cost_model(TestPerColumnStats::new(
+            TestMostCommonValues::new(vec![(Value::Int32(1), 0.3)]),
+            0,
+            0.1,
+            Some(TestDistribution::empty()),
+        ));
+        let expr_tree = bin_op(BinOpType::Eq, cast(col_ref(0), DataType::Int64), cnst(Value::Int64(1)));
+        let column_refs = GroupColumnRefs::new_test(
+            vec![ColumnRef::base_table_column_ref(
+                String::from(TABLE1_NAME),
+                0,
+            )],
+            None,
+        );
+        assert_approx_eq::assert_approx_eq!(
+            cost_model.get_filter_selectivity(expr_tree, &column_refs),
+            0.3
+        );
+    }
 }

--- a/optd-datafusion-repr/src/cost/base_cost/filter.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/filter.rs
@@ -1,5 +1,6 @@
 use std::ops::Bound;
 
+use arrow_schema::DataType;
 use optd_core::{
     cascades::{CascadesOptimizer, RelNodeContext},
     cost::Cost,
@@ -13,11 +14,11 @@ use crate::{
         UNIMPLEMENTED_SEL,
     },
     plan_nodes::{
-        BinOpType, CastExpr, ColumnRefExpr, ConstantExpr, ConstantType, InListExpr, LikeExpr, LogOpType, OptRelNode, OptRelNodeRef, OptRelNodeTyp, UnOpType
+        BinOpType, CastExpr, ColumnRefExpr, ConstantExpr, ConstantType, Expr, InListExpr, LikeExpr, LogOpType, OptRelNode, OptRelNodeRef, OptRelNodeTyp, UnOpType
     },
-    properties::column_ref::{
+    properties::{column_ref::{
         BaseTableColumnRef, ColumnRef, ColumnRefPropertyBuilder, GroupColumnRefs,
-    },
+    }, schema::{Schema, SchemaPropertyBuilder}},
 };
 
 use super::{
@@ -41,6 +42,7 @@ impl<
         let (row_cnt, _, _) = Self::cost_tuple(&children[0]);
         let (_, compute_cost, _) = Self::cost_tuple(&children[1]);
         let selectivity = if let (Some(context), Some(optimizer)) = (context, optimizer) {
+            let schema = optimizer.get_property_by_group::<SchemaPropertyBuilder>(context.group_id, 0);
             let column_refs =
                 optimizer.get_property_by_group::<ColumnRefPropertyBuilder>(context.group_id, 1);
             let expr_group_id = context.children_group_ids[1];
@@ -48,7 +50,7 @@ impl<
             // there may be more than one expression tree in a group (you can see this trivially as you can just swap the order of two subtrees for commutative operators)
             // however, we just take an arbitrary expression tree from the group to compute selectivity
             let expr_tree = expr_trees.first().expect("expression missing");
-            self.get_filter_selectivity(expr_tree.clone(), &column_refs)
+            self.get_filter_selectivity(expr_tree.clone(), &schema, &column_refs)
         } else {
             DEFAULT_UNK_SEL
         };
@@ -75,6 +77,7 @@ impl<
     pub(super) fn get_filter_selectivity(
         &self,
         expr_tree: OptRelNodeRef,
+        schema: &Schema,
         column_refs: &GroupColumnRefs,
     ) -> f64 {
         assert!(expr_tree.typ.is_expression());
@@ -87,7 +90,7 @@ impl<
                 match un_op_typ {
                     // not doesn't care about nulls so there's no complex logic. it just reverses the selectivity
                     // for instance, != _will not_ include nulls but "NOT ==" _will_ include nulls
-                    UnOpType::Not => 1.0 - self.get_filter_selectivity(child, column_refs),
+                    UnOpType::Not => 1.0 - self.get_filter_selectivity(child, schema, column_refs),
                     UnOpType::Neg => panic!(
                         "the selectivity of operations that return numerical values is undefined"
                     ),
@@ -109,7 +112,7 @@ impl<
                 }
             }
             OptRelNodeTyp::LogOp(log_op_typ) => {
-                self.get_log_op_selectivity(*log_op_typ, &expr_tree.children, column_refs)
+                self.get_log_op_selectivity(*log_op_typ, &expr_tree.children, schema, column_refs)
             }
             OptRelNodeTyp::Func(_) => unimplemented!("check bool type or else panic"),
             OptRelNodeTyp::SortOrder(_) => {
@@ -165,11 +168,12 @@ impl<
         &self,
         log_op_typ: LogOpType,
         children: &[OptRelNodeRef],
+        schema: &Schema,
         column_refs: &GroupColumnRefs,
     ) -> f64 {
         let children_sel = children
             .iter()
-            .map(|expr| self.get_filter_selectivity(expr.clone(), column_refs));
+            .map(|expr| self.get_filter_selectivity(expr.clone(), schema, column_refs));
 
         match log_op_typ {
             LogOpType::And => children_sel.product(),
@@ -214,7 +218,12 @@ impl<
 
                 match cast_expr_child.typ {
                     OptRelNodeTyp::Constant(_) => {
-                        cast_node = ConstantExpr::new(ConstantExpr::from_rel_node(cast_expr_child).expect("we already checked that the type is Constant").value().convert_to_type(cast_expr_cast_to)).into_rel_node()
+                        cast_node = ConstantExpr::new(ConstantExpr::from_rel_node(cast_expr_child).expect("we already checked that the type is Constant").value().convert_to_type(cast_expr_cast_to)).into_rel_node();
+                    }
+                    OptRelNodeTyp::ColumnRef => {
+                        assert!(cast_expr_cast_to == DataType::Int64);
+                        cast_node = cast_expr_child;
+                        non_cast_node = CastExpr::new(Expr::from_rel_node(non_cast_node).unwrap(), DataType::Int32).into_rel_node();
                     }
                     _ => todo!()
                 }
@@ -504,7 +513,7 @@ mod tests {
     use crate::{
         cost::base_cost::tests::*,
         plan_nodes::{BinOpType, LogOpType, UnOpType},
-        properties::column_ref::{ColumnRef, GroupColumnRefs},
+        properties::{column_ref::{ColumnRef, GroupColumnRefs}, schema::Schema},
     };
 
     #[test]
@@ -513,6 +522,7 @@ mod tests {
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_filter_selectivity(
                 cnst(Value::Bool(true)),
+                &Schema::new(vec![]),
                 &GroupColumnRefs::new_test(vec![], None)
             ),
             1.0
@@ -520,6 +530,7 @@ mod tests {
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_filter_selectivity(
                 cnst(Value::Bool(false)),
+                &Schema::new(vec![]),
                 &GroupColumnRefs::new_test(vec![], None)
             ),
             0.0
@@ -536,6 +547,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), cnst(Value::Int32(1)));
         let expr_tree_rev = bin_op(BinOpType::Eq, cnst(Value::Int32(1)), col_ref(0));
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
@@ -544,11 +556,11 @@ mod tests {
             None,
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree, &schema, &column_refs),
             0.3
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree_rev, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree_rev, &schema, &column_refs),
             0.3
         );
     }
@@ -563,6 +575,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), cnst(Value::Int32(2)));
         let expr_tree_rev = bin_op(BinOpType::Eq, cnst(Value::Int32(2)), col_ref(0));
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
@@ -571,11 +584,11 @@ mod tests {
             None,
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree, &schema, &column_refs),
             0.12
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree_rev, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree_rev, &schema, &column_refs),
             0.12
         );
     }
@@ -590,6 +603,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), cnst(Value::Int32(2)));
         let expr_tree_rev = bin_op(BinOpType::Eq, cnst(Value::Int32(2)), col_ref(0));
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
@@ -598,11 +612,11 @@ mod tests {
             None,
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree, &schema, &column_refs),
             0.11
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree_rev, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree_rev, &schema, &column_refs),
             0.11
         );
     }
@@ -618,6 +632,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Neq, col_ref(0), cnst(Value::Int32(1)));
         let expr_tree_rev = bin_op(BinOpType::Neq, cnst(Value::Int32(1)), col_ref(0));
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
@@ -626,11 +641,11 @@ mod tests {
             None,
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree, &schema, &column_refs),
             1.0 - 0.3
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree_rev, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree_rev, &schema, &column_refs),
             1.0 - 0.3
         );
     }
@@ -645,6 +660,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Leq, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Gt, cnst(Value::Int32(15)), col_ref(0));
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
@@ -653,11 +669,11 @@ mod tests {
             None,
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree, &schema, &column_refs),
             0.7
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree_rev, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree_rev, &schema, &column_refs),
             0.7
         );
     }
@@ -672,6 +688,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Leq, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Gt, cnst(Value::Int32(15)), col_ref(0));
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
@@ -680,11 +697,11 @@ mod tests {
             None,
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree, &schema, &column_refs),
             0.7 * 0.9
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree_rev, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree_rev, &schema, &column_refs),
             0.7 * 0.9
         );
     }
@@ -708,6 +725,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Leq, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Gt, cnst(Value::Int32(15)), col_ref(0));
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
@@ -716,11 +734,11 @@ mod tests {
             None,
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree, &schema, &column_refs),
             0.85
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree_rev, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree_rev, &schema, &column_refs),
             0.85
         );
     }
@@ -740,6 +758,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Leq, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Gt, cnst(Value::Int32(15)), col_ref(0));
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
@@ -748,11 +767,11 @@ mod tests {
             None,
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree, &schema, &column_refs),
             0.93
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree_rev, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree_rev, &schema, &column_refs),
             0.93
         );
     }
@@ -767,6 +786,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Lt, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Geq, cnst(Value::Int32(15)), col_ref(0));
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
@@ -775,11 +795,11 @@ mod tests {
             None,
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree, &schema, &column_refs),
             0.6
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree_rev, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree_rev, &schema, &column_refs),
             0.6
         );
     }
@@ -794,6 +814,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Lt, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Geq, cnst(Value::Int32(15)), col_ref(0));
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
@@ -802,11 +823,11 @@ mod tests {
             None,
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree, &schema, &column_refs),
             0.6 * 0.9
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree_rev, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree_rev, &schema, &column_refs),
             0.6 * 0.9
         );
     }
@@ -830,6 +851,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Lt, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Geq, cnst(Value::Int32(15)), col_ref(0));
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
@@ -838,11 +860,11 @@ mod tests {
             None,
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree, &schema, &column_refs),
             0.75
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree_rev, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree_rev, &schema, &column_refs),
             0.75
         );
     }
@@ -866,6 +888,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Lt, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Geq, cnst(Value::Int32(15)), col_ref(0));
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
@@ -874,11 +897,11 @@ mod tests {
             None,
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree, &schema, &column_refs),
             0.85
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree_rev, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree_rev, &schema, &column_refs),
             0.85
         );
     }
@@ -895,6 +918,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Gt, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Leq, cnst(Value::Int32(15)), col_ref(0));
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
@@ -903,11 +927,11 @@ mod tests {
             None,
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree, &schema, &column_refs),
             1.0 - 0.7
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree_rev, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree_rev, &schema, &column_refs),
             1.0 - 0.7
         );
     }
@@ -922,6 +946,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Gt, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Leq, cnst(Value::Int32(15)), col_ref(0));
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
@@ -930,11 +955,11 @@ mod tests {
             None,
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree, &schema, &column_refs),
             (1.0 - 0.7) * 0.9
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree_rev, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree_rev, &schema, &column_refs),
             (1.0 - 0.7) * 0.9
         );
     }
@@ -950,6 +975,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Geq, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Lt, cnst(Value::Int32(15)), col_ref(0));
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
@@ -958,11 +984,11 @@ mod tests {
             None,
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree, &schema, &column_refs),
             1.0 - 0.6
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree_rev, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree_rev, &schema, &column_refs),
             1.0 - 0.6
         );
     }
@@ -977,6 +1003,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Geq, col_ref(0), cnst(Value::Int32(15)));
         let expr_tree_rev = bin_op(BinOpType::Lt, cnst(Value::Int32(15)), col_ref(0));
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
@@ -986,11 +1013,11 @@ mod tests {
         );
         // we have to add 0.1 since it's Geq
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree, &schema, &column_refs),
             (1.0 - 0.7 + 0.1) * 0.9
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree_rev, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree_rev, &schema, &column_refs),
             (1.0 - 0.7 + 0.1) * 0.9
         );
     }
@@ -1017,6 +1044,7 @@ mod tests {
         let expr_tree = log_op(LogOpType::And, vec![eq1.clone(), eq5.clone(), eq8.clone()]);
         let expr_tree_shift1 = log_op(LogOpType::And, vec![eq5.clone(), eq8.clone(), eq1.clone()]);
         let expr_tree_shift2 = log_op(LogOpType::And, vec![eq8.clone(), eq1.clone(), eq5.clone()]);
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
@@ -1025,15 +1053,15 @@ mod tests {
             None,
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree, &schema, &column_refs),
             0.03
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree_shift1, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree_shift1, &schema, &column_refs),
             0.03
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree_shift2, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree_shift2, &schema, &column_refs),
             0.03
         );
     }
@@ -1060,6 +1088,7 @@ mod tests {
         let expr_tree = log_op(LogOpType::Or, vec![eq1.clone(), eq5.clone(), eq8.clone()]);
         let expr_tree_shift1 = log_op(LogOpType::Or, vec![eq5.clone(), eq8.clone(), eq1.clone()]);
         let expr_tree_shift2 = log_op(LogOpType::Or, vec![eq8.clone(), eq1.clone(), eq5.clone()]);
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
@@ -1068,15 +1097,15 @@ mod tests {
             None,
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree, &schema, &column_refs),
             0.72
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree_shift1, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree_shift1, &schema, &column_refs),
             0.72
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree_shift2, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree_shift2, &schema, &column_refs),
             0.72
         );
     }
@@ -1093,6 +1122,7 @@ mod tests {
             UnOpType::Not,
             bin_op(BinOpType::Eq, col_ref(0), cnst(Value::Int32(1))),
         );
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
@@ -1101,7 +1131,7 @@ mod tests {
             None,
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree, &schema, &column_refs),
             0.7
         );
     }
@@ -1118,6 +1148,7 @@ mod tests {
             UnOpType::Not,
             bin_op(BinOpType::Eq, col_ref(0), cnst(Value::Int32(1))),
         );
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
@@ -1128,7 +1159,7 @@ mod tests {
         // not doesn't care about nulls. it just reverses the selectivity
         // for instance, != _will not_ include nulls but "NOT ==" _will_ include nulls
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree, &schema, &column_refs),
             0.7
         );
     }
@@ -1145,6 +1176,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), cast(cnst(Value::Int64(1)), DataType::Int32));
         let expr_tree_rev = bin_op(BinOpType::Eq, cast(cnst(Value::Int64(1)), DataType::Int32), col_ref(0));
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
@@ -1153,11 +1185,11 @@ mod tests {
             None,
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree, &schema, &column_refs),
             0.3
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree_rev, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree_rev, &schema, &column_refs),
             0.3
         );
     }
@@ -1171,6 +1203,8 @@ mod tests {
             Some(TestDistribution::empty()),
         ));
         let expr_tree = bin_op(BinOpType::Eq, cast(col_ref(0), DataType::Int64), cnst(Value::Int64(1)));
+        let expr_tree_rev = bin_op(BinOpType::Eq, cnst(Value::Int64(1)), cast(col_ref(0), DataType::Int64));
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
@@ -1179,7 +1213,11 @@ mod tests {
             None,
         );
         assert_approx_eq::assert_approx_eq!(
-            cost_model.get_filter_selectivity(expr_tree, &column_refs),
+            cost_model.get_filter_selectivity(expr_tree, &schema, &column_refs),
+            0.3
+        );
+        assert_approx_eq::assert_approx_eq!(
+            cost_model.get_filter_selectivity(expr_tree_rev, &schema, &column_refs),
             0.3
         );
     }

--- a/optd-datafusion-repr/src/cost/base_cost/filter.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/filter.rs
@@ -1,5 +1,6 @@
 use std::ops::Bound;
 
+use chrono::Local;
 use optd_core::{
     cascades::{CascadesOptimizer, RelNodeContext},
     cost::Cost,
@@ -194,10 +195,11 @@ impl<
         let mut non_col_ref_exprs = vec![];
         let is_left_col_ref;
 
-        // Recursively unwrap casts
+        // Recursively unwrap casts as much as we can.
         let mut uncasted_left = left;
         let mut uncasted_right = right;
         loop {
+            // println!("loop {}, uncasted_left={:?}, uncasted_right={:?}", Local::now(), uncasted_left, uncasted_right);
             if uncasted_left.as_ref().typ == OptRelNodeTyp::Cast && uncasted_right.as_ref().typ == OptRelNodeTyp::Cast {
                 let left_cast_expr = CastExpr::from_rel_node(uncasted_left).expect("we already checked that the type is Cast");
                 let right_cast_expr = CastExpr::from_rel_node(uncasted_right).expect("we already checked that the type is Cast");
@@ -216,25 +218,43 @@ impl<
                 let cast_expr_child = cast_expr.child().into_rel_node();
                 let cast_expr_cast_to = cast_expr.cast_to();
 
-                match cast_expr_child.typ {
+                let should_break = match cast_expr_child.typ {
                     OptRelNodeTyp::Constant(_) => {
                         cast_node = ConstantExpr::new(ConstantExpr::from_rel_node(cast_expr_child).expect("we already checked that the type is Constant").value().convert_to_type(cast_expr_cast_to)).into_rel_node();
-                    }
+                        false
+                    },
                     OptRelNodeTyp::ColumnRef => {
                         let col_ref_expr = ColumnRefExpr::from_rel_node(cast_expr_child).expect("we already checked that the type is ColumnRef");
                         let col_ref_idx = col_ref_expr.index();
                         cast_node = col_ref_expr.into_rel_node();
-                        let field = &schema.fields[col_ref_idx];
-                        let field_data_type = field.typ.into_data_type();
-                        non_cast_node = CastExpr::new(Expr::from_rel_node(non_cast_node).unwrap(), field_data_type).into_rel_node();
+                        // The "invert" cast is to invert the cast so that we're casting the non_cast_node to
+                        // the column's original type.
+                        let invert_cast_data_type =  &schema.fields[col_ref_idx].typ.into_data_type();
+
+                        match non_cast_node.typ {
+                            OptRelNodeTyp::ColumnRef => {
+                                // In general, there's no way to remove the Cast here. We can't move the Cast to the
+                                // other ColumnRef because that would lead to an infinite loop. Thus, we just leave the
+                                // cast where it is and break.
+                                true
+                            },
+                            _ => {
+                                non_cast_node = CastExpr::new(Expr::from_rel_node(non_cast_node).unwrap(), invert_cast_data_type.clone()).into_rel_node();
+                                false
+                            }
+                        }
                     }
                     _ => todo!()
-                }
+                };
 
                 (uncasted_left, uncasted_right) = if is_left_cast {
                     (cast_node, non_cast_node)
                 } else {
                     (non_cast_node, cast_node)
+                };
+
+                if should_break {
+                    break;
                 }
             } else {
                 break;
@@ -515,7 +535,7 @@ mod tests {
     use optd_core::rel_node::Value;
 
     use crate::{
-        cost::base_cost::tests::*,
+        cost::base_cost::{tests::*, DEFAULT_EQ_SEL},
         plan_nodes::{BinOpType, ConstantType, LogOpType, UnOpType},
         properties::{column_ref::{ColumnRef, GroupColumnRefs}, schema::{Field, Schema}},
     };
@@ -1171,7 +1191,7 @@ mod tests {
     // I didn't test any non-unique cases with filter. The non-unique tests without filter should cover that
 
     #[test]
-    fn test_cast_value() {
+    fn test_colref_eq_cast_value() {
         let cost_model = create_one_column_cost_model(TestPerColumnStats::new(
             TestMostCommonValues::new(vec![(Value::Int32(1), 0.3)]),
             0,
@@ -1199,7 +1219,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cast_colref() {
+    fn test_cast_colref_eq_value() {
         let cost_model = create_one_column_cost_model(TestPerColumnStats::new(
             TestMostCommonValues::new(vec![(Value::Int32(1), 0.3)]),
             0,
@@ -1223,6 +1243,39 @@ mod tests {
         assert_approx_eq::assert_approx_eq!(
             cost_model.get_filter_selectivity(expr_tree_rev, &schema, &column_refs),
             0.3
+        );
+    }
+
+    /// In this case, we should leave the Cast as is.
+    /// 
+    /// Note that the test only checks the selectivity and thus doesn't explicitly test that the
+    /// Cast is indeed left as is. However, if get_filter_selectivity() doesn't crash, that's a
+    /// pretty good signal that the Cast was left as is.
+    #[test]
+    fn test_cast_colref_eq_colref() {
+        let cost_model = create_one_column_cost_model(TestPerColumnStats::new(
+            TestMostCommonValues::new(vec![]),
+            0,
+            0.0,
+            Some(TestDistribution::empty()),
+        ));
+        let expr_tree = bin_op(BinOpType::Eq, cast(col_ref(0), DataType::Int64), col_ref(1));
+        let expr_tree_rev = bin_op(BinOpType::Eq, col_ref(1), cast(col_ref(0), DataType::Int64));
+        let schema = Schema::new(vec![Field {name: String::from(""), typ: ConstantType::Int32, nullable: false}, Field {name: String::from(""), typ: ConstantType::Int64, nullable: false}]);
+        let column_refs = GroupColumnRefs::new_test(
+            vec![ColumnRef::base_table_column_ref(
+                String::from(TABLE1_NAME),
+                0,
+            )],
+            None,
+        );
+        assert_approx_eq::assert_approx_eq!(
+            cost_model.get_filter_selectivity(expr_tree, &schema, &column_refs),
+            DEFAULT_EQ_SEL
+        );
+        assert_approx_eq::assert_approx_eq!(
+            cost_model.get_filter_selectivity(expr_tree_rev, &schema, &column_refs),
+            DEFAULT_EQ_SEL
         );
     }
 }

--- a/optd-datafusion-repr/src/cost/base_cost/filter.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/filter.rs
@@ -1,6 +1,5 @@
 use std::ops::Bound;
 
-use arrow_schema::DataType;
 use optd_core::{
     cascades::{CascadesOptimizer, RelNodeContext},
     cost::Cost,
@@ -102,7 +101,7 @@ impl<
                 let right_child = expr_tree.child(1);
 
                 if bin_op_typ.is_comparison() {
-                    self.get_comp_op_selectivity(*bin_op_typ, left_child, right_child, column_refs)
+                    self.get_comp_op_selectivity(*bin_op_typ, left_child, right_child, schema, column_refs)
                 } else if bin_op_typ.is_numerical() {
                     panic!(
                         "the selectivity of operations that return numerical values is undefined"
@@ -188,6 +187,7 @@ impl<
     fn get_semantic_nodes(
         left: OptRelNodeRef,
         right: OptRelNodeRef,
+        schema: &Schema,
     ) -> (Vec<ColumnRefExpr>, Vec<Value>, Vec<OptRelNodeRef>, bool) {
         let mut col_ref_exprs = vec![];
         let mut values = vec![];
@@ -221,9 +221,12 @@ impl<
                         cast_node = ConstantExpr::new(ConstantExpr::from_rel_node(cast_expr_child).expect("we already checked that the type is Constant").value().convert_to_type(cast_expr_cast_to)).into_rel_node();
                     }
                     OptRelNodeTyp::ColumnRef => {
-                        assert!(cast_expr_cast_to == DataType::Int64);
-                        cast_node = cast_expr_child;
-                        non_cast_node = CastExpr::new(Expr::from_rel_node(non_cast_node).unwrap(), DataType::Int32).into_rel_node();
+                        let col_ref_expr = ColumnRefExpr::from_rel_node(cast_expr_child).expect("we already checked that the type is ColumnRef");
+                        let col_ref_idx = col_ref_expr.index();
+                        cast_node = col_ref_expr.into_rel_node();
+                        let field = &schema.fields[col_ref_idx];
+                        let field_data_type = field.typ.into_data_type();
+                        non_cast_node = CastExpr::new(Expr::from_rel_node(non_cast_node).unwrap(), field_data_type).into_rel_node();
                     }
                     _ => todo!()
                 }
@@ -281,13 +284,14 @@ impl<
         comp_bin_op_typ: BinOpType,
         left: OptRelNodeRef,
         right: OptRelNodeRef,
+        schema: &Schema,
         column_refs: &GroupColumnRefs,
     ) -> f64 {
         assert!(comp_bin_op_typ.is_comparison());
 
         // I intentionally performed moves on left and right. This way, we don't accidentally use them after this block
         let (col_ref_exprs, values, non_col_ref_exprs, is_left_col_ref) =
-            Self::get_semantic_nodes(left, right);
+            Self::get_semantic_nodes(left, right, schema);
 
         // Handle the different cases of semantic nodes.
         if col_ref_exprs.is_empty() {
@@ -512,8 +516,8 @@ mod tests {
 
     use crate::{
         cost::base_cost::tests::*,
-        plan_nodes::{BinOpType, LogOpType, UnOpType},
-        properties::{column_ref::{ColumnRef, GroupColumnRefs}, schema::Schema},
+        plan_nodes::{BinOpType, ConstantType, LogOpType, UnOpType},
+        properties::{column_ref::{ColumnRef, GroupColumnRefs}, schema::{Field, Schema}},
     };
 
     #[test]
@@ -1204,7 +1208,7 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Eq, cast(col_ref(0), DataType::Int64), cnst(Value::Int64(1)));
         let expr_tree_rev = bin_op(BinOpType::Eq, cnst(Value::Int64(1)), cast(col_ref(0), DataType::Int64));
-        let schema = Schema::new(vec![]);
+        let schema = Schema::new(vec![Field {name: String::from(""), typ: ConstantType::Int32, nullable: false}]);
         let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),

--- a/optd-datafusion-repr/src/cost/base_cost/filter.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/filter.rs
@@ -13,8 +13,7 @@ use crate::{
         UNIMPLEMENTED_SEL,
     },
     plan_nodes::{
-        BinOpType, ColumnRefExpr, ConstantType, InListExpr, LikeExpr, LogOpType, OptRelNode,
-        OptRelNodeRef, OptRelNodeTyp, UnOpType,
+        BinOpType, CastExpr, ColumnRefExpr, ConstantExpr, ConstantType, InListExpr, LikeExpr, LogOpType, OptRelNode, OptRelNodeRef, OptRelNodeTyp, UnOpType
     },
     properties::column_ref::{
         BaseTableColumnRef, ColumnRef, ColumnRefPropertyBuilder, GroupColumnRefs,
@@ -179,36 +178,56 @@ impl<
         }
     }
 
-    /// Convert the left and right child nodes of some operation to what they semantically are
-    /// This is convenient to avoid repeating the same logic just with "left" and "right" swapped
+    /// Convert the left and right child nodes of some operation to what they semantically are.
+    /// This is convenient to avoid repeating the same logic just with "left" and "right" swapped.
+    /// The last return value is true when the input node (left) is a ColumnRefExpr.
     fn get_semantic_nodes(
         left: OptRelNodeRef,
         right: OptRelNodeRef,
-    ) -> (Vec<ColumnRefExpr>, Vec<OptRelNodeRef>, bool) {
+    ) -> (Vec<ColumnRefExpr>, Vec<Value>, Vec<OptRelNodeRef>, bool) {
         let mut col_ref_exprs = vec![];
+        let mut values = vec![];
         let mut non_col_ref_exprs = vec![];
         let is_left_col_ref;
+
+        // TODO(phw2): factor is_left_col_ref out of this function
+
         // I intentionally performed moves on left and right. This way, we don't accidentally use them after this block
         // We always want to use "col_ref_expr" and "non_col_ref_expr" instead of "left" or "right"
-        if left.as_ref().typ == OptRelNodeTyp::ColumnRef {
-            is_left_col_ref = true;
-            col_ref_exprs.push(
-                ColumnRefExpr::from_rel_node(left)
-                    .expect("we already checked that the type is ColumnRef"),
-            );
-        } else {
-            is_left_col_ref = false;
-            non_col_ref_exprs.push(left);
+        match left.as_ref().typ {
+            OptRelNodeTyp::ColumnRef => {
+                is_left_col_ref = true;
+                col_ref_exprs.push(
+                    ColumnRefExpr::from_rel_node(left)
+                        .expect("we already checked that the type is ColumnRef"),
+                );
+            },
+            OptRelNodeTyp::Constant(_) => {
+                is_left_col_ref = false;
+                values.push(ConstantExpr::from_rel_node(left).expect("we already checked that the type is Constant").value())
+            }
+            _ => {
+                is_left_col_ref = false;
+                non_col_ref_exprs.push(left);
+            }
         }
-        if right.as_ref().typ == OptRelNodeTyp::ColumnRef {
-            col_ref_exprs.push(
-                ColumnRefExpr::from_rel_node(right)
-                    .expect("we already checked that the type is ColumnRef"),
-            );
-        } else {
-            non_col_ref_exprs.push(right);
+        match right.as_ref().typ {
+            OptRelNodeTyp::ColumnRef => {
+                col_ref_exprs.push(
+                    ColumnRefExpr::from_rel_node(right)
+                        .expect("we already checked that the type is ColumnRef"),
+                );
+            },
+            OptRelNodeTyp::Constant(_) => {
+                values.push(ConstantExpr::from_rel_node(right).expect("we already checked that the type is Constant").value())
+            }
+            _ => {
+                non_col_ref_exprs.push(right);
+            }
         }
-        (col_ref_exprs, non_col_ref_exprs, is_left_col_ref)
+
+        assert!(col_ref_exprs.len() + values.len() + non_col_ref_exprs.len() == 2);
+        (col_ref_exprs, values, non_col_ref_exprs, is_left_col_ref)
     }
 
     /// Comparison operators are the base case for recursion in get_filter_selectivity()
@@ -222,10 +241,10 @@ impl<
         assert!(comp_bin_op_typ.is_comparison());
 
         // I intentionally performed moves on left and right. This way, we don't accidentally use them after this block
-        let (col_ref_exprs, non_col_ref_exprs, is_left_col_ref) =
+        let (col_ref_exprs, values, non_col_ref_exprs, is_left_col_ref) =
             Self::get_semantic_nodes(left, right);
 
-        // handle the different cases of column nodes
+        // Handle the different cases of semantic nodes.
         if col_ref_exprs.is_empty() {
             UNIMPLEMENTED_SEL
         } else if col_ref_exprs.len() == 1 {
@@ -237,57 +256,55 @@ impl<
             if let ColumnRef::BaseTableColumnRef(BaseTableColumnRef { table, col_idx }) =
                 &column_refs[col_ref_idx]
             {
-                let non_col_ref_expr = non_col_ref_exprs
+                if values.len() == 1 {
+                    let value = values.first().expect("we just checked that values.len() == 1");
+                    match comp_bin_op_typ {
+                        BinOpType::Eq => {
+                            self.get_column_equality_selectivity(table, *col_idx, value, true)
+                        }
+                        BinOpType::Neq => {
+                            self.get_column_equality_selectivity(table, *col_idx, value, false)
+                        }
+                        BinOpType::Lt | BinOpType::Leq | BinOpType::Gt | BinOpType::Geq => {
+                            let start = match (comp_bin_op_typ, is_left_col_ref) {
+                                (BinOpType::Lt, true) | (BinOpType::Geq, false) => Bound::Unbounded,
+                                (BinOpType::Leq, true) | (BinOpType::Gt, false) => Bound::Unbounded,
+                                (BinOpType::Gt, true) | (BinOpType::Leq, false) => Bound::Excluded(value),
+                                (BinOpType::Geq, true) | (BinOpType::Lt, false) => Bound::Included(value),
+                                _ => unreachable!("all comparison BinOpTypes were enumerated. this should be unreachable"),
+                            };
+                            let end = match (comp_bin_op_typ, is_left_col_ref) {
+                                (BinOpType::Lt, true) | (BinOpType::Geq, false) => Bound::Excluded(value),
+                                (BinOpType::Leq, true) | (BinOpType::Gt, false) => Bound::Included(value),
+                                (BinOpType::Gt, true) | (BinOpType::Leq, false) => Bound::Unbounded,
+                                (BinOpType::Geq, true) | (BinOpType::Lt, false) => Bound::Unbounded,
+                                _ => unreachable!("all comparison BinOpTypes were enumerated. this should be unreachable"),
+                            };
+                            self.get_column_range_selectivity(
+                                table,
+                                *col_idx,
+                                start,
+                                end,
+                            )
+                        },
+                        _ => unreachable!("all comparison BinOpTypes were enumerated. this should be unreachable"),
+                    }
+                } else {
+                    let non_col_ref_expr = non_col_ref_exprs
                     .first()
                     .expect("non_col_ref_exprs should have a value since col_ref_exprs.len() == 1");
 
-                match non_col_ref_expr.as_ref().typ {
-                    OptRelNodeTyp::Constant(_) => {
-                        let value = non_col_ref_expr
-                            .as_ref()
-                            .data
-                            .as_ref()
-                            .expect("constants should have data");
-                        match comp_bin_op_typ {
-                            BinOpType::Eq => {
-                                self.get_column_equality_selectivity(table, *col_idx, value, true)
-                            }
-                            BinOpType::Neq => {
-                                self.get_column_equality_selectivity(table, *col_idx, value, false)
-                            }
-                            BinOpType::Lt | BinOpType::Leq | BinOpType::Gt | BinOpType::Geq => {
-                                let start = match (comp_bin_op_typ, is_left_col_ref) {
-                                    (BinOpType::Lt, true) | (BinOpType::Geq, false) => Bound::Unbounded,
-                                    (BinOpType::Leq, true) | (BinOpType::Gt, false) => Bound::Unbounded,
-                                    (BinOpType::Gt, true) | (BinOpType::Leq, false) => Bound::Excluded(value),
-                                    (BinOpType::Geq, true) | (BinOpType::Lt, false) => Bound::Included(value),
-                                    _ => unreachable!("all comparison BinOpTypes were enumerated. this should be unreachable"),
-                                };
-                                let end = match (comp_bin_op_typ, is_left_col_ref) {
-                                    (BinOpType::Lt, true) | (BinOpType::Geq, false) => Bound::Excluded(value),
-                                    (BinOpType::Leq, true) | (BinOpType::Gt, false) => Bound::Included(value),
-                                    (BinOpType::Gt, true) | (BinOpType::Leq, false) => Bound::Unbounded,
-                                    (BinOpType::Geq, true) | (BinOpType::Lt, false) => Bound::Unbounded,
-                                    _ => unreachable!("all comparison BinOpTypes were enumerated. this should be unreachable"),
-                                };
-                                self.get_column_range_selectivity(
-                                    table,
-                                    *col_idx,
-                                    start,
-                                    end,
-                                )
-                            },
-                            _ => unreachable!("all comparison BinOpTypes were enumerated. this should be unreachable"),
+                    match non_col_ref_expr.as_ref().typ {
+                        OptRelNodeTyp::BinOp(_) => {
+                            Self::get_default_comparison_op_selectivity(comp_bin_op_typ)
                         }
+                        OptRelNodeTyp::Cast => UNIMPLEMENTED_SEL,
+                        OptRelNodeTyp::Constant(_) => unreachable!("we should have handled this in the values.len() == 1 branch"),
+                        _ => unimplemented!(
+                            "unhandled case of comparing a column ref node to {}",
+                            non_col_ref_expr.as_ref().typ
+                        ),
                     }
-                    OptRelNodeTyp::BinOp(_) => {
-                        Self::get_default_comparison_op_selectivity(comp_bin_op_typ)
-                    }
-                    OptRelNodeTyp::Cast => UNIMPLEMENTED_SEL,
-                    _ => unimplemented!(
-                        "unhandled case of comparing a column ref node to {}",
-                        non_col_ref_expr.as_ref().typ
-                    ),
                 }
             } else {
                 Self::get_default_comparison_op_selectivity(comp_bin_op_typ)
@@ -312,7 +329,7 @@ impl<
         value: &Value,
         is_eq: bool,
     ) -> f64 {
-        let ret_freq = if let Some(column_stats) = self.get_column_comb_stats(table, &[col_idx]) {
+        let ret_sel = if let Some(column_stats) = self.get_column_comb_stats(table, &[col_idx]) {
             let eq_freq = if let Some(freq) = column_stats.mcvs.freq(&vec![Some(value.clone())]) {
                 freq
             } else {
@@ -340,11 +357,11 @@ impl<
             }
         };
         assert!(
-            (0.0..=1.0).contains(&ret_freq),
-            "ret_freq ({}) should be in [0, 1]",
-            ret_freq
+            (0.0..=1.0).contains(&ret_sel),
+            "ret_sel ({}) should be in [0, 1]",
+            ret_sel
         );
-        ret_freq
+        ret_sel
     }
 
     /// Compute the frequency of values in a column less than or equal to the given value.

--- a/optd-datafusion-repr/src/cost/base_cost/filter.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/filter.rs
@@ -1,6 +1,5 @@
 use std::ops::Bound;
 
-use chrono::Local;
 use optd_core::{
     cascades::{CascadesOptimizer, RelNodeContext},
     cost::Cost,
@@ -14,11 +13,13 @@ use crate::{
         UNIMPLEMENTED_SEL,
     },
     plan_nodes::{
-        BinOpType, CastExpr, ColumnRefExpr, ConstantExpr, ConstantType, Expr, InListExpr, LikeExpr, LogOpType, OptRelNode, OptRelNodeRef, OptRelNodeTyp, UnOpType
+        BinOpType, CastExpr, ColumnRefExpr, ConstantExpr, ConstantType, Expr, InListExpr, LikeExpr,
+        LogOpType, OptRelNode, OptRelNodeRef, OptRelNodeTyp, UnOpType,
     },
-    properties::{column_ref::{
-        BaseTableColumnRef, ColumnRef, ColumnRefPropertyBuilder, GroupColumnRefs,
-    }, schema::{Schema, SchemaPropertyBuilder}},
+    properties::{
+        column_ref::{BaseTableColumnRef, ColumnRef, ColumnRefPropertyBuilder, GroupColumnRefs},
+        schema::{Schema, SchemaPropertyBuilder},
+    },
 };
 
 use super::{
@@ -42,7 +43,8 @@ impl<
         let (row_cnt, _, _) = Self::cost_tuple(&children[0]);
         let (_, compute_cost, _) = Self::cost_tuple(&children[1]);
         let selectivity = if let (Some(context), Some(optimizer)) = (context, optimizer) {
-            let schema = optimizer.get_property_by_group::<SchemaPropertyBuilder>(context.group_id, 0);
+            let schema =
+                optimizer.get_property_by_group::<SchemaPropertyBuilder>(context.group_id, 0);
             let column_refs =
                 optimizer.get_property_by_group::<ColumnRefPropertyBuilder>(context.group_id, 1);
             let expr_group_id = context.children_group_ids[1];
@@ -102,7 +104,13 @@ impl<
                 let right_child = expr_tree.child(1);
 
                 if bin_op_typ.is_comparison() {
-                    self.get_comp_op_selectivity(*bin_op_typ, left_child, right_child, schema, column_refs)
+                    self.get_comp_op_selectivity(
+                        *bin_op_typ,
+                        left_child,
+                        right_child,
+                        schema,
+                        column_refs,
+                    )
                 } else if bin_op_typ.is_numerical() {
                     panic!(
                         "the selectivity of operations that return numerical values is undefined"
@@ -200,13 +208,19 @@ impl<
         let mut uncasted_right = right;
         loop {
             // println!("loop {}, uncasted_left={:?}, uncasted_right={:?}", Local::now(), uncasted_left, uncasted_right);
-            if uncasted_left.as_ref().typ == OptRelNodeTyp::Cast && uncasted_right.as_ref().typ == OptRelNodeTyp::Cast {
-                let left_cast_expr = CastExpr::from_rel_node(uncasted_left).expect("we already checked that the type is Cast");
-                let right_cast_expr = CastExpr::from_rel_node(uncasted_right).expect("we already checked that the type is Cast");
+            if uncasted_left.as_ref().typ == OptRelNodeTyp::Cast
+                && uncasted_right.as_ref().typ == OptRelNodeTyp::Cast
+            {
+                let left_cast_expr = CastExpr::from_rel_node(uncasted_left)
+                    .expect("we already checked that the type is Cast");
+                let right_cast_expr = CastExpr::from_rel_node(uncasted_right)
+                    .expect("we already checked that the type is Cast");
                 assert!(left_cast_expr.cast_to() == right_cast_expr.cast_to());
                 uncasted_left = left_cast_expr.child().into_rel_node();
                 uncasted_right = right_cast_expr.child().into_rel_node();
-            } else if uncasted_left.as_ref().typ == OptRelNodeTyp::Cast || uncasted_right.as_ref().typ == OptRelNodeTyp::Cast {
+            } else if uncasted_left.as_ref().typ == OptRelNodeTyp::Cast
+                || uncasted_right.as_ref().typ == OptRelNodeTyp::Cast
+            {
                 let is_left_cast = uncasted_left.as_ref().typ == OptRelNodeTyp::Cast;
                 let (mut cast_node, mut non_cast_node) = if is_left_cast {
                     (uncasted_left, uncasted_right)
@@ -214,22 +228,31 @@ impl<
                     (uncasted_right, uncasted_left)
                 };
 
-                let cast_expr = CastExpr::from_rel_node(cast_node).expect("we already checked that the type is Cast");
+                let cast_expr = CastExpr::from_rel_node(cast_node)
+                    .expect("we already checked that the type is Cast");
                 let cast_expr_child = cast_expr.child().into_rel_node();
                 let cast_expr_cast_to = cast_expr.cast_to();
 
                 let should_break = match cast_expr_child.typ {
                     OptRelNodeTyp::Constant(_) => {
-                        cast_node = ConstantExpr::new(ConstantExpr::from_rel_node(cast_expr_child).expect("we already checked that the type is Constant").value().convert_to_type(cast_expr_cast_to)).into_rel_node();
+                        cast_node = ConstantExpr::new(
+                            ConstantExpr::from_rel_node(cast_expr_child)
+                                .expect("we already checked that the type is Constant")
+                                .value()
+                                .convert_to_type(cast_expr_cast_to),
+                        )
+                        .into_rel_node();
                         false
-                    },
+                    }
                     OptRelNodeTyp::ColumnRef => {
-                        let col_ref_expr = ColumnRefExpr::from_rel_node(cast_expr_child).expect("we already checked that the type is ColumnRef");
+                        let col_ref_expr = ColumnRefExpr::from_rel_node(cast_expr_child)
+                            .expect("we already checked that the type is ColumnRef");
                         let col_ref_idx = col_ref_expr.index();
                         cast_node = col_ref_expr.into_rel_node();
                         // The "invert" cast is to invert the cast so that we're casting the non_cast_node to
                         // the column's original type.
-                        let invert_cast_data_type =  &schema.fields[col_ref_idx].typ.into_data_type();
+                        let invert_cast_data_type =
+                            &schema.fields[col_ref_idx].typ.into_data_type();
 
                         match non_cast_node.typ {
                             OptRelNodeTyp::ColumnRef => {
@@ -237,14 +260,18 @@ impl<
                                 // other ColumnRef because that would lead to an infinite loop. Thus, we just leave the
                                 // cast where it is and break.
                                 true
-                            },
+                            }
                             _ => {
-                                non_cast_node = CastExpr::new(Expr::from_rel_node(non_cast_node).unwrap(), invert_cast_data_type.clone()).into_rel_node();
+                                non_cast_node = CastExpr::new(
+                                    Expr::from_rel_node(non_cast_node).unwrap(),
+                                    invert_cast_data_type.clone(),
+                                )
+                                .into_rel_node();
                                 false
                             }
                         }
                     }
-                    _ => todo!()
+                    _ => todo!(),
                 };
 
                 (uncasted_left, uncasted_right) = if is_left_cast {
@@ -269,10 +296,14 @@ impl<
                     ColumnRefExpr::from_rel_node(uncasted_left)
                         .expect("we already checked that the type is ColumnRef"),
                 );
-            },
+            }
             OptRelNodeTyp::Constant(_) => {
                 is_left_col_ref = false;
-                values.push(ConstantExpr::from_rel_node(uncasted_left).expect("we already checked that the type is Constant").value())
+                values.push(
+                    ConstantExpr::from_rel_node(uncasted_left)
+                        .expect("we already checked that the type is Constant")
+                        .value(),
+                )
             }
             _ => {
                 is_left_col_ref = false;
@@ -285,10 +316,12 @@ impl<
                     ColumnRefExpr::from_rel_node(uncasted_right)
                         .expect("we already checked that the type is ColumnRef"),
                 );
-            },
-            OptRelNodeTyp::Constant(_) => {
-                values.push(ConstantExpr::from_rel_node(uncasted_right).expect("we already checked that the type is Constant").value())
             }
+            OptRelNodeTyp::Constant(_) => values.push(
+                ConstantExpr::from_rel_node(uncasted_right)
+                    .expect("we already checked that the type is Constant")
+                    .value(),
+            ),
             _ => {
                 non_col_ref_exprs.push(uncasted_right);
             }
@@ -326,7 +359,9 @@ impl<
                 &column_refs[col_ref_idx]
             {
                 if values.len() == 1 {
-                    let value = values.first().expect("we just checked that values.len() == 1");
+                    let value = values
+                        .first()
+                        .expect("we just checked that values.len() == 1");
                     match comp_bin_op_typ {
                         BinOpType::Eq => {
                             self.get_column_equality_selectivity(table, *col_idx, value, true)
@@ -349,26 +384,25 @@ impl<
                                 (BinOpType::Geq, true) | (BinOpType::Lt, false) => Bound::Unbounded,
                                 _ => unreachable!("all comparison BinOpTypes were enumerated. this should be unreachable"),
                             };
-                            self.get_column_range_selectivity(
-                                table,
-                                *col_idx,
-                                start,
-                                end,
-                            )
-                        },
-                        _ => unreachable!("all comparison BinOpTypes were enumerated. this should be unreachable"),
+                            self.get_column_range_selectivity(table, *col_idx, start, end)
+                        }
+                        _ => unreachable!(
+                            "all comparison BinOpTypes were enumerated. this should be unreachable"
+                        ),
                     }
                 } else {
-                    let non_col_ref_expr = non_col_ref_exprs
-                    .first()
-                    .expect("non_col_ref_exprs should have a value since col_ref_exprs.len() == 1");
+                    let non_col_ref_expr = non_col_ref_exprs.first().expect(
+                        "non_col_ref_exprs should have a value since col_ref_exprs.len() == 1",
+                    );
 
                     match non_col_ref_expr.as_ref().typ {
                         OptRelNodeTyp::BinOp(_) => {
                             Self::get_default_comparison_op_selectivity(comp_bin_op_typ)
                         }
                         OptRelNodeTyp::Cast => UNIMPLEMENTED_SEL,
-                        OptRelNodeTyp::Constant(_) => unreachable!("we should have handled this in the values.len() == 1 branch"),
+                        OptRelNodeTyp::Constant(_) => unreachable!(
+                            "we should have handled this in the values.len() == 1 branch"
+                        ),
                         _ => unimplemented!(
                             "unhandled case of comparing a column ref node to {}",
                             non_col_ref_expr.as_ref().typ
@@ -537,7 +571,10 @@ mod tests {
     use crate::{
         cost::base_cost::{tests::*, DEFAULT_EQ_SEL},
         plan_nodes::{BinOpType, ConstantType, LogOpType, UnOpType},
-        properties::{column_ref::{ColumnRef, GroupColumnRefs}, schema::{Field, Schema}},
+        properties::{
+            column_ref::{ColumnRef, GroupColumnRefs},
+            schema::{Field, Schema},
+        },
     };
 
     #[test]
@@ -1198,8 +1235,16 @@ mod tests {
             0.1,
             Some(TestDistribution::empty()),
         ));
-        let expr_tree = bin_op(BinOpType::Eq, col_ref(0), cast(cnst(Value::Int64(1)), DataType::Int32));
-        let expr_tree_rev = bin_op(BinOpType::Eq, cast(cnst(Value::Int64(1)), DataType::Int32), col_ref(0));
+        let expr_tree = bin_op(
+            BinOpType::Eq,
+            col_ref(0),
+            cast(cnst(Value::Int64(1)), DataType::Int32),
+        );
+        let expr_tree_rev = bin_op(
+            BinOpType::Eq,
+            cast(cnst(Value::Int64(1)), DataType::Int32),
+            col_ref(0),
+        );
         let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
@@ -1226,9 +1271,21 @@ mod tests {
             0.1,
             Some(TestDistribution::empty()),
         ));
-        let expr_tree = bin_op(BinOpType::Eq, cast(col_ref(0), DataType::Int64), cnst(Value::Int64(1)));
-        let expr_tree_rev = bin_op(BinOpType::Eq, cnst(Value::Int64(1)), cast(col_ref(0), DataType::Int64));
-        let schema = Schema::new(vec![Field {name: String::from(""), typ: ConstantType::Int32, nullable: false}]);
+        let expr_tree = bin_op(
+            BinOpType::Eq,
+            cast(col_ref(0), DataType::Int64),
+            cnst(Value::Int64(1)),
+        );
+        let expr_tree_rev = bin_op(
+            BinOpType::Eq,
+            cnst(Value::Int64(1)),
+            cast(col_ref(0), DataType::Int64),
+        );
+        let schema = Schema::new(vec![Field {
+            name: String::from(""),
+            typ: ConstantType::Int32,
+            nullable: false,
+        }]);
         let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),
@@ -1247,7 +1304,7 @@ mod tests {
     }
 
     /// In this case, we should leave the Cast as is.
-    /// 
+    ///
     /// Note that the test only checks the selectivity and thus doesn't explicitly test that the
     /// Cast is indeed left as is. However, if get_filter_selectivity() doesn't crash, that's a
     /// pretty good signal that the Cast was left as is.
@@ -1261,7 +1318,18 @@ mod tests {
         ));
         let expr_tree = bin_op(BinOpType::Eq, cast(col_ref(0), DataType::Int64), col_ref(1));
         let expr_tree_rev = bin_op(BinOpType::Eq, col_ref(1), cast(col_ref(0), DataType::Int64));
-        let schema = Schema::new(vec![Field {name: String::from(""), typ: ConstantType::Int32, nullable: false}, Field {name: String::from(""), typ: ConstantType::Int64, nullable: false}]);
+        let schema = Schema::new(vec![
+            Field {
+                name: String::from(""),
+                typ: ConstantType::Int32,
+                nullable: false,
+            },
+            Field {
+                name: String::from(""),
+                typ: ConstantType::Int64,
+                nullable: false,
+            },
+        ]);
         let column_refs = GroupColumnRefs::new_test(
             vec![ColumnRef::base_table_column_ref(
                 String::from(TABLE1_NAME),

--- a/optd-datafusion-repr/src/cost/base_cost/join.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/join.rs
@@ -16,10 +16,13 @@ use crate::{
         BinOpType, ColumnRefExpr, Expr, ExprList, JoinType, LogOpExpr, LogOpType, OptRelNode,
         OptRelNodeRef, OptRelNodeTyp,
     },
-    properties::{column_ref::{
-        BaseTableColumnRef, ColumnRef, ColumnRefPropertyBuilder, EqBaseTableColumnSets,
-        EqPredicate, GroupColumnRefs, SemanticCorrelation,
-    }, schema::{Schema, SchemaPropertyBuilder}},
+    properties::{
+        column_ref::{
+            BaseTableColumnRef, ColumnRef, ColumnRefPropertyBuilder, EqBaseTableColumnSets,
+            EqPredicate, GroupColumnRefs, SemanticCorrelation,
+        },
+        schema::{Schema, SchemaPropertyBuilder},
+    },
 };
 
 use super::{OptCostModel, DEFAULT_UNK_SEL};
@@ -40,7 +43,8 @@ impl<
         let (row_cnt_2, _, _) = Self::cost_tuple(&children[1]);
         let (_, compute_cost, _) = Self::cost_tuple(&children[2]);
         let selectivity = if let (Some(context), Some(optimizer)) = (context, optimizer) {
-            let schema = optimizer.get_property_by_group::<SchemaPropertyBuilder>(context.group_id, 0);
+            let schema =
+                optimizer.get_property_by_group::<SchemaPropertyBuilder>(context.group_id, 0);
             let column_refs =
                 optimizer.get_property_by_group::<ColumnRefPropertyBuilder>(context.group_id, 1);
             let expr_group_id = context.children_group_ids[2];
@@ -76,7 +80,8 @@ impl<
         let (row_cnt_1, _, _) = Self::cost_tuple(&children[0]);
         let (row_cnt_2, _, _) = Self::cost_tuple(&children[1]);
         let selectivity = if let (Some(context), Some(optimizer)) = (context, optimizer) {
-            let schema = optimizer.get_property_by_group::<SchemaPropertyBuilder>(context.group_id, 0);
+            let schema =
+                optimizer.get_property_by_group::<SchemaPropertyBuilder>(context.group_id, 0);
             let column_refs =
                 optimizer.get_property_by_group::<ColumnRefPropertyBuilder>(context.group_id, 1);
             let left_keys_group_id = context.children_group_ids[2];
@@ -187,7 +192,9 @@ impl<
         // different tables. Currently, this doesn't affect the get_filter_selectivity() function, but this may change in
         // the future.
         let join_filter_selectivity = match filter_expr_tree {
-            Some(filter_expr_tree) => self.get_filter_selectivity(filter_expr_tree, schema, column_refs),
+            Some(filter_expr_tree) => {
+                self.get_filter_selectivity(filter_expr_tree, schema, column_refs)
+            }
             None => 1.0,
         };
         let inner_join_selectivity = join_on_selectivity * join_filter_selectivity;
@@ -504,10 +511,13 @@ mod tests {
     use crate::{
         cost::base_cost::{tests::*, DEFAULT_EQ_SEL},
         plan_nodes::{BinOpType, JoinType, LogOpType, OptRelNodeRef},
-        properties::{column_ref::{
-            BaseTableColumnRef, ColumnRef, EqBaseTableColumnSets, EqPredicate, GroupColumnRefs,
-            SemanticCorrelation,
-        }, schema::Schema},
+        properties::{
+            column_ref::{
+                BaseTableColumnRef, ColumnRef, EqBaseTableColumnSets, EqPredicate, GroupColumnRefs,
+                SemanticCorrelation,
+            },
+            schema::Schema,
+        },
     };
 
     /// A wrapper around get_join_selectivity_from_expr_tree that extracts the
@@ -597,7 +607,14 @@ mod tests {
             None,
         );
         assert_approx_eq::assert_approx_eq!(
-            test_get_join_selectivity(&cost_model, false, JoinType::Inner, expr_tree, &schema, &column_refs),
+            test_get_join_selectivity(
+                &cost_model,
+                false,
+                JoinType::Inner,
+                expr_tree,
+                &schema,
+                &column_refs
+            ),
             0.2
         );
         assert_approx_eq::assert_approx_eq!(
@@ -642,7 +659,14 @@ mod tests {
             None,
         );
         assert_approx_eq::assert_approx_eq!(
-            test_get_join_selectivity(&cost_model, false, JoinType::Inner, expr_tree, &schema, &column_refs),
+            test_get_join_selectivity(
+                &cost_model,
+                false,
+                JoinType::Inner,
+                expr_tree,
+                &schema,
+                &column_refs
+            ),
             0.2
         );
         assert_approx_eq::assert_approx_eq!(
@@ -687,7 +711,14 @@ mod tests {
             None,
         );
         assert_approx_eq::assert_approx_eq!(
-            test_get_join_selectivity(&cost_model, false, JoinType::Inner, expr_tree, &schema, &column_refs),
+            test_get_join_selectivity(
+                &cost_model,
+                false,
+                JoinType::Inner,
+                expr_tree,
+                &schema,
+                &column_refs
+            ),
             0.05
         );
         assert_approx_eq::assert_approx_eq!(
@@ -732,7 +763,14 @@ mod tests {
             None,
         );
         assert_approx_eq::assert_approx_eq!(
-            test_get_join_selectivity(&cost_model, false, JoinType::Inner, expr_tree, &schema, &column_refs),
+            test_get_join_selectivity(
+                &cost_model,
+                false,
+                JoinType::Inner,
+                expr_tree,
+                &schema,
+                &column_refs
+            ),
             0.2
         );
         assert_approx_eq::assert_approx_eq!(
@@ -774,7 +812,14 @@ mod tests {
             None,
         );
         assert_approx_eq::assert_approx_eq!(
-            test_get_join_selectivity(&cost_model, false, JoinType::Inner, expr_tree, &schema, &column_refs),
+            test_get_join_selectivity(
+                &cost_model,
+                false,
+                JoinType::Inner,
+                expr_tree,
+                &schema,
+                &column_refs
+            ),
             DEFAULT_EQ_SEL
         );
     }

--- a/optd-datafusion-repr/src/cost/base_cost/join.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/join.rs
@@ -16,10 +16,10 @@ use crate::{
         BinOpType, ColumnRefExpr, Expr, ExprList, JoinType, LogOpExpr, LogOpType, OptRelNode,
         OptRelNodeRef, OptRelNodeTyp,
     },
-    properties::column_ref::{
+    properties::{column_ref::{
         BaseTableColumnRef, ColumnRef, ColumnRefPropertyBuilder, EqBaseTableColumnSets,
         EqPredicate, GroupColumnRefs, SemanticCorrelation,
-    },
+    }, schema::{Schema, SchemaPropertyBuilder}},
 };
 
 use super::{OptCostModel, DEFAULT_UNK_SEL};
@@ -40,6 +40,7 @@ impl<
         let (row_cnt_2, _, _) = Self::cost_tuple(&children[1]);
         let (_, compute_cost, _) = Self::cost_tuple(&children[2]);
         let selectivity = if let (Some(context), Some(optimizer)) = (context, optimizer) {
+            let schema = optimizer.get_property_by_group::<SchemaPropertyBuilder>(context.group_id, 0);
             let column_refs =
                 optimizer.get_property_by_group::<ColumnRefPropertyBuilder>(context.group_id, 1);
             let expr_group_id = context.children_group_ids[2];
@@ -50,6 +51,7 @@ impl<
             self.get_join_selectivity_from_expr_tree(
                 join_typ,
                 expr_tree.clone(),
+                &schema,
                 &column_refs,
                 row_cnt_1,
                 row_cnt_2,
@@ -74,6 +76,7 @@ impl<
         let (row_cnt_1, _, _) = Self::cost_tuple(&children[0]);
         let (row_cnt_2, _, _) = Self::cost_tuple(&children[1]);
         let selectivity = if let (Some(context), Some(optimizer)) = (context, optimizer) {
+            let schema = optimizer.get_property_by_group::<SchemaPropertyBuilder>(context.group_id, 0);
             let column_refs =
                 optimizer.get_property_by_group::<ColumnRefPropertyBuilder>(context.group_id, 1);
             let left_keys_group_id = context.children_group_ids[2];
@@ -94,6 +97,7 @@ impl<
                     .expect("left_keys should be an ExprList"),
                 ExprList::from_rel_node(right_keys.clone())
                     .expect("right_keys should be an ExprList"),
+                &schema,
                 &column_refs,
                 row_cnt_1,
                 row_cnt_2,
@@ -116,6 +120,7 @@ impl<
         join_typ: JoinType,
         left_keys: ExprList,
         right_keys: ExprList,
+        schema: &Schema,
         column_refs: &GroupColumnRefs,
         left_row_cnt: f64,
         right_row_cnt: f64,
@@ -141,6 +146,7 @@ impl<
             join_typ,
             on_col_ref_pairs,
             None,
+            schema,
             column_refs,
             left_row_cnt,
             right_row_cnt,
@@ -166,6 +172,7 @@ impl<
         join_typ: JoinType,
         on_col_ref_pairs: Vec<(ColumnRefExpr, ColumnRefExpr)>,
         filter_expr_tree: Option<OptRelNodeRef>,
+        schema: &Schema,
         column_refs: &GroupColumnRefs,
         left_row_cnt: f64,
         right_row_cnt: f64,
@@ -180,7 +187,7 @@ impl<
         // different tables. Currently, this doesn't affect the get_filter_selectivity() function, but this may change in
         // the future.
         let join_filter_selectivity = match filter_expr_tree {
-            Some(filter_expr_tree) => self.get_filter_selectivity(filter_expr_tree, column_refs),
+            Some(filter_expr_tree) => self.get_filter_selectivity(filter_expr_tree, schema, column_refs),
             None => 1.0,
         };
         let inner_join_selectivity = join_on_selectivity * join_filter_selectivity;
@@ -207,6 +214,7 @@ impl<
         &self,
         join_typ: JoinType,
         expr_tree: OptRelNodeRef,
+        schema: &Schema,
         column_refs: &GroupColumnRefs,
         left_row_cnt: f64,
         right_row_cnt: f64,
@@ -240,6 +248,7 @@ impl<
                 join_typ,
                 on_col_ref_pairs,
                 filter_expr_tree,
+                schema,
                 column_refs,
                 left_row_cnt,
                 right_row_cnt,
@@ -253,6 +262,7 @@ impl<
                     join_typ,
                     vec![on_col_ref_pair],
                     None,
+                    schema,
                     column_refs,
                     left_row_cnt,
                     right_row_cnt,
@@ -263,6 +273,7 @@ impl<
                     join_typ,
                     vec![],
                     Some(expr_tree),
+                    schema,
                     column_refs,
                     left_row_cnt,
                     right_row_cnt,
@@ -493,10 +504,10 @@ mod tests {
     use crate::{
         cost::base_cost::{tests::*, DEFAULT_EQ_SEL},
         plan_nodes::{BinOpType, JoinType, LogOpType, OptRelNodeRef},
-        properties::column_ref::{
+        properties::{column_ref::{
             BaseTableColumnRef, ColumnRef, EqBaseTableColumnSets, EqPredicate, GroupColumnRefs,
             SemanticCorrelation,
-        },
+        }, schema::Schema},
     };
 
     /// A wrapper around get_join_selectivity_from_expr_tree that extracts the
@@ -506,6 +517,7 @@ mod tests {
         reverse_tables: bool,
         join_typ: JoinType,
         expr_tree: OptRelNodeRef,
+        schema: &Schema,
         column_refs: &GroupColumnRefs,
     ) -> f64 {
         let table1_row_cnt = cost_model.per_table_stats_map[TABLE1_NAME].row_cnt as f64;
@@ -514,6 +526,7 @@ mod tests {
             cost_model.get_join_selectivity_from_expr_tree(
                 join_typ,
                 expr_tree,
+                schema,
                 column_refs,
                 table1_row_cnt,
                 table2_row_cnt,
@@ -522,6 +535,7 @@ mod tests {
             cost_model.get_join_selectivity_from_expr_tree(
                 join_typ,
                 expr_tree,
+                schema,
                 column_refs,
                 table2_row_cnt,
                 table1_row_cnt,
@@ -536,6 +550,7 @@ mod tests {
             cost_model.get_join_selectivity_from_expr_tree(
                 JoinType::Inner,
                 cnst(Value::Bool(true)),
+                &Schema::new(vec![]),
                 &GroupColumnRefs::new_test(vec![], None),
                 f64::NAN,
                 f64::NAN
@@ -546,6 +561,7 @@ mod tests {
             cost_model.get_join_selectivity_from_expr_tree(
                 JoinType::Inner,
                 cnst(Value::Bool(false)),
+                &Schema::new(vec![]),
                 &GroupColumnRefs::new_test(vec![], None),
                 f64::NAN,
                 f64::NAN
@@ -572,6 +588,7 @@ mod tests {
         );
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), col_ref(1));
         let expr_tree_rev = bin_op(BinOpType::Eq, col_ref(1), col_ref(0));
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![
                 ColumnRef::base_table_column_ref(String::from(TABLE1_NAME), 0),
@@ -580,7 +597,7 @@ mod tests {
             None,
         );
         assert_approx_eq::assert_approx_eq!(
-            test_get_join_selectivity(&cost_model, false, JoinType::Inner, expr_tree, &column_refs),
+            test_get_join_selectivity(&cost_model, false, JoinType::Inner, expr_tree, &schema, &column_refs),
             0.2
         );
         assert_approx_eq::assert_approx_eq!(
@@ -589,6 +606,7 @@ mod tests {
                 false,
                 JoinType::Inner,
                 expr_tree_rev,
+                &schema,
                 &column_refs,
             ),
             0.2
@@ -615,6 +633,7 @@ mod tests {
         let eq1and0 = bin_op(BinOpType::Eq, col_ref(1), col_ref(0));
         let expr_tree = log_op(LogOpType::And, vec![eq0and1.clone(), eq1and0.clone()]);
         let expr_tree_rev = log_op(LogOpType::And, vec![eq1and0.clone(), eq0and1.clone()]);
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![
                 ColumnRef::base_table_column_ref(String::from(TABLE1_NAME), 0),
@@ -623,7 +642,7 @@ mod tests {
             None,
         );
         assert_approx_eq::assert_approx_eq!(
-            test_get_join_selectivity(&cost_model, false, JoinType::Inner, expr_tree, &column_refs),
+            test_get_join_selectivity(&cost_model, false, JoinType::Inner, expr_tree, &schema, &column_refs),
             0.2
         );
         assert_approx_eq::assert_approx_eq!(
@@ -632,6 +651,7 @@ mod tests {
                 false,
                 JoinType::Inner,
                 expr_tree_rev,
+                &schema,
                 &column_refs
             ),
             0.2
@@ -658,6 +678,7 @@ mod tests {
         let eq100 = bin_op(BinOpType::Eq, col_ref(1), cnst(Value::Int32(100)));
         let expr_tree = log_op(LogOpType::And, vec![eq0and1.clone(), eq100.clone()]);
         let expr_tree_rev = log_op(LogOpType::And, vec![eq100.clone(), eq0and1.clone()]);
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![
                 ColumnRef::base_table_column_ref(String::from(TABLE1_NAME), 0),
@@ -666,7 +687,7 @@ mod tests {
             None,
         );
         assert_approx_eq::assert_approx_eq!(
-            test_get_join_selectivity(&cost_model, false, JoinType::Inner, expr_tree, &column_refs),
+            test_get_join_selectivity(&cost_model, false, JoinType::Inner, expr_tree, &schema, &column_refs),
             0.05
         );
         assert_approx_eq::assert_approx_eq!(
@@ -675,6 +696,7 @@ mod tests {
                 false,
                 JoinType::Inner,
                 expr_tree_rev,
+                &schema,
                 &column_refs
             ),
             0.05
@@ -701,6 +723,7 @@ mod tests {
         let eq100 = bin_op(BinOpType::Eq, col_ref(1), cnst(Value::Int32(100)));
         let expr_tree = log_op(LogOpType::And, vec![neq12.clone(), eq100.clone()]);
         let expr_tree_rev = log_op(LogOpType::And, vec![eq100.clone(), neq12.clone()]);
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![
                 ColumnRef::base_table_column_ref(String::from(TABLE1_NAME), 0),
@@ -709,7 +732,7 @@ mod tests {
             None,
         );
         assert_approx_eq::assert_approx_eq!(
-            test_get_join_selectivity(&cost_model, false, JoinType::Inner, expr_tree, &column_refs),
+            test_get_join_selectivity(&cost_model, false, JoinType::Inner, expr_tree, &schema, &column_refs),
             0.2
         );
         assert_approx_eq::assert_approx_eq!(
@@ -718,6 +741,7 @@ mod tests {
                 false,
                 JoinType::Inner,
                 expr_tree_rev,
+                &schema,
                 &column_refs
             ),
             0.2
@@ -741,6 +765,7 @@ mod tests {
             ),
         );
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), col_ref(0));
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![
                 ColumnRef::base_table_column_ref(String::from(TABLE1_NAME), 0),
@@ -749,7 +774,7 @@ mod tests {
             None,
         );
         assert_approx_eq::assert_approx_eq!(
-            test_get_join_selectivity(&cost_model, false, JoinType::Inner, expr_tree, &column_refs),
+            test_get_join_selectivity(&cost_model, false, JoinType::Inner, expr_tree, &schema, &column_refs),
             DEFAULT_EQ_SEL
         );
     }
@@ -761,6 +786,7 @@ mod tests {
         cost_model: &TestOptCostModel,
         expr_tree: OptRelNodeRef,
         expr_tree_rev: OptRelNodeRef,
+        schema: &Schema,
         column_refs: &GroupColumnRefs,
         expected_table1_outer_sel: f64,
         expected_table2_outer_sel: f64,
@@ -772,6 +798,7 @@ mod tests {
                 false,
                 JoinType::LeftOuter,
                 expr_tree.clone(),
+                schema,
                 column_refs
             ),
             expected_table1_outer_sel
@@ -782,6 +809,7 @@ mod tests {
                 false,
                 JoinType::LeftOuter,
                 expr_tree_rev.clone(),
+                schema,
                 column_refs
             ),
             expected_table1_outer_sel
@@ -792,6 +820,7 @@ mod tests {
                 true,
                 JoinType::RightOuter,
                 expr_tree.clone(),
+                schema,
                 column_refs
             ),
             expected_table1_outer_sel
@@ -802,6 +831,7 @@ mod tests {
                 true,
                 JoinType::RightOuter,
                 expr_tree_rev.clone(),
+                schema,
                 column_refs
             ),
             expected_table1_outer_sel
@@ -813,6 +843,7 @@ mod tests {
                 true,
                 JoinType::LeftOuter,
                 expr_tree.clone(),
+                schema,
                 column_refs
             ),
             expected_table2_outer_sel
@@ -823,6 +854,7 @@ mod tests {
                 true,
                 JoinType::LeftOuter,
                 expr_tree_rev.clone(),
+                schema,
                 column_refs
             ),
             expected_table2_outer_sel
@@ -833,6 +865,7 @@ mod tests {
                 false,
                 JoinType::RightOuter,
                 expr_tree.clone(),
+                schema,
                 column_refs
             ),
             expected_table2_outer_sel
@@ -843,6 +876,7 @@ mod tests {
                 false,
                 JoinType::RightOuter,
                 expr_tree_rev.clone(),
+                schema,
                 column_refs
             ),
             expected_table2_outer_sel
@@ -873,6 +907,7 @@ mod tests {
         // the left/right of the join refers to the tables, not the order of columns in the predicate
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), col_ref(1));
         let expr_tree_rev = bin_op(BinOpType::Eq, col_ref(1), col_ref(0));
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![
                 ColumnRef::base_table_column_ref(String::from(TABLE1_NAME), 0),
@@ -888,6 +923,7 @@ mod tests {
                 false,
                 JoinType::Inner,
                 expr_tree.clone(),
+                &schema,
                 &column_refs
             ),
             expected_inner_sel
@@ -898,6 +934,7 @@ mod tests {
                 false,
                 JoinType::Inner,
                 expr_tree_rev.clone(),
+                &schema,
                 &column_refs
             ),
             expected_inner_sel
@@ -907,6 +944,7 @@ mod tests {
             &cost_model,
             expr_tree,
             expr_tree_rev,
+            &schema,
             &column_refs,
             0.25,
             0.2,
@@ -936,6 +974,7 @@ mod tests {
         // the left/right of the join refers to the tables, not the order of columns in the predicate
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), col_ref(1));
         let expr_tree_rev = bin_op(BinOpType::Eq, col_ref(1), col_ref(0));
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![
                 ColumnRef::base_table_column_ref(String::from(TABLE1_NAME), 0),
@@ -951,6 +990,7 @@ mod tests {
                 false,
                 JoinType::Inner,
                 expr_tree.clone(),
+                &schema,
                 &column_refs
             ),
             expected_inner_sel
@@ -961,6 +1001,7 @@ mod tests {
                 false,
                 JoinType::Inner,
                 expr_tree_rev.clone(),
+                &schema,
                 &column_refs
             ),
             expected_inner_sel
@@ -970,6 +1011,7 @@ mod tests {
             &cost_model,
             expr_tree,
             expr_tree_rev,
+            &schema,
             &column_refs,
             0.2,
             0.2,
@@ -1000,6 +1042,7 @@ mod tests {
         // the left/right of the join refers to the tables, not the order of columns in the predicate
         let expr_tree = bin_op(BinOpType::Eq, col_ref(0), col_ref(1));
         let expr_tree_rev = bin_op(BinOpType::Eq, col_ref(1), col_ref(0));
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![
                 ColumnRef::base_table_column_ref(String::from(TABLE1_NAME), 0),
@@ -1015,6 +1058,7 @@ mod tests {
                 false,
                 JoinType::Inner,
                 expr_tree.clone(),
+                &schema,
                 &column_refs
             ),
             expected_inner_sel
@@ -1025,6 +1069,7 @@ mod tests {
                 false,
                 JoinType::Inner,
                 expr_tree_rev.clone(),
+                &schema,
                 &column_refs
             ),
             expected_inner_sel
@@ -1034,6 +1079,7 @@ mod tests {
             &cost_model,
             expr_tree,
             expr_tree_rev,
+            &schema,
             &column_refs,
             0.25,
             0.1,
@@ -1069,6 +1115,7 @@ mod tests {
         let expr_tree = log_op(LogOpType::And, vec![eq0and1, filter.clone()]);
         // inner rev means its the inner expr (the eq op) whose children are being reversed, as opposed to the and op
         let expr_tree_inner_rev = log_op(LogOpType::And, vec![eq1and0, filter.clone()]);
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(
             vec![
                 ColumnRef::base_table_column_ref(String::from(TABLE1_NAME), 0),
@@ -1084,6 +1131,7 @@ mod tests {
                 false,
                 JoinType::Inner,
                 expr_tree.clone(),
+                &schema,
                 &column_refs
             ),
             expected_inner_sel
@@ -1094,6 +1142,7 @@ mod tests {
                 false,
                 JoinType::Inner,
                 expr_tree_inner_rev.clone(),
+                &schema,
                 &column_refs
             ),
             expected_inner_sel
@@ -1103,6 +1152,7 @@ mod tests {
             &cost_model,
             expr_tree,
             expr_tree_inner_rev,
+            &schema,
             &column_refs,
             0.25,
             0.02,
@@ -1192,6 +1242,7 @@ mod tests {
             }
         };
         let semantic_correlation = SemanticCorrelation::new(eq_columns);
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(col_refs, Some(semantic_correlation));
 
         // Try all join conditions of the final join which would lead to all three tables being joined.
@@ -1228,6 +1279,7 @@ mod tests {
                     false,
                     JoinType::Inner,
                     expr_tree.clone(),
+                    &schema,
                     &column_refs,
                 );
             assert_approx_eq::assert_approx_eq!(overall_selectivity, 1.0 / 12.0);
@@ -1297,6 +1349,7 @@ mod tests {
         ));
         let initial_selectivity = 1.0 / (3.0 * 5.0);
         let semantic_correlation = SemanticCorrelation::new(eq_columns);
+        let schema = Schema::new(vec![]);
         let column_refs = GroupColumnRefs::new_test(col_refs, Some(semantic_correlation));
 
         let eq1and2 = bin_op(BinOpType::Eq, col_ref(1), col_ref(2));
@@ -1306,6 +1359,7 @@ mod tests {
                 false,
                 JoinType::Inner,
                 eq1and2.clone(),
+                &schema,
                 &column_refs,
             );
         assert_approx_eq::assert_approx_eq!(overall_selectivity, 1.0 / (3.0 * 4.0 * 5.0));

--- a/optd-datafusion-repr/src/plan_nodes/expr.rs
+++ b/optd-datafusion-repr/src/plan_nodes/expr.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Display, sync::Arc};
 
-use arrow_schema::DataType;
+use arrow_schema::{DataType, IntervalUnit};
 use itertools::Itertools;
 use pretty_xmlish::Pretty;
 use serde::{Deserialize, Serialize};
@@ -100,6 +100,26 @@ impl ConstantType {
             Value::Int64(_) => ConstantType::Int64,
             Value::Float(_) => ConstantType::Float64,
             _ => unimplemented!(),
+        }
+    }
+
+    pub fn into_data_type(&self) -> DataType {
+        match self {
+            ConstantType::Any => unimplemented!(),
+            ConstantType::Bool => DataType::Boolean,
+            ConstantType::UInt8 => DataType::UInt8,
+            ConstantType::UInt16 => DataType::UInt16,
+            ConstantType::UInt32 => DataType::UInt32,
+            ConstantType::UInt64 => DataType::UInt64,
+            ConstantType::Int8 => DataType::Int8,
+            ConstantType::Int16 => DataType::Int16,
+            ConstantType::Int32 => DataType::Int32,
+            ConstantType::Int64 => DataType::Int64,
+            ConstantType::Float64 => DataType::Float64,
+            ConstantType::Date => DataType::Date32,
+            ConstantType::IntervalMonthDateNano => DataType::Interval(IntervalUnit::MonthDayNano),
+            ConstantType::Decimal => DataType::Float64,
+            ConstantType::Utf8String => DataType::Utf8,
         }
     }
 }

--- a/optd-datafusion-repr/src/plan_nodes/expr.rs
+++ b/optd-datafusion-repr/src/plan_nodes/expr.rs
@@ -99,7 +99,31 @@ impl ConstantType {
             Value::Int32(_) => ConstantType::Int32,
             Value::Int64(_) => ConstantType::Int64,
             Value::Float(_) => ConstantType::Float64,
-            _ => unimplemented!(),
+            Value::Date32(_) => ConstantType::Date,
+            _ => unimplemented!("get_data_type_from_value() not implemented for value {value}"),
+        }
+    }
+
+    // TODO: current DataType and ConstantType are not 1 to 1 mapping
+    // optd schema stores constantType from data type in catalog.get
+    // for decimal128, the precision is lost
+    pub fn from_data_type(data_type: DataType) -> Self {
+        match data_type {
+            DataType::Boolean => ConstantType::Bool,
+            DataType::UInt8 => ConstantType::UInt8,
+            DataType::UInt16 => ConstantType::UInt16,
+            DataType::UInt32 => ConstantType::UInt32,
+            DataType::UInt64 => ConstantType::UInt64,
+            DataType::Int8 => ConstantType::Int8,
+            DataType::Int16 => ConstantType::Int16,
+            DataType::Int32 => ConstantType::Int32,
+            DataType::Int64 => ConstantType::Int64,
+            DataType::Float64 => ConstantType::Float64,
+            DataType::Date32 => ConstantType::Date,
+            DataType::Interval(IntervalUnit::MonthDayNano) => ConstantType::IntervalMonthDateNano,
+            DataType::Utf8 => ConstantType::Utf8String,
+            DataType::Decimal128(_, _) => ConstantType::Decimal,
+            _ => unimplemented!("no conversion to ConstantType for DataType {data_type}"),
         }
     }
 

--- a/optd-datafusion-repr/src/properties/schema.rs
+++ b/optd-datafusion-repr/src/properties/schema.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use optd_core::property::PropertyBuilder;
 
 use super::DEFAULT_NAME;
-use crate::plan_nodes::{ConstantType, EmptyRelationData, FuncType, OptRelNodeTyp};
+use crate::plan_nodes::{CastExpr, ConstantType, EmptyRelationData, FuncType, OptRelNode, OptRelNodeTyp};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Field {
@@ -112,7 +112,24 @@ impl PropertyBuilder<OptRelNodeTyp> for SchemaPropertyBuilder {
                 let agg_schema = children[2].clone();
                 group_by_schema.fields.extend(agg_schema.fields);
                 group_by_schema
-            }
+            },
+            OptRelNodeTyp::Cast => Schema {
+                fields: children[0].fields.iter().map(|field| {
+                    Field {
+                        typ: children[1].fields[0].typ,
+                        ..field.clone()
+                    }
+                }).collect()
+            },
+            OptRelNodeTyp::DataType(data_type) => Schema {
+                fields: vec![Field {
+                    // name and nullable are just placeholders since
+                    // they'll be overwritten by Cast
+                    name: DEFAULT_NAME.to_string(),
+                    typ: ConstantType::from_data_type(data_type),
+                    nullable: true,
+                }]
+            },
             OptRelNodeTyp::Func(FuncType::Agg(_)) => Schema {
                 // TODO: this is just a place holder now.
                 // The real type should be the column type.

--- a/optd-datafusion-repr/src/properties/schema.rs
+++ b/optd-datafusion-repr/src/properties/schema.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use optd_core::property::PropertyBuilder;
 
 use super::DEFAULT_NAME;
-use crate::plan_nodes::{CastExpr, ConstantType, EmptyRelationData, FuncType, OptRelNode, OptRelNodeTyp};
+use crate::plan_nodes::{ConstantType, EmptyRelationData, FuncType, OptRelNodeTyp};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Field {
@@ -31,9 +31,7 @@ pub struct Schema {
 
 impl Schema {
     pub fn new(fields: Vec<Field>) -> Self {
-        Self {
-            fields
-        }
+        Self { fields }
     }
 
     pub fn len(&self) -> usize {
@@ -112,14 +110,16 @@ impl PropertyBuilder<OptRelNodeTyp> for SchemaPropertyBuilder {
                 let agg_schema = children[2].clone();
                 group_by_schema.fields.extend(agg_schema.fields);
                 group_by_schema
-            },
+            }
             OptRelNodeTyp::Cast => Schema {
-                fields: children[0].fields.iter().map(|field| {
-                    Field {
+                fields: children[0]
+                    .fields
+                    .iter()
+                    .map(|field| Field {
                         typ: children[1].fields[0].typ,
                         ..field.clone()
-                    }
-                }).collect()
+                    })
+                    .collect(),
             },
             OptRelNodeTyp::DataType(data_type) => Schema {
                 fields: vec![Field {
@@ -128,7 +128,7 @@ impl PropertyBuilder<OptRelNodeTyp> for SchemaPropertyBuilder {
                     name: DEFAULT_NAME.to_string(),
                     typ: ConstantType::from_data_type(data_type),
                     nullable: true,
-                }]
+                }],
             },
             OptRelNodeTyp::Func(FuncType::Agg(_)) => Schema {
                 // TODO: this is just a place holder now.

--- a/optd-datafusion-repr/src/properties/schema.rs
+++ b/optd-datafusion-repr/src/properties/schema.rs
@@ -30,6 +30,12 @@ pub struct Schema {
 }
 
 impl Schema {
+    pub fn new(fields: Vec<Field>) -> Self {
+        Self {
+            fields
+        }
+    }
+
     pub fn len(&self) -> usize {
         self.fields.len()
     }

--- a/optd-perftest/src/cardtest.rs
+++ b/optd-perftest/src/cardtest.rs
@@ -18,6 +18,7 @@ pub struct CardtestRunner {
     truecard_getter: Box<dyn TruecardGetter>,
 }
 
+#[derive(Clone)]
 pub struct Cardinfo {
     pub qerror: f64,
     pub estcard: usize,

--- a/optd-perftest/src/datafusion_dbms.rs
+++ b/optd-perftest/src/datafusion_dbms.rs
@@ -41,7 +41,7 @@ pub struct DatafusionDBMS {
 }
 
 const WITH_LOGICAL_FOR_TPCH: bool = true;
-const WITH_LOGICAL_FOR_JOB: bool = false;
+const WITH_LOGICAL_FOR_JOB: bool = true;
 
 #[async_trait]
 impl CardtestRunnerDBMSHelper for DatafusionDBMS {

--- a/optd-perftest/src/datafusion_dbms.rs
+++ b/optd-perftest/src/datafusion_dbms.rs
@@ -41,7 +41,7 @@ pub struct DatafusionDBMS {
 }
 
 const WITH_LOGICAL_FOR_TPCH: bool = true;
-const WITH_LOGICAL_FOR_JOB: bool = true;
+const WITH_LOGICAL_FOR_JOB: bool = false;
 
 #[async_trait]
 impl CardtestRunnerDBMSHelper for DatafusionDBMS {

--- a/optd-perftest/src/postgres_dbms.rs
+++ b/optd-perftest/src/postgres_dbms.rs
@@ -163,7 +163,6 @@ impl PostgresDBMS {
         }
 
         // load the constraints and indexes
-        // TODO(phw2): constraints are currently broken
         let sql = fs::read_to_string(tpch_kit.constraints_fpath.to_str().unwrap())?;
         client.batch_execute(&sql).await?;
         let sql = fs::read_to_string(tpch_kit.indexes_fpath.to_str().unwrap())?;

--- a/optd-sqlplannertest/tests/basic_nodes.planner.sql
+++ b/optd-sqlplannertest/tests/basic_nodes.planner.sql
@@ -15,10 +15,10 @@ select * from t1 limit 3;
 select * from t1 limit 5;
 
 /*
-LogicalLimit { skip: 0, fetch: 1 }
+LogicalLimit { skip: 0(u64), fetch: 1(u64) }
 └── LogicalProjection { exprs: [ #0, #1 ] }
     └── LogicalScan { table: t1 }
-PhysicalLimit { skip: 0, fetch: 1 }
+PhysicalLimit { skip: 0(u64), fetch: 1(u64) }
 └── PhysicalProjection { exprs: [ #0, #1 ] }
     └── PhysicalScan { table: t1 }
 0 0

--- a/optd-sqlplannertest/tests/eliminate_limit.planner.sql
+++ b/optd-sqlplannertest/tests/eliminate_limit.planner.sql
@@ -13,7 +13,7 @@ insert into t2 values (0, 200), (1, 201), (2, 202);
 select * from t1 LIMIT 0;
 
 /*
-LogicalLimit { skip: 0, fetch: 0 }
+LogicalLimit { skip: 0(u64), fetch: 0(u64) }
 └── LogicalProjection { exprs: [ #0, #1 ] }
     └── LogicalScan { table: t1 }
 PhysicalEmptyRelation { produce_one_row: false }

--- a/optd-sqlplannertest/tests/empty_relation.planner.sql
+++ b/optd-sqlplannertest/tests/empty_relation.planner.sql
@@ -16,13 +16,13 @@ select 64 + 1 from t1;
 /*
 LogicalProjection
 ├── exprs:Add
-│   ├── 64
-│   └── 1
+│   ├── 64(i64)
+│   └── 1(i64)
 └── LogicalEmptyRelation { produce_one_row: true }
 PhysicalProjection
 ├── exprs:Add
-│   ├── 64
-│   └── 1
+│   ├── 64(i64)
+│   └── 1(i64)
 └── PhysicalEmptyRelation { produce_one_row: true }
 65
 65

--- a/optd-sqlplannertest/tests/tpch.planner.sql
+++ b/optd-sqlplannertest/tests/tpch.planner.sql
@@ -127,17 +127,17 @@ LogicalSort
         │   │   └── Mul
         │   │       ├── #5
         │   │       └── Sub
-        │   │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+        │   │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1(i64) }
         │   │           └── #6
         │   ├── Agg(Sum)
         │   │   └── Mul
         │   │       ├── Mul
         │   │       │   ├── #5
         │   │       │   └── Sub
-        │   │       │       ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+        │   │       │       ├── Cast { cast_to: Decimal128(20, 0), expr: 1(i64) }
         │   │       │       └── #6
         │   │       └── Add
-        │   │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+        │   │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1(i64) }
         │   │           └── #7
         │   ├── Agg(Avg)
         │   │   └── [ #4 ]
@@ -146,7 +146,7 @@ LogicalSort
         │   ├── Agg(Avg)
         │   │   └── [ #6 ]
         │   └── Agg(Count)
-        │       └── [ 1 ]
+        │       └── [ 1(u8) ]
         ├── groups: [ #8, #9 ]
         └── LogicalFilter
             ├── cond:Leq
@@ -172,17 +172,17 @@ PhysicalSort
         │   │   └── Mul
         │   │       ├── #5
         │   │       └── Sub
-        │   │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+        │   │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1(i64) }
         │   │           └── #6
         │   ├── Agg(Sum)
         │   │   └── Mul
         │   │       ├── Mul
         │   │       │   ├── #5
         │   │       │   └── Sub
-        │   │       │       ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+        │   │       │       ├── Cast { cast_to: Decimal128(20, 0), expr: 1(i64) }
         │   │       │       └── #6
         │   │       └── Add
-        │   │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+        │   │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1(i64) }
         │   │           └── #7
         │   ├── Agg(Avg)
         │   │   └── [ #4 ]
@@ -191,7 +191,7 @@ PhysicalSort
         │   ├── Agg(Avg)
         │   │   └── [ #6 ]
         │   └── Agg(Count)
-        │       └── [ 1 ]
+        │       └── [ 1(u8) ]
         ├── groups: [ #8, #9 ]
         └── PhysicalFilter
             ├── cond:Leq
@@ -249,7 +249,7 @@ order by
 limit 100;
 
 /*
-LogicalLimit { skip: 0, fetch: 100 }
+LogicalLimit { skip: 0(u64), fetch: 100(u64) }
 └── LogicalSort
     ├── exprs:
     │   ┌── SortOrder { order: Desc }
@@ -299,7 +299,7 @@ LogicalLimit { skip: 0, fetch: 100 }
             │       │       │       │       │       ├── cond:And
             │       │       │       │       │       │   ├── Eq
             │       │       │       │       │       │   │   ├── #3
-            │       │       │       │       │       │   │   └── 4
+            │       │       │       │       │       │   │   └── 4(i32)
             │       │       │       │       │       │   └── Like { expr: #2, pattern: "%TIN", negated: false, case_insensitive: false }
             │       │       │       │       │       └── LogicalProjection { exprs: [ #0, #2, #4, #5 ] }
             │       │       │       │       │           └── LogicalScan { table: part }
@@ -352,7 +352,7 @@ LogicalLimit { skip: 0, fetch: 100 }
                                     │   └── "AFRICA"
                                     └── LogicalProjection { exprs: [ #0, #1 ] }
                                         └── LogicalScan { table: region }
-PhysicalLimit { skip: 0, fetch: 100 }
+PhysicalLimit { skip: 0(u64), fetch: 100(u64) }
 └── PhysicalSort
     ├── exprs:
     │   ┌── SortOrder { order: Desc }
@@ -379,7 +379,7 @@ PhysicalLimit { skip: 0, fetch: 100 }
             │       │       │       │       │           ├── cond:And
             │       │       │       │       │           │   ├── Eq
             │       │       │       │       │           │   │   ├── #5
-            │       │       │       │       │           │   │   └── 4
+            │       │       │       │       │           │   │   └── 4(i32)
             │       │       │       │       │           │   └── Like { expr: #4, pattern: "%TIN", negated: false, case_insensitive: false }
             │       │       │       │       │           └── PhysicalScan { table: part }
             │       │       │       │       └── PhysicalProjection { exprs: [ #0, #1, #3 ] }
@@ -446,7 +446,7 @@ ORDER BY
     o_orderdate LIMIT 10;
 
 /*
-LogicalLimit { skip: 0, fetch: 10 }
+LogicalLimit { skip: 0(u64), fetch: 10(u64) }
 └── LogicalSort
     ├── exprs:
     │   ┌── SortOrder { order: Desc }
@@ -459,7 +459,7 @@ LogicalLimit { skip: 0, fetch: 10 }
             │   └── Mul
             │       ├── #3
             │       └── Sub
-            │           ├── 1
+            │           ├── 1(float)
             │           └── #4
             ├── groups: [ #2, #0, #1 ]
             └── LogicalProjection { exprs: [ #1, #2, #3, #4, #5 ] }
@@ -484,17 +484,17 @@ LogicalLimit { skip: 0, fetch: 10 }
                     │       └── LogicalFilter
                     │           ├── cond:Lt
                     │           │   ├── #2
-                    │           │   └── 9218
+                    │           │   └── 9218(i64)
                     │           └── LogicalProjection { exprs: [ #0, #1, #4, #7 ] }
                     │               └── LogicalScan { table: orders }
                     └── LogicalProjection { exprs: [ #0, #1, #2 ] }
                         └── LogicalFilter
                             ├── cond:Gt
                             │   ├── #3
-                            │   └── 9218
+                            │   └── 9218(i64)
                             └── LogicalProjection { exprs: [ #0, #5, #6, #10 ] }
                                 └── LogicalScan { table: lineitem }
-PhysicalLimit { skip: 0, fetch: 10 }
+PhysicalLimit { skip: 0(u64), fetch: 10(u64) }
 └── PhysicalSort
     ├── exprs:
     │   ┌── SortOrder { order: Desc }
@@ -507,7 +507,7 @@ PhysicalLimit { skip: 0, fetch: 10 }
             │   └── Mul
             │       ├── #3
             │       └── Sub
-            │           ├── 1
+            │           ├── 1(float)
             │           └── #4
             ├── groups: [ #2, #0, #1 ]
             └── PhysicalProjection { exprs: [ #1, #2, #3, #4, #5 ] }
@@ -525,14 +525,14 @@ PhysicalLimit { skip: 0, fetch: 10 }
                     │           └── PhysicalFilter
                     │               ├── cond:Lt
                     │               │   ├── #4
-                    │               │   └── 9218
+                    │               │   └── 9218(i64)
                     │               └── PhysicalScan { table: orders }
                     └── PhysicalProjection { exprs: [ #0, #1, #2 ] }
                         └── PhysicalProjection { exprs: [ #0, #5, #6, #10 ] }
                             └── PhysicalFilter
                                 ├── cond:Gt
                                 │   ├── #10
-                                │   └── 9218
+                                │   └── 9218(i64)
                                 └── PhysicalScan { table: lineitem }
 */
 
@@ -572,7 +572,7 @@ LogicalSort
         │   └── Mul
         │       ├── #22
         │       └── Sub
-        │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+        │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1(i64) }
         │           └── #23
         ├── groups: [ #41 ]
         └── LogicalFilter
@@ -624,7 +624,7 @@ PhysicalSort
         │   └── Mul
         │       ├── #22
         │       └── Sub
-        │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+        │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1(i64) }
         │           └── #23
         ├── groups: [ #41 ]
         └── PhysicalHashJoin { join_type: Inner, left_keys: [ #19, #3 ], right_keys: [ #0, #3 ] }
@@ -679,10 +679,10 @@ LogicalProjection { exprs: [ #0 ] }
         │   ├── Lt
         │   │   ├── #10
         │   │   └── Cast { cast_to: Date32, expr: "2024-01-01" }
-        │   ├── Between { expr: Cast { cast_to: Decimal128(30, 15), expr: #6 }, lower: Cast { cast_to: Decimal128(30, 15), expr: 0.05 }, upper: Cast { cast_to: Decimal128(30, 15), expr: 0.07 } }
+        │   ├── Between { expr: Cast { cast_to: Decimal128(30, 15), expr: #6 }, lower: Cast { cast_to: Decimal128(30, 15), expr: 0.05(float) }, upper: Cast { cast_to: Decimal128(30, 15), expr: 0.07(float) } }
         │   └── Lt
         │       ├── Cast { cast_to: Decimal128(22, 2), expr: #4 }
-        │       └── Cast { cast_to: Decimal128(22, 2), expr: 24 }
+        │       └── Cast { cast_to: Decimal128(22, 2), expr: 24(i64) }
         └── LogicalScan { table: lineitem }
 PhysicalProjection { exprs: [ #0 ] }
 └── PhysicalAgg
@@ -699,10 +699,10 @@ PhysicalProjection { exprs: [ #0 ] }
         │   ├── Lt
         │   │   ├── #10
         │   │   └── Cast { cast_to: Date32, expr: "2024-01-01" }
-        │   ├── Between { expr: Cast { cast_to: Decimal128(30, 15), expr: #6 }, lower: Cast { cast_to: Decimal128(30, 15), expr: 0.05 }, upper: Cast { cast_to: Decimal128(30, 15), expr: 0.07 } }
+        │   ├── Between { expr: Cast { cast_to: Decimal128(30, 15), expr: #6 }, lower: Cast { cast_to: Decimal128(30, 15), expr: 0.05(float) }, upper: Cast { cast_to: Decimal128(30, 15), expr: 0.07(float) } }
         │   └── Lt
         │       ├── Cast { cast_to: Decimal128(22, 2), expr: #4 }
-        │       └── Cast { cast_to: Decimal128(22, 2), expr: 24 }
+        │       └── Cast { cast_to: Decimal128(22, 2), expr: 24(i64) }
         └── PhysicalScan { table: lineitem }
 */
 
@@ -770,7 +770,7 @@ LogicalSort
             │   └── Mul
             │       ├── #12
             │       └── Sub
-            │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+            │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1(i64) }
             │           └── #13
             └── LogicalFilter
                 ├── cond:And
@@ -838,7 +838,7 @@ PhysicalSort
             │   └── Mul
             │       ├── #12
             │       └── Sub
-            │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+            │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1(i64) }
             │           └── #13
             └── PhysicalNestedLoopJoin
                 ├── join_type: Inner
@@ -932,7 +932,7 @@ LogicalSort
         │   │           │   ├── #2
         │   │           │   └── "IRAQ"
         │   │           ├── #1
-        │   │           └── Cast { cast_to: Decimal128(38, 4), expr: 0 }
+        │   │           └── Cast { cast_to: Decimal128(38, 4), expr: 0(i64) }
         │   └── Agg(Sum)
         │       └── [ #1 ]
         ├── groups: [ #0 ]
@@ -943,7 +943,7 @@ LogicalSort
             │   ├── Mul
             │   │   ├── #21
             │   │   └── Sub
-            │   │       ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+            │   │       ├── Cast { cast_to: Decimal128(20, 0), expr: 1(i64) }
             │   │       └── #22
             │   └── #54
             └── LogicalFilter
@@ -1009,7 +1009,7 @@ PhysicalSort
         │   │           │   ├── #2
         │   │           │   └── "IRAQ"
         │   │           ├── #1
-        │   │           └── Cast { cast_to: Decimal128(38, 4), expr: 0 }
+        │   │           └── Cast { cast_to: Decimal128(38, 4), expr: 0(i64) }
         │   └── Agg(Sum)
         │       └── [ #1 ]
         ├── groups: [ #0 ]
@@ -1020,7 +1020,7 @@ PhysicalSort
             │   ├── Mul
             │   │   ├── #21
             │   │   └── Sub
-            │   │       ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+            │   │       ├── Cast { cast_to: Decimal128(20, 0), expr: 1(i64) }
             │   │       └── #22
             │   └── #54
             └── PhysicalHashJoin { join_type: Inner, left_keys: [ #51 ], right_keys: [ #0 ] }
@@ -1104,7 +1104,7 @@ LogicalSort
             │       ├── Mul
             │       │   ├── #21
             │       │   └── Sub
-            │       │       ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+            │       │       ├── Cast { cast_to: Decimal128(20, 0), expr: 1(i64) }
             │       │       └── #22
             │       └── Mul
             │           ├── #35
@@ -1161,7 +1161,7 @@ PhysicalSort
             │       ├── Mul
             │       │   ├── #21
             │       │   └── Sub
-            │       │       ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+            │       │       ├── Cast { cast_to: Decimal128(20, 0), expr: 1(i64) }
             │       │       └── #22
             │       └── Mul
             │           ├── #35
@@ -1235,7 +1235,7 @@ LogicalSort
             │       ├── Mul
             │       │   ├── #21
             │       │   └── Sub
-            │       │       ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+            │       │       ├── Cast { cast_to: Decimal128(20, 0), expr: 1(i64) }
             │       │       └── #22
             │       └── Mul
             │           ├── #35
@@ -1292,7 +1292,7 @@ PhysicalSort
             │       ├── Mul
             │       │   ├── #21
             │       │   └── Sub
-            │       │       ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+            │       │       ├── Cast { cast_to: Decimal128(20, 0), expr: 1(i64) }
             │       │       └── #22
             │       └── Mul
             │           ├── #35
@@ -1346,7 +1346,7 @@ ORDER BY
 LIMIT 20;
 
 /*
-LogicalLimit { skip: 0, fetch: 20 }
+LogicalLimit { skip: 0(u64), fetch: 20(u64) }
 └── LogicalSort
     ├── exprs:SortOrder { order: Desc }
     │   └── #2
@@ -1356,7 +1356,7 @@ LogicalLimit { skip: 0, fetch: 20 }
             │   └── Mul
             │       ├── #22
             │       └── Sub
-            │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+            │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1(i64) }
             │           └── #23
             ├── groups: [ #0, #1, #5, #4, #34, #2, #7 ]
             └── LogicalFilter
@@ -1388,7 +1388,7 @@ LogicalLimit { skip: 0, fetch: 20 }
                     │   │   └── LogicalScan { table: orders }
                     │   └── LogicalScan { table: lineitem }
                     └── LogicalScan { table: nation }
-PhysicalLimit { skip: 0, fetch: 20 }
+PhysicalLimit { skip: 0(u64), fetch: 20(u64) }
 └── PhysicalSort
     ├── exprs:SortOrder { order: Desc }
     │   └── #2
@@ -1398,7 +1398,7 @@ PhysicalLimit { skip: 0, fetch: 20 }
             │   └── Mul
             │       ├── #22
             │       └── Sub
-            │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+            │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1(i64) }
             │           └── #23
             ├── groups: [ #0, #1, #5, #4, #34, #2, #7 ]
             └── PhysicalHashJoin { join_type: Inner, left_keys: [ #3 ], right_keys: [ #0 ] }
@@ -1497,7 +1497,7 @@ LogicalSort
             │   ├── cast_to: Decimal128(38, 15)
             │   ├── expr:Mul
             │   │   ├── Cast { cast_to: Float64, expr: #0 }
-            │   │   └── 0.0001
+            │   │   └── 0.0001(float)
 
             └── LogicalAgg
                 ├── exprs:Agg(Sum)
@@ -1543,7 +1543,7 @@ PhysicalSort
             │   │   ├── cast_to: Decimal128(38, 15)
             │   │   ├── expr:Mul
             │   │   │   ├── Cast { cast_to: Float64, expr: #0 }
-            │   │   │   └── 0.0001
+            │   │   │   └── 0.0001(float)
 
             │   └── PhysicalAgg
             │       ├── aggrs:Agg(Sum)
@@ -1630,8 +1630,8 @@ LogicalSort
         │   │           │   └── Eq
         │   │           │       ├── #5
         │   │           │       └── "2-HIGH"
-        │   │           ├── 1
-        │   │           └── 0
+        │   │           ├── 1(i64)
+        │   │           └── 0(i64)
         │   └── Agg(Sum)
         │       └── Case
         │           └── 
@@ -1642,8 +1642,8 @@ LogicalSort
         │               │   └── Neq
         │               │       ├── #5
         │               │       └── "2-HIGH"
-        │               ├── 1
-        │               └── 0
+        │               ├── 1(i64)
+        │               └── 0(i64)
         ├── groups: [ #23 ]
         └── LogicalFilter
             ├── cond:And
@@ -1682,8 +1682,8 @@ PhysicalSort
         │   │           │   └── Eq
         │   │           │       ├── #5
         │   │           │       └── "2-HIGH"
-        │   │           ├── 1
-        │   │           └── 0
+        │   │           ├── 1(i64)
+        │   │           └── 0(i64)
         │   └── Agg(Sum)
         │       └── Case
         │           └── 
@@ -1694,8 +1694,8 @@ PhysicalSort
         │               │   └── Neq
         │               │       ├── #5
         │               │       └── "2-HIGH"
-        │               ├── 1
-        │               └── 0
+        │               ├── 1(i64)
+        │               └── 0(i64)
         ├── groups: [ #23 ]
         └── PhysicalHashJoin { join_type: Inner, left_keys: [ #0 ], right_keys: [ #0 ] }
             ├── PhysicalScan { table: orders }
@@ -1734,7 +1734,7 @@ WHERE
 LogicalProjection
 ├── exprs:Div
 │   ├── Mul
-│   │   ├── 100
+│   │   ├── 100(float)
 │   │   └── Cast { cast_to: Float64, expr: #0 }
 │   └── Cast { cast_to: Float64, expr: #1 }
 └── LogicalAgg
@@ -1746,14 +1746,14 @@ LogicalProjection
     │   │           ├── Mul
     │   │           │   ├── #5
     │   │           │   └── Sub
-    │   │           │       ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+    │   │           │       ├── Cast { cast_to: Decimal128(20, 0), expr: 1(i64) }
     │   │           │       └── #6
-    │   │           └── Cast { cast_to: Decimal128(38, 4), expr: 0 }
+    │   │           └── Cast { cast_to: Decimal128(38, 4), expr: 0(i64) }
     │   └── Agg(Sum)
     │       └── Mul
     │           ├── #5
     │           └── Sub
-    │               ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+    │               ├── Cast { cast_to: Decimal128(20, 0), expr: 1(i64) }
     │               └── #6
     ├── groups: []
     └── LogicalFilter
@@ -1775,7 +1775,7 @@ LogicalProjection
 PhysicalProjection
 ├── exprs:Div
 │   ├── Mul
-│   │   ├── 100
+│   │   ├── 100(float)
 │   │   └── Cast { cast_to: Float64, expr: #0 }
 │   └── Cast { cast_to: Float64, expr: #1 }
 └── PhysicalAgg
@@ -1787,14 +1787,14 @@ PhysicalProjection
     │   │           ├── Mul
     │   │           │   ├── #5
     │   │           │   └── Sub
-    │   │           │       ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+    │   │           │       ├── Cast { cast_to: Decimal128(20, 0), expr: 1(i64) }
     │   │           │       └── #6
-    │   │           └── Cast { cast_to: Decimal128(38, 4), expr: 0 }
+    │   │           └── Cast { cast_to: Decimal128(38, 4), expr: 0(i64) }
     │   └── Agg(Sum)
     │       └── Mul
     │           ├── #5
     │           └── Sub
-    │               ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+    │               ├── Cast { cast_to: Decimal128(20, 0), expr: 1(i64) }
     │               └── #6
     ├── groups: []
     └── PhysicalHashJoin { join_type: Inner, left_keys: [ #1 ], right_keys: [ #0 ] }
@@ -1871,7 +1871,7 @@ LogicalSort
         │               │   └── Mul
         │               │       ├── #1
         │               │       └── Sub
-        │               │           ├── 1
+        │               │           ├── 1(float)
         │               │           └── #2
         │               ├── groups: [ #0 ]
         │               └── LogicalProjection { exprs: [ #0, #1, #2 ] }
@@ -1879,10 +1879,10 @@ LogicalSort
         │                       ├── cond:And
         │                       │   ├── Geq
         │                       │   │   ├── #3
-        │                       │   │   └── 8401
+        │                       │   │   └── 8401(i64)
         │                       │   └── Lt
         │                       │       ├── #3
-        │                       │       └── 8491
+        │                       │       └── 8491(i64)
         │                       └── LogicalProjection { exprs: [ #2, #5, #6, #10 ] }
         │                           └── LogicalScan { table: lineitem }
         └── LogicalAgg
@@ -1895,7 +1895,7 @@ LogicalSort
                     │   └── Mul
                     │       ├── #1
                     │       └── Sub
-                    │           ├── 1
+                    │           ├── 1(float)
                     │           └── #2
                     ├── groups: [ #0 ]
                     └── LogicalProjection { exprs: [ #0, #1, #2 ] }
@@ -1903,10 +1903,10 @@ LogicalSort
                             ├── cond:And
                             │   ├── Geq
                             │   │   ├── #3
-                            │   │   └── 8401
+                            │   │   └── 8401(i64)
                             │   └── Lt
                             │       ├── #3
-                            │       └── 8491
+                            │       └── 8491(i64)
                             └── LogicalProjection { exprs: [ #2, #5, #6, #10 ] }
                                 └── LogicalScan { table: lineitem }
 PhysicalSort
@@ -1930,7 +1930,7 @@ PhysicalSort
                         │           │   └── Mul
                         │           │       ├── #1
                         │           │       └── Sub
-                        │           │           ├── 1
+                        │           │           ├── 1(float)
                         │           │           └── #2
                         │           ├── groups: [ #0 ]
                         │           └── PhysicalProjection { exprs: [ #0, #1, #2 ] }
@@ -1939,17 +1939,17 @@ PhysicalSort
                         │                       ├── cond:And
                         │                       │   ├── Geq
                         │                       │   │   ├── #10
-                        │                       │   │   └── 8401
+                        │                       │   │   └── 8401(i64)
                         │                       │   └── Lt
                         │                       │       ├── #10
-                        │                       │       └── 8491
+                        │                       │       └── 8491(i64)
                         │                       └── PhysicalScan { table: lineitem }
                         └── PhysicalAgg
                             ├── aggrs:Agg(Sum)
                             │   └── Mul
                             │       ├── #1
                             │       └── Sub
-                            │           ├── 1
+                            │           ├── 1(float)
                             │           └── #2
                             ├── groups: [ #0 ]
                             └── PhysicalProjection { exprs: [ #0, #1, #2 ] }
@@ -1958,10 +1958,10 @@ PhysicalSort
                                         ├── cond:And
                                         │   ├── Geq
                                         │   │   ├── #10
-                                        │   │   └── 8401
+                                        │   │   └── 8401(i64)
                                         │   └── Lt
                                         │       ├── #10
-                                        │       └── 8491
+                                        │       └── 8491(i64)
                                         └── PhysicalScan { table: lineitem }
 */
 
@@ -1990,8 +1990,8 @@ LogicalProjection
 │   └── 
 │       ┌── Div
 │       │   ├── Cast { cast_to: Float64, expr: #0 }
-│       │   └── 7
-│       └── 16
+│       │   └── 7(float)
+│       └── 16(i64)
 └── LogicalAgg
     ├── exprs:Agg(Sum)
     │   └── [ #0 ]
@@ -2030,7 +2030,7 @@ LogicalProjection
                 │   ┌── Cast
                 │   │   ├── cast_to: Decimal128(30, 15)
                 │   │   ├── expr:Mul
-                │   │   │   ├── 0.2
+                │   │   │   ├── 0.2(float)
                 │   │   │   └── Cast { cast_to: Float64, expr: #1 }
 
                 │   └── #0
@@ -2045,8 +2045,8 @@ PhysicalProjection
 │   └── 
 │       ┌── Div
 │       │   ├── Cast { cast_to: Float64, expr: #0 }
-│       │   └── 7
-│       └── 16
+│       │   └── 7(float)
+│       └── 16(i64)
 └── PhysicalAgg
     ├── aggrs:Agg(Sum)
     │   └── [ #0 ]
@@ -2081,7 +2081,7 @@ PhysicalProjection
                 │   ┌── Cast
                 │   │   ├── cast_to: Decimal128(30, 15)
                 │   │   ├── expr:Mul
-                │   │   │   ├── 0.2
+                │   │   │   ├── 0.2(float)
                 │   │   │   └── Cast { cast_to: Float64, expr: #1 }
 
                 │   └── #0
@@ -2133,7 +2133,7 @@ LogicalProjection { exprs: [ #0 ] }
     │   └── Mul
     │       ├── #5
     │       └── Sub
-    │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+    │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1(i64) }
     │           └── #6
     ├── groups: []
     └── LogicalFilter
@@ -2148,11 +2148,11 @@ LogicalProjection { exprs: [ #0 ] }
         │   │   ├── InList { expr: #22, list: [ "SM CASE", "SM BOX", "SM PACK", "SM PKG" ], negated: false }
         │   │   ├── Geq
         │   │   │   ├── Cast { cast_to: Decimal128(22, 2), expr: #4 }
-        │   │   │   └── Cast { cast_to: Decimal128(22, 2), expr: 1 }
+        │   │   │   └── Cast { cast_to: Decimal128(22, 2), expr: 1(i64) }
         │   │   ├── Leq
         │   │   │   ├── Cast { cast_to: Decimal128(22, 2), expr: #4 }
-        │   │   │   └── Cast { cast_to: Decimal128(22, 2), expr: 11 }
-        │   │   ├── Between { expr: Cast { cast_to: Int64, expr: #21 }, lower: 1, upper: 5 }
+        │   │   │   └── Cast { cast_to: Decimal128(22, 2), expr: 11(i64) }
+        │   │   ├── Between { expr: Cast { cast_to: Int64, expr: #21 }, lower: 1(i64), upper: 5(i64) }
         │   │   ├── InList { expr: #14, list: [ "AIR", "AIR REG" ], negated: false }
         │   │   └── Eq
         │   │       ├── #13
@@ -2167,11 +2167,11 @@ LogicalProjection { exprs: [ #0 ] }
         │   │   ├── InList { expr: #22, list: [ "MED BAG", "MED BOX", "MED PKG", "MED PACK" ], negated: false }
         │   │   ├── Geq
         │   │   │   ├── Cast { cast_to: Decimal128(22, 2), expr: #4 }
-        │   │   │   └── Cast { cast_to: Decimal128(22, 2), expr: 10 }
+        │   │   │   └── Cast { cast_to: Decimal128(22, 2), expr: 10(i64) }
         │   │   ├── Leq
         │   │   │   ├── Cast { cast_to: Decimal128(22, 2), expr: #4 }
-        │   │   │   └── Cast { cast_to: Decimal128(22, 2), expr: 20 }
-        │   │   ├── Between { expr: Cast { cast_to: Int64, expr: #21 }, lower: 1, upper: 10 }
+        │   │   │   └── Cast { cast_to: Decimal128(22, 2), expr: 20(i64) }
+        │   │   ├── Between { expr: Cast { cast_to: Int64, expr: #21 }, lower: 1(i64), upper: 10(i64) }
         │   │   ├── InList { expr: #14, list: [ "AIR", "AIR REG" ], negated: false }
         │   │   └── Eq
         │   │       ├── #13
@@ -2186,11 +2186,11 @@ LogicalProjection { exprs: [ #0 ] }
         │       ├── InList { expr: #22, list: [ "LG CASE", "LG BOX", "LG PACK", "LG PKG" ], negated: false }
         │       ├── Geq
         │       │   ├── Cast { cast_to: Decimal128(22, 2), expr: #4 }
-        │       │   └── Cast { cast_to: Decimal128(22, 2), expr: 20 }
+        │       │   └── Cast { cast_to: Decimal128(22, 2), expr: 20(i64) }
         │       ├── Leq
         │       │   ├── Cast { cast_to: Decimal128(22, 2), expr: #4 }
-        │       │   └── Cast { cast_to: Decimal128(22, 2), expr: 30 }
-        │       ├── Between { expr: Cast { cast_to: Int64, expr: #21 }, lower: 1, upper: 15 }
+        │       │   └── Cast { cast_to: Decimal128(22, 2), expr: 30(i64) }
+        │       ├── Between { expr: Cast { cast_to: Int64, expr: #21 }, lower: 1(i64), upper: 15(i64) }
         │       ├── InList { expr: #14, list: [ "AIR", "AIR REG" ], negated: false }
         │       └── Eq
         │           ├── #13
@@ -2204,7 +2204,7 @@ PhysicalProjection { exprs: [ #0 ] }
     │   └── Mul
     │       ├── #5
     │       └── Sub
-    │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1 }
+    │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1(i64) }
     │           └── #6
     ├── groups: []
     └── PhysicalNestedLoopJoin
@@ -2220,11 +2220,11 @@ PhysicalProjection { exprs: [ #0 ] }
         │   │   ├── InList { expr: #22, list: [ "SM CASE", "SM BOX", "SM PACK", "SM PKG" ], negated: false }
         │   │   ├── Geq
         │   │   │   ├── Cast { cast_to: Decimal128(22, 2), expr: #4 }
-        │   │   │   └── Cast { cast_to: Decimal128(22, 2), expr: 1 }
+        │   │   │   └── Cast { cast_to: Decimal128(22, 2), expr: 1(i64) }
         │   │   ├── Leq
         │   │   │   ├── Cast { cast_to: Decimal128(22, 2), expr: #4 }
-        │   │   │   └── Cast { cast_to: Decimal128(22, 2), expr: 11 }
-        │   │   ├── Between { expr: Cast { cast_to: Int64, expr: #21 }, lower: 1, upper: 5 }
+        │   │   │   └── Cast { cast_to: Decimal128(22, 2), expr: 11(i64) }
+        │   │   ├── Between { expr: Cast { cast_to: Int64, expr: #21 }, lower: 1(i64), upper: 5(i64) }
         │   │   ├── InList { expr: #14, list: [ "AIR", "AIR REG" ], negated: false }
         │   │   └── Eq
         │   │       ├── #13
@@ -2239,11 +2239,11 @@ PhysicalProjection { exprs: [ #0 ] }
         │   │   ├── InList { expr: #22, list: [ "MED BAG", "MED BOX", "MED PKG", "MED PACK" ], negated: false }
         │   │   ├── Geq
         │   │   │   ├── Cast { cast_to: Decimal128(22, 2), expr: #4 }
-        │   │   │   └── Cast { cast_to: Decimal128(22, 2), expr: 10 }
+        │   │   │   └── Cast { cast_to: Decimal128(22, 2), expr: 10(i64) }
         │   │   ├── Leq
         │   │   │   ├── Cast { cast_to: Decimal128(22, 2), expr: #4 }
-        │   │   │   └── Cast { cast_to: Decimal128(22, 2), expr: 20 }
-        │   │   ├── Between { expr: Cast { cast_to: Int64, expr: #21 }, lower: 1, upper: 10 }
+        │   │   │   └── Cast { cast_to: Decimal128(22, 2), expr: 20(i64) }
+        │   │   ├── Between { expr: Cast { cast_to: Int64, expr: #21 }, lower: 1(i64), upper: 10(i64) }
         │   │   ├── InList { expr: #14, list: [ "AIR", "AIR REG" ], negated: false }
         │   │   └── Eq
         │   │       ├── #13
@@ -2258,11 +2258,11 @@ PhysicalProjection { exprs: [ #0 ] }
         │       ├── InList { expr: #22, list: [ "LG CASE", "LG BOX", "LG PACK", "LG PKG" ], negated: false }
         │       ├── Geq
         │       │   ├── Cast { cast_to: Decimal128(22, 2), expr: #4 }
-        │       │   └── Cast { cast_to: Decimal128(22, 2), expr: 20 }
+        │       │   └── Cast { cast_to: Decimal128(22, 2), expr: 20(i64) }
         │       ├── Leq
         │       │   ├── Cast { cast_to: Decimal128(22, 2), expr: #4 }
-        │       │   └── Cast { cast_to: Decimal128(22, 2), expr: 30 }
-        │       ├── Between { expr: Cast { cast_to: Int64, expr: #21 }, lower: 1, upper: 15 }
+        │       │   └── Cast { cast_to: Decimal128(22, 2), expr: 30(i64) }
+        │       ├── Between { expr: Cast { cast_to: Int64, expr: #21 }, lower: 1(i64), upper: 15(i64) }
         │       ├── InList { expr: #14, list: [ "AIR", "AIR REG" ], negated: false }
         │       └── Eq
         │           ├── #13

--- a/optd-sqlplannertest/tests/verbose.planner.sql
+++ b/optd-sqlplannertest/tests/verbose.planner.sql
@@ -29,7 +29,7 @@ select count(*) from t1;
 PhysicalProjection { exprs: [ #0 ], cost: weighted=21.18,row_cnt=1.00,compute=20.18,io=1.00 }
 └── PhysicalAgg
     ├── aggrs:Agg(Count)
-    │   └── [ 1 ]
+    │   └── [ 1(u8) ]
     ├── groups: []
     ├── cost: weighted=21.12,row_cnt=1.00,compute=20.12,io=1.00
     └── PhysicalScan { table: t1, cost: weighted=1.00,row_cnt=1.00,compute=0.00,io=1.00 }


### PR DESCRIPTION
**Summary**: The cost model can now handle `Cast` nodes around `ColumnRef`s and/or `Constant`s

**Demo**:
With this feature, our average q-error on joblight _when using our own optimizer_ is now 5.03 instead of ~4000.
<img width="967" alt="Screenshot 2024-04-30 at 16 37 29" src="https://github.com/cmu-db/optd/assets/20631215/42510a5f-10ca-4b5c-8532-6c63d447c1db">

**Details**:
* When using DataFusion's optimizer, the cost model never deals with `Cast` nodes. However, when using the optd optimizer, the cost model does have to deal with `Cast` nodes.
* We should also add a rule in the optimizer to get rid of `Cast`s. However, even after adding that rule, it's still valuable for the cost model to be able to handle `Cast`s.
* The algorithm currently will not work for nested `Cast`s. You'll need to resolve the `Cast`s from bottom-up instead of top-down to do this.