### PR TITLE
[WIP] core: group reduction using union find

### DIFF
--- a/optd-core/src/cascades/memo.rs
+++ b/optd-core/src/cascades/memo.rs
@@ -6,7 +6,10 @@ use std::{
 };
 
 use anyhow::{bail, Result};
-use disjoint_group::set::{DisjointSet, UnionFind};
+use disjoint_group::{
+    set::{DisjointSet, UnionFind},
+    DisjointGroupMap,
+};
 use itertools::Itertools;
 use std::any::Any;
 
@@ -195,6 +198,7 @@ impl<T: RelNodeTyp> Memo<T> {
         props
     }
 
+    // TODO(yuchen): make internal to disjoint group
     fn clear_exprs_in_group(&mut self, group_id: GroupId) {
         self.groups.remove(&group_id);
     }
@@ -202,6 +206,7 @@ impl<T: RelNodeTyp> Memo<T> {
     /// If group_id exists, it adds expr_id to the existing group
     /// Otherwise, it creates a new group of that group_id and insert expr_id into the new group
     fn add_expr_to_group(&mut self, expr_id: ExprId, group_id: GroupId, memo_node: RelMemoNode<T>) {
+        // TODO(yuchen): use entry API
         if let Entry::Occupied(mut entry) = self.groups.entry(group_id) {
             let group = entry.get_mut();
             group.group_exprs.insert(expr_id);
@@ -214,6 +219,7 @@ impl<T: RelNodeTyp> Memo<T> {
         };
         group.group_exprs.insert(expr_id);
         self.disjoint_group_ids.add(group_id);
+        // TODO(yuchen): use insert
         self.groups.insert(group_id, group);
     }
 
@@ -228,6 +234,7 @@ impl<T: RelNodeTyp> Memo<T> {
     ) -> bool {
         let replace_group_id = self.get_reduced_group_id(replace_group_id);
 
+        // TODO(yuchen): use disjoint group entry API
         if let Entry::Occupied(mut entry) = self.groups.entry(replace_group_id) {
             let group = entry.get_mut();
             if !group.group_exprs.contains(&expr_id) {

--- a/optd-core/src/cascades/memo.rs
+++ b/optd-core/src/cascades/memo.rs
@@ -1,4 +1,4 @@
-mod disjoint_set;
+mod disjoint_group;
 
 use std::{
     collections::{hash_map::Entry, HashMap, HashSet},
@@ -6,7 +6,7 @@ use std::{
 };
 
 use anyhow::{bail, Result};
-use disjoint_set::{DisjointSet, UnionFind};
+use disjoint_group::set::{DisjointSet, UnionFind};
 use itertools::Itertools;
 use std::any::Any;
 

--- a/optd-core/src/cascades/memo.rs
+++ b/optd-core/src/cascades/memo.rs
@@ -118,7 +118,7 @@ impl<T: RelNodeTyp> Memo<T> {
         // Remove all expressions from group other (so we don't accidentally access it)
         self.clear_exprs_in_group(other);
 
-        group_b
+        rep
     }
 
     fn get_group_id_of_expr_id(&self, expr_id: ExprId) -> GroupId {

--- a/optd-core/src/cascades/memo/disjoint_group.rs
+++ b/optd-core/src/cascades/memo/disjoint_group.rs
@@ -1,0 +1,1 @@
+pub mod set;

--- a/optd-core/src/cascades/memo/disjoint_group.rs
+++ b/optd-core/src/cascades/memo/disjoint_group.rs
@@ -1,1 +1,111 @@
+use std::{
+    collections::{hash_map, HashMap},
+    ops::Index,
+};
+
+use set::{DisjointSet, UnionFind};
+
+use crate::cascades::GroupId;
+
+use super::Group;
+
 pub mod set;
+
+const MISMATCH_ERROR: &str = "`groups` and `id_map` report unmatched group membership";
+
+pub(crate) struct DisjointGroupMap {
+    id_map: DisjointSet<GroupId>,
+    groups: HashMap<GroupId, Group>,
+}
+
+impl DisjointGroupMap {
+    /// Creates a new disjoint group instance.
+    pub fn new() -> Self {
+        DisjointGroupMap {
+            id_map: DisjointSet::new(),
+            groups: HashMap::new(),
+        }
+    }
+
+    pub fn get(&self, id: &GroupId) -> Option<&Group> {
+        self.id_map
+            .find(id)
+            .map(|rep| self.groups.get(&rep).expect(MISMATCH_ERROR))
+    }
+
+    pub fn get_mut(&mut self, id: &GroupId) -> Option<&mut Group> {
+        self.id_map
+            .find(id)
+            .map(|rep| self.groups.get_mut(&rep).expect(MISMATCH_ERROR))
+    }
+
+    unsafe fn insert_new(&mut self, id: GroupId, group: Group) {
+        self.id_map.add(id);
+        self.groups.insert(id, group);
+    }
+
+    pub fn entry(&mut self, id: GroupId) -> GroupEntry<'_> {
+        use hash_map::Entry::*;
+        let rep = self.id_map.find(&id).unwrap_or(id);
+        let id_entry = self.id_map.entry(rep);
+        let group_entry = self.groups.entry(rep);
+        match (id_entry, group_entry) {
+            (Occupied(_), Occupied(inner)) => GroupEntry::Occupied(OccupiedGroupEntry { inner }),
+            (Vacant(id), Vacant(inner)) => GroupEntry::Vacant(VacantGroupEntry { id, inner }),
+            _ => unreachable!("{MISMATCH_ERROR}"),
+        }
+    }
+}
+
+pub enum GroupEntry<'a> {
+    Occupied(OccupiedGroupEntry<'a>),
+    Vacant(VacantGroupEntry<'a>),
+}
+
+pub struct OccupiedGroupEntry<'a> {
+    inner: hash_map::OccupiedEntry<'a, GroupId, Group>,
+}
+
+pub struct VacantGroupEntry<'a> {
+    id: hash_map::VacantEntry<'a, GroupId, GroupId>,
+    inner: hash_map::VacantEntry<'a, GroupId, Group>,
+}
+
+impl<'a> OccupiedGroupEntry<'a> {
+    pub fn id(&self) -> &GroupId {
+        self.inner.key()
+    }
+
+    pub fn get(&self) -> &Group {
+        self.inner.get()
+    }
+
+    pub fn get_mut(&mut self) -> &mut Group {
+        self.inner.get_mut()
+    }
+}
+
+impl<'a> VacantGroupEntry<'a> {
+    pub fn id(&self) -> &GroupId {
+        self.inner.key()
+    }
+
+    pub fn insert(self, group: Group) -> &'a mut Group {
+        let id = *self.id();
+        self.id.insert(id);
+        self.inner.insert(group)
+    }
+}
+
+impl Index<&GroupId> for DisjointGroupMap {
+    type Output = Group;
+
+    fn index(&self, index: &GroupId) -> &Self::Output {
+        let rep = self
+            .id_map
+            .find(index)
+            .expect("no group found for group id");
+
+        self.groups.get(&rep).expect(MISMATCH_ERROR)
+    }
+}

--- a/optd-core/src/cascades/memo/disjoint_group/set.rs
+++ b/optd-core/src/cascades/memo/disjoint_group/set.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, fmt::Debug, hash::Hash};
+use std::{
+    collections::{hash_map, HashMap},
+    fmt::Debug,
+    hash::Hash,
+};
 
 /// A data structure for efficiently maintaining disjoint sets of `T`.
 pub struct DisjointSet<T> {
@@ -37,7 +41,7 @@ where
 
 impl<T> DisjointSet<T>
 where
-    T: Ord + Hash + Copy,
+    T: Ord + Hash + Copy + Debug,
 {
     pub fn new() -> Self {
         DisjointSet {
@@ -98,6 +102,11 @@ where
         }
 
         Some(parent)
+    }
+
+    /// Gets the given node corresponding entry in `node_parents` map for in-place manipulation.
+    pub(super) fn entry(&mut self, node: T) -> hash_map::Entry<'_, T, T> {
+        self.node_parents.entry(node)
     }
 }
 

--- a/optd-core/src/cascades/memo/disjoint_set.rs
+++ b/optd-core/src/cascades/memo/disjoint_set.rs
@@ -1,0 +1,243 @@
+use std::{
+    collections::HashMap,
+    fmt::Debug,
+    hash::Hash,
+    ops::{Deref, DerefMut},
+    sync::{atomic::AtomicUsize, Arc, RwLock, RwLockReadGuard, RwLockWriteGuard},
+};
+
+/// A data structure for efficiently maintaining disjoint sets of `T`.
+pub struct DisjointSet<T> {
+    /// Mapping from node to its parent.
+    ///
+    /// # Design
+    /// We use a `mutex` instead of reader-writer lock so that
+    /// we always need write permission to perform `path compression`
+    /// during "finds".
+    ///
+    /// Alternatively, we could do no path compression at `find`,
+    /// and only do path compression when we were doing union.
+    node_parents: Arc<RwLock<HashMap<T, T>>>,
+    /// Number of disjoint sets.
+    num_sets: AtomicUsize,
+}
+
+pub trait UnionFind<T>
+where
+    T: Ord,
+{
+    /// Unions the set containing `a` and the set containing `b`.
+    /// Returns the new representative followed by the other node,
+    /// or `None` if one the node is not present.
+    ///
+    /// The smaller representative is selected as the new representative.
+    fn union(&self, a: &T, b: &T) -> Option<[T; 2]>;
+
+    /// Gets the representative node of the set that `node` is in.
+    /// Path compression is performed while finding the representative.
+    fn find_path_compress(&self, node: &T) -> Option<T>;
+
+    /// Gets the representative node of the set that `node` is in.
+    fn find(&self, node: &T) -> Option<T>;
+}
+
+impl<T> DisjointSet<T>
+where
+    T: Ord + Hash + Copy,
+{
+    pub fn new() -> Self {
+        DisjointSet {
+            node_parents: Arc::new(RwLock::new(HashMap::new())),
+            num_sets: AtomicUsize::new(0),
+        }
+    }
+
+    pub fn size(&self) -> usize {
+        let g = self.node_parents.read().unwrap();
+        g.len()
+    }
+
+    pub fn num_sets(&self) -> usize {
+        self.num_sets.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub fn add(&mut self, node: T) {
+        use std::collections::hash_map::Entry;
+
+        let mut g = self.node_parents.write().unwrap();
+        if let Entry::Vacant(entry) = g.entry(node) {
+            entry.insert(node);
+            drop(g);
+            self.num_sets
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+
+    fn get_parent(g: &impl Deref<Target = HashMap<T, T>>, node: &T) -> Option<T> {
+        g.get(node).copied()
+    }
+
+    fn set_parent(g: &mut impl DerefMut<Target = HashMap<T, T>>, node: T, parent: T) {
+        g.insert(node, parent);
+    }
+
+    /// Recursively find the parent of the `node` until reaching the representative of the set.
+    /// A node is the representative if the its parent is the node itself.
+    ///
+    /// We utilize "path compression" to shorten the height of parent forest.
+    fn find_path_compress_inner(
+        g: &mut RwLockWriteGuard<'_, HashMap<T, T>>,
+        node: &T,
+    ) -> Option<T> {
+        let mut parent = Self::get_parent(g, node)?;
+
+        if *node != parent {
+            parent = Self::find_path_compress_inner(g, &parent)?;
+
+            // Path compression.
+            Self::set_parent(g, *node, parent);
+        }
+
+        Some(parent)
+    }
+
+    /// Recursively find the parent of the `node` until reaching the representative of the set.
+    /// A node is the representative if the its parent is the node itself.
+    fn find_inner(g: &RwLockReadGuard<'_, HashMap<T, T>>, node: &T) -> Option<T> {
+        let mut parent = Self::get_parent(g, node)?;
+
+        if *node != parent {
+            parent = Self::find_inner(g, &parent)?;
+        }
+
+        Some(parent)
+    }
+}
+
+impl<T> UnionFind<T> for DisjointSet<T>
+where
+    T: Ord + Hash + Copy + Debug,
+{
+    fn union(&self, a: &T, b: &T) -> Option<[T; 2]> {
+        use std::cmp::Ordering;
+
+        // Gets the represenatives for set containing `a`.
+        let a_rep = self.find_path_compress(&a)?;
+
+        // Gets the represenatives for set containing `b`.
+        let b_rep = self.find_path_compress(&b)?;
+
+        let mut g = self.node_parents.write().unwrap();
+
+        // Node with smaller value becomes the representative.
+        let res = match a_rep.cmp(&b_rep) {
+            Ordering::Less => {
+                Self::set_parent(&mut g, b_rep, a_rep);
+                self.num_sets
+                    .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+                [a_rep, b_rep]
+            }
+            Ordering::Greater => {
+                Self::set_parent(&mut g, a_rep, b_rep);
+                self.num_sets
+                    .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+                [b_rep, a_rep]
+            }
+            Ordering::Equal => [a_rep, b_rep],
+        };
+        Some(res)
+    }
+
+    /// See [`Self::find_inner`] for implementation detail.
+    fn find_path_compress(&self, node: &T) -> Option<T> {
+        let mut g = self.node_parents.write().unwrap();
+        Self::find_path_compress_inner(&mut g, node)
+    }
+
+    /// See [`Self::find_inner`] for implementation detail.
+    fn find(&self, node: &T) -> Option<T> {
+        let g = self.node_parents.read().unwrap();
+        Self::find_inner(&g, node)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    fn minmax<T>(v1: T, v2: T) -> [T; 2]
+    where
+        T: Ord,
+    {
+        if v1 <= v2 {
+            [v1, v2]
+        } else {
+            [v2, v1]
+        }
+    }
+
+    fn test_union_find<T>(inputs: Vec<T>)
+    where
+        T: Ord + Hash + Copy + Debug,
+    {
+        let mut set = DisjointSet::new();
+
+        for input in inputs.iter() {
+            set.add(*input);
+        }
+
+        for input in inputs.iter() {
+            let rep = set.find(input);
+            assert_eq!(
+                rep,
+                Some(*input),
+                "representive should be node itself for singleton"
+            );
+        }
+        assert_eq!(set.size(), 10);
+        assert_eq!(set.num_sets(), 10);
+
+        for input in inputs.iter() {
+            set.union(input, input).unwrap();
+            let rep = set.find(input);
+            assert_eq!(
+                rep,
+                Some(*input),
+                "representive should be node itself for singleton"
+            );
+        }
+        assert_eq!(set.size(), 10);
+        assert_eq!(set.num_sets(), 10);
+
+        for (x, y) in inputs.iter().zip(inputs.iter().rev()) {
+            let y_rep = set.find(&y).unwrap();
+            let [rep, other] = set.union(x, y).expect(&format!(
+                "union should be successful between {:?} and {:?}",
+                x, y,
+            ));
+            if rep != other {
+                assert_eq!([rep, other], minmax(*x, y_rep));
+            }
+        }
+
+        for (x, y) in inputs.iter().zip(inputs.iter().rev()) {
+            let rep = set.find(x);
+
+            let expected = x.min(y);
+            assert_eq!(rep, Some(*expected));
+        }
+        assert_eq!(set.size(), 10);
+        assert_eq!(set.num_sets(), 5);
+    }
+
+    #[test]
+    fn test_union_find_i32() {
+        test_union_find(Vec::from_iter(0..10));
+    }
+
+    #[test]
+    fn test_union_find_group() {
+        test_union_find(Vec::from_iter((0..10).map(|i| crate::cascades::GroupId(i))));
+    }
+}

--- a/optd-sqlplannertest/tests/tpch.planner.sql
+++ b/optd-sqlplannertest/tests/tpch.planner.sql
@@ -627,29 +627,29 @@ PhysicalSort
         │           ├── Cast { cast_to: Decimal128(20, 0), expr: 1(i64) }
         │           └── #23
         ├── groups: [ #41 ]
-        └── PhysicalHashJoin { join_type: Inner, left_keys: [ #19, #3 ], right_keys: [ #0, #3 ] }
-            ├── PhysicalHashJoin { join_type: Inner, left_keys: [ #0 ], right_keys: [ #1 ] }
-            │   ├── PhysicalScan { table: customer }
-            │   └── PhysicalHashJoin { join_type: Inner, left_keys: [ #0 ], right_keys: [ #0 ] }
-            │       ├── PhysicalFilter
-            │       │   ├── cond:And
-            │       │   │   ├── Geq
-            │       │   │   │   ├── #4
-            │       │   │   │   └── Cast { cast_to: Date32, expr: "2023-01-01" }
-            │       │   │   └── Lt
-            │       │   │       ├── #4
-            │       │   │       └── Cast { cast_to: Date32, expr: "2024-01-01" }
-            │       │   └── PhysicalScan { table: orders }
-            │       └── PhysicalScan { table: lineitem }
-            └── PhysicalHashJoin { join_type: Inner, left_keys: [ #9 ], right_keys: [ #0 ] }
-                ├── PhysicalHashJoin { join_type: Inner, left_keys: [ #3 ], right_keys: [ #0 ] }
-                │   ├── PhysicalScan { table: supplier }
-                │   └── PhysicalScan { table: nation }
-                └── PhysicalFilter
-                    ├── cond:Eq
-                    │   ├── #1
-                    │   └── "Asia"
-                    └── PhysicalScan { table: region }
+        └── PhysicalHashJoin { join_type: Inner, left_keys: [ #42 ], right_keys: [ #0 ] }
+            ├── PhysicalHashJoin { join_type: Inner, left_keys: [ #36 ], right_keys: [ #0 ] }
+            │   ├── PhysicalHashJoin { join_type: Inner, left_keys: [ #19, #3 ], right_keys: [ #0, #3 ] }
+            │   │   ├── PhysicalHashJoin { join_type: Inner, left_keys: [ #0 ], right_keys: [ #1 ] }
+            │   │   │   ├── PhysicalScan { table: customer }
+            │   │   │   └── PhysicalHashJoin { join_type: Inner, left_keys: [ #0 ], right_keys: [ #0 ] }
+            │   │   │       ├── PhysicalFilter
+            │   │   │       │   ├── cond:And
+            │   │   │       │   │   ├── Geq
+            │   │   │       │   │   │   ├── #4
+            │   │   │       │   │   │   └── Cast { cast_to: Date32, expr: "2023-01-01" }
+            │   │   │       │   │   └── Lt
+            │   │   │       │   │       ├── #4
+            │   │   │       │   │       └── Cast { cast_to: Date32, expr: "2024-01-01" }
+            │   │   │       │   └── PhysicalScan { table: orders }
+            │   │   │       └── PhysicalScan { table: lineitem }
+            │   │   └── PhysicalScan { table: supplier }
+            │   └── PhysicalScan { table: nation }
+            └── PhysicalFilter
+                ├── cond:Eq
+                │   ├── #1
+                │   └── "Asia"
+                └── PhysicalScan { table: region }
 */
 
 -- TPC-H Q6
@@ -864,12 +864,12 @@ PhysicalSort
                 ├── PhysicalHashJoin { join_type: Inner, left_keys: [ #3 ], right_keys: [ #0 ] }
                 │   ├── PhysicalHashJoin { join_type: Inner, left_keys: [ #0 ], right_keys: [ #2 ] }
                 │   │   ├── PhysicalScan { table: supplier }
-                │   │   └── PhysicalHashJoin { join_type: Inner, left_keys: [ #17 ], right_keys: [ #0 ] }
-                │   │       ├── PhysicalHashJoin { join_type: Inner, left_keys: [ #0 ], right_keys: [ #0 ] }
-                │   │       │   ├── PhysicalFilter { cond: Between { expr: #10, lower: Cast { cast_to: Date32, expr: "1995-01-01" }, upper: Cast { cast_to: Date32, expr: "1996-12-31" } } }
-                │   │       │   │   └── PhysicalScan { table: lineitem }
-                │   │       │   └── PhysicalScan { table: orders }
-                │   │       └── PhysicalScan { table: customer }
+                │   │   └── PhysicalHashJoin { join_type: Inner, left_keys: [ #0 ], right_keys: [ #0 ] }
+                │   │       ├── PhysicalFilter { cond: Between { expr: #10, lower: Cast { cast_to: Date32, expr: "1995-01-01" }, upper: Cast { cast_to: Date32, expr: "1996-12-31" } } }
+                │   │       │   └── PhysicalScan { table: lineitem }
+                │   │       └── PhysicalHashJoin { join_type: Inner, left_keys: [ #1 ], right_keys: [ #0 ] }
+                │   │           ├── PhysicalScan { table: orders }
+                │   │           └── PhysicalScan { table: customer }
                 │   └── PhysicalScan { table: nation }
                 └── PhysicalScan { table: nation }
 */
@@ -1033,14 +1033,14 @@ PhysicalSort
                 │   │   │   │   │   └── "ECONOMY ANODIZED STEEL"
                 │   │   │   │   └── PhysicalScan { table: part }
                 │   │   │   └── PhysicalScan { table: supplier }
-                │   │   └── PhysicalHashJoin { join_type: Inner, left_keys: [ #17 ], right_keys: [ #0 ] }
-                │   │       ├── PhysicalHashJoin { join_type: Inner, left_keys: [ #0 ], right_keys: [ #0 ] }
-                │   │       │   ├── PhysicalScan { table: lineitem }
-                │   │       │   └── PhysicalFilter { cond: Between { expr: #4, lower: Cast { cast_to: Date32, expr: "1995-01-01" }, upper: Cast { cast_to: Date32, expr: "1996-12-31" } } }
-                │   │       │       └── PhysicalScan { table: orders }
-                │   │       └── PhysicalHashJoin { join_type: Inner, left_keys: [ #3 ], right_keys: [ #0 ] }
-                │   │           ├── PhysicalScan { table: customer }
-                │   │           └── PhysicalScan { table: nation }
+                │   │   └── PhysicalHashJoin { join_type: Inner, left_keys: [ #0 ], right_keys: [ #0 ] }
+                │   │       ├── PhysicalScan { table: lineitem }
+                │   │       └── PhysicalHashJoin { join_type: Inner, left_keys: [ #1 ], right_keys: [ #0 ] }
+                │   │           ├── PhysicalFilter { cond: Between { expr: #4, lower: Cast { cast_to: Date32, expr: "1995-01-01" }, upper: Cast { cast_to: Date32, expr: "1996-12-31" } } }
+                │   │           │   └── PhysicalScan { table: orders }
+                │   │           └── PhysicalHashJoin { join_type: Inner, left_keys: [ #3 ], right_keys: [ #0 ] }
+                │   │               ├── PhysicalScan { table: customer }
+                │   │               └── PhysicalScan { table: nation }
                 │   └── PhysicalScan { table: nation }
                 └── PhysicalFilter
                     ├── cond:Eq
@@ -1167,16 +1167,16 @@ PhysicalSort
             │           ├── #35
             │           └── #20
             └── PhysicalHashJoin { join_type: Inner, left_keys: [ #12 ], right_keys: [ #0 ] }
-                ├── PhysicalHashJoin { join_type: Inner, left_keys: [ #9, #0 ], right_keys: [ #2, #1 ] }
-                │   ├── PhysicalNestedLoopJoin { join_type: Cross, cond: true }
-                │   │   ├── PhysicalFilter { cond: Like { expr: #1, pattern: "%green%", negated: false, case_insensitive: false } }
-                │   │   │   └── PhysicalScan { table: part }
-                │   │   └── PhysicalScan { table: supplier }
-                │   └── PhysicalHashJoin { join_type: Inner, left_keys: [ #0 ], right_keys: [ #0 ] }
-                │       ├── PhysicalHashJoin { join_type: Inner, left_keys: [ #2, #1 ], right_keys: [ #1, #0 ] }
-                │       │   ├── PhysicalScan { table: lineitem }
-                │       │   └── PhysicalScan { table: partsupp }
-                │       └── PhysicalScan { table: orders }
+                ├── PhysicalHashJoin { join_type: Inner, left_keys: [ #16 ], right_keys: [ #0 ] }
+                │   ├── PhysicalHashJoin { join_type: Inner, left_keys: [ #9, #0 ], right_keys: [ #2, #1 ] }
+                │   │   ├── PhysicalNestedLoopJoin { join_type: Cross, cond: true }
+                │   │   │   ├── PhysicalFilter { cond: Like { expr: #1, pattern: "%green%", negated: false, case_insensitive: false } }
+                │   │   │   │   └── PhysicalScan { table: part }
+                │   │   │   └── PhysicalScan { table: supplier }
+                │   │   └── PhysicalHashJoin { join_type: Inner, left_keys: [ #2, #1 ], right_keys: [ #1, #0 ] }
+                │   │       ├── PhysicalScan { table: lineitem }
+                │   │       └── PhysicalScan { table: partsupp }
+                │   └── PhysicalScan { table: orders }
                 └── PhysicalScan { table: nation }
 */
 
@@ -1298,16 +1298,16 @@ PhysicalSort
             │           ├── #35
             │           └── #20
             └── PhysicalHashJoin { join_type: Inner, left_keys: [ #12 ], right_keys: [ #0 ] }
-                ├── PhysicalHashJoin { join_type: Inner, left_keys: [ #9, #0 ], right_keys: [ #2, #1 ] }
-                │   ├── PhysicalNestedLoopJoin { join_type: Cross, cond: true }
-                │   │   ├── PhysicalFilter { cond: Like { expr: #1, pattern: "%green%", negated: false, case_insensitive: false } }
-                │   │   │   └── PhysicalScan { table: part }
-                │   │   └── PhysicalScan { table: supplier }
-                │   └── PhysicalHashJoin { join_type: Inner, left_keys: [ #0 ], right_keys: [ #0 ] }
-                │       ├── PhysicalHashJoin { join_type: Inner, left_keys: [ #2, #1 ], right_keys: [ #1, #0 ] }
-                │       │   ├── PhysicalScan { table: lineitem }
-                │       │   └── PhysicalScan { table: partsupp }
-                │       └── PhysicalScan { table: orders }
+                ├── PhysicalHashJoin { join_type: Inner, left_keys: [ #16 ], right_keys: [ #0 ] }
+                │   ├── PhysicalHashJoin { join_type: Inner, left_keys: [ #9, #0 ], right_keys: [ #2, #1 ] }
+                │   │   ├── PhysicalNestedLoopJoin { join_type: Cross, cond: true }
+                │   │   │   ├── PhysicalFilter { cond: Like { expr: #1, pattern: "%green%", negated: false, case_insensitive: false } }
+                │   │   │   │   └── PhysicalScan { table: part }
+                │   │   │   └── PhysicalScan { table: supplier }
+                │   │   └── PhysicalHashJoin { join_type: Inner, left_keys: [ #2, #1 ], right_keys: [ #1, #0 ] }
+                │   │       ├── PhysicalScan { table: lineitem }
+                │   │       └── PhysicalScan { table: partsupp }
+                │   └── PhysicalScan { table: orders }
                 └── PhysicalScan { table: nation }
 */
 
@@ -2057,7 +2057,7 @@ PhysicalProjection
             ├── cond:And
             │   ├── Eq
             │   │   ├── #2
-            │   │   └── #0
+            │   │   └── #4
             │   └── Lt
             │       ├── Cast { cast_to: Decimal128(30, 15), expr: #0 }
             │       └── #3


### PR DESCRIPTION
The PR uses union-find to maintain group equivalence. This is done by maintaining 
- a DisjointSet of group ids
- representative group id to Group mapping.

The "path compression" done during `union` operation speeds up tpch sqlplannertest run from ~89s to ~9s on local machine.


TODO
- [ ] Better to have a Map<GroupId, Group> interface without thinking about reduced group. We can use `DisjointGroup` to replace `get_reduced_group_id`, `Memo::groups::...`, and `Memo::merge_group` functionalities.