### PR TITLE
fix(core): logical property in heuristics, depjoin schema in df-repr

### DIFF
--- a/optd-core/src/heuristics/optimizer.rs
+++ b/optd-core/src/heuristics/optimizer.rs
@@ -131,10 +131,9 @@ impl<T: RelNodeTyp> HeuristicsOptimizer<T> {
     fn apply_rules(&mut self, mut root_rel: RelNodeRef<T>) -> Result<RelNodeRef<T>> {
         for rule in self.rules.clone().as_ref() {
             // Properties only matter for applying rules, therefore applying it before each rule invoke.
-            self.infer_properties(root_rel.clone());
-
             let matcher = rule.matcher();
             if let Some(picks) = match_and_pick(matcher, root_rel.clone()) {
+                self.infer_properties(root_rel.clone());
                 let mut results = rule.apply(self, picks);
                 assert!(results.len() <= 1);
                 if !results.is_empty() {

--- a/optd-core/src/heuristics/optimizer.rs
+++ b/optd-core/src/heuristics/optimizer.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use itertools::Itertools;
 use std::any::Any;
 
@@ -123,13 +123,16 @@ impl<T: RelNodeTyp> HeuristicsOptimizer<T> {
     fn optimize_inputs(&mut self, inputs: &[RelNodeRef<T>]) -> Result<Vec<RelNodeRef<T>>> {
         let mut optimized_inputs = Vec::with_capacity(inputs.len());
         for input in inputs {
-            optimized_inputs.push(self.optimize(input.clone())?);
+            optimized_inputs.push(self.optimize_inner(input.clone())?);
         }
         Ok(optimized_inputs)
     }
 
     fn apply_rules(&mut self, mut root_rel: RelNodeRef<T>) -> Result<RelNodeRef<T>> {
-        for rule in self.rules.as_ref() {
+        for rule in self.rules.clone().as_ref() {
+            // Properties only matter for applying rules, therefore applying it before each rule invoke.
+            self.infer_properties(root_rel.clone());
+
             let matcher = rule.matcher();
             if let Some(picks) = match_and_pick(matcher, root_rel.clone()) {
                 let mut results = rule.apply(self, picks);
@@ -154,15 +157,9 @@ impl<T: RelNodeTyp> HeuristicsOptimizer<T> {
                     }
                     .into(),
                 )?;
-                self.infer_properties(root_rel.clone());
-                self.properties.insert(
-                    node.clone(),
-                    self.properties.get(&root_rel.clone()).unwrap().clone(),
-                );
                 Ok(node)
             }
             ApplyOrder::TopDown => {
-                self.infer_properties(root_rel.clone());
                 let root_rel = self.apply_rules(root_rel)?;
                 let optimized_children = self.optimize_inputs(&root_rel.children)?;
                 let node: Arc<RelNode<T>> = RelNode {
@@ -171,11 +168,6 @@ impl<T: RelNodeTyp> HeuristicsOptimizer<T> {
                     data: root_rel.data.clone(),
                 }
                 .into();
-                self.infer_properties(root_rel.clone());
-                self.properties.insert(
-                    node.clone(),
-                    self.properties.get(&root_rel.clone()).unwrap().clone(),
-                );
                 Ok(node)
             }
         }
@@ -221,8 +213,20 @@ impl<T: RelNodeTyp> Optimizer<T> for HeuristicsOptimizer<T> {
         root_rel: RelNodeRef<T>,
         idx: usize,
     ) -> P::Prop {
-        let props = self.properties.get(&root_rel).unwrap();
+        let props = self
+            .properties
+            .get(&root_rel)
+            .with_context(|| format!("cannot obtain properties for {}", root_rel))
+            .unwrap();
         let prop = props[idx].as_ref();
-        prop.downcast_ref::<P::Prop>().unwrap().clone()
+        prop.downcast_ref::<P::Prop>()
+            .with_context(|| {
+                format!(
+                    "cannot downcast property at idx {} into provided property instance",
+                    idx
+                )
+            })
+            .unwrap()
+            .clone()
     }
 }

--- a/optd-datafusion-repr/src/lib.rs
+++ b/optd-datafusion-repr/src/lib.rs
@@ -99,8 +99,7 @@ impl DatafusionOptimizer {
             Arc::new(DepJoinPastAgg::new()),
             Arc::new(ProjectMergeRule::new()),
             Arc::new(FilterMergeRule::new()),
-            // disabled due to logical properties are not implemented in heuristics
-            // Arc::new(EliminateProjectRule::new()),
+            Arc::new(EliminateProjectRule::new()),
         ]
     }
 

--- a/optd-datafusion-repr/src/lib.rs
+++ b/optd-datafusion-repr/src/lib.rs
@@ -85,6 +85,7 @@ impl DatafusionOptimizer {
     pub fn default_heuristic_rules(
     ) -> Vec<Arc<dyn Rule<OptRelNodeTyp, HeuristicsOptimizer<OptRelNodeTyp>>>> {
         vec![
+            Arc::new(EliminateProjectRule::new()),
             Arc::new(SimplifyFilterRule::new()),
             Arc::new(SimplifyJoinCondRule::new()),
             Arc::new(EliminateFilterRule::new()),
@@ -99,7 +100,6 @@ impl DatafusionOptimizer {
             Arc::new(DepJoinPastAgg::new()),
             Arc::new(ProjectMergeRule::new()),
             Arc::new(FilterMergeRule::new()),
-            Arc::new(EliminateProjectRule::new()),
         ]
     }
 

--- a/optd-datafusion-repr/src/properties/schema.rs
+++ b/optd-datafusion-repr/src/properties/schema.rs
@@ -73,7 +73,8 @@ impl PropertyBuilder<OptRelNodeTyp> for SchemaPropertyBuilder {
             }
             OptRelNodeTyp::Projection => children[1].clone(),
             OptRelNodeTyp::Filter => children[0].clone(),
-            OptRelNodeTyp::DepJoin(_) | OptRelNodeTyp::Join(_) => {
+            OptRelNodeTyp::DepJoin(_) => children[0].clone(),
+            OptRelNodeTyp::Join(_) => {
                 let mut schema = children[0].clone();
                 let schema2 = children[1].clone();
                 schema.fields.extend(schema2.fields);

--- a/optd-sqlplannertest/tests/basic/empty_relation.planner.sql
+++ b/optd-sqlplannertest/tests/basic/empty_relation.planner.sql
@@ -39,6 +39,8 @@ LogicalProjection { exprs: [ #0, #1, #2, #3 ] }
 └── LogicalJoin { join_type: Inner, cond: false }
     ├── LogicalScan { table: t1 }
     └── LogicalScan { table: t2 }
-PhysicalEmptyRelation { produce_one_row: false }
+PhysicalNestedLoopJoin { join_type: Inner, cond: false }
+├── PhysicalScan { table: t1 }
+└── PhysicalScan { table: t2 }
 */
 

--- a/optd-sqlplannertest/tests/basic/empty_relation.planner.sql
+++ b/optd-sqlplannertest/tests/basic/empty_relation.planner.sql
@@ -39,8 +39,7 @@ LogicalProjection { exprs: [ #0, #1, #2, #3 ] }
 └── LogicalJoin { join_type: Inner, cond: false }
     ├── LogicalScan { table: t1 }
     └── LogicalScan { table: t2 }
-PhysicalNestedLoopJoin { join_type: Inner, cond: false }
-├── PhysicalScan { table: t1 }
-└── PhysicalScan { table: t2 }
+LogicalEmptyRelation { produce_one_row: false }
+PhysicalEmptyRelation { produce_one_row: false }
 */
 

--- a/optd-sqlplannertest/tests/basic/empty_relation.yml
+++ b/optd-sqlplannertest/tests/basic/empty_relation.yml
@@ -17,5 +17,5 @@
     select 64+1 from t1 inner join t2 on false;
   desc: Test whether the optimizer eliminates join to empty relation
   tasks:
-    - explain:logical_optd,physical_optd
+    - explain:logical_optd,optimized_logical_optd,physical_optd
     - execute

--- a/optd-sqlplannertest/tests/basic/filter.planner.sql
+++ b/optd-sqlplannertest/tests/basic/filter.planner.sql
@@ -95,9 +95,11 @@ PhysicalNestedLoopJoin
 │   ├── Eq
 │   │   ├── #0
 │   │   └── #2
-│   └── Eq
-│       ├── #0
-│       └── #3
+│   └── And
+│       ├── Eq
+│       │   ├── #0
+│       │   └── #3
+│       └── true
 ├── PhysicalScan { table: t1 }
 └── PhysicalScan { table: t2 }
 0 0 0 200
@@ -122,7 +124,16 @@ LogicalProjection { exprs: [ #0, #1, #2, #3 ] }
     └── LogicalJoin { join_type: Cross, cond: true }
         ├── LogicalScan { table: t1 }
         └── LogicalScan { table: t2 }
-PhysicalNestedLoopJoin { join_type: Cross, cond: true }
+PhysicalNestedLoopJoin
+├── join_type: Inner
+├── cond:Or
+│   ├── Eq
+│   │   ├── #0
+│   │   └── #2
+│   ├── Eq
+│   │   ├── #0
+│   │   └── #3
+│   └── true
 ├── PhysicalScan { table: t1 }
 └── PhysicalScan { table: t2 }
 0 0 0 200
@@ -156,7 +167,19 @@ LogicalProjection { exprs: [ #0, #1, #2, #3 ] }
     └── LogicalJoin { join_type: Cross, cond: true }
         ├── LogicalScan { table: t1 }
         └── LogicalScan { table: t2 }
-PhysicalHashJoin { join_type: Inner, left_keys: [ #0 ], right_keys: [ #0 ] }
+PhysicalNestedLoopJoin
+├── join_type: Inner
+├── cond:Or
+│   ├── Eq
+│   │   ├── #0
+│   │   └── #2
+│   └── And
+│       ├── Eq
+│       │   ├── #0
+│       │   └── #2
+│       └── Eq
+│           ├── #0
+│           └── #2
 ├── PhysicalScan { table: t1 }
 └── PhysicalScan { table: t2 }
 0 0 0 200
@@ -178,7 +201,15 @@ LogicalProjection { exprs: [ #0, #1, #2, #3 ] }
     │   └── false
     ├── LogicalScan { table: t1 }
     └── LogicalScan { table: t2 }
-PhysicalEmptyRelation { produce_one_row: false }
+PhysicalNestedLoopJoin
+├── join_type: Inner
+├── cond:And
+│   ├── Eq
+│   │   ├── #0
+│   │   └── #2
+│   └── false
+├── PhysicalScan { table: t1 }
+└── PhysicalScan { table: t2 }
 */
 
 -- Test SimplifyJoinCondRule (skip true filter for and)
@@ -198,7 +229,16 @@ LogicalProjection { exprs: [ #0, #1, #2, #3 ] }
     │   └── true
     ├── LogicalScan { table: t1 }
     └── LogicalScan { table: t2 }
-PhysicalHashJoin { join_type: Inner, left_keys: [ #0, #0 ], right_keys: [ #0, #1 ] }
+PhysicalNestedLoopJoin
+├── join_type: Inner
+├── cond:And
+│   ├── Eq
+│   │   ├── #0
+│   │   └── #2
+│   ├── Eq
+│   │   ├── #0
+│   │   └── #3
+│   └── true
 ├── PhysicalScan { table: t1 }
 └── PhysicalScan { table: t2 }
 */
@@ -227,9 +267,11 @@ PhysicalNestedLoopJoin
 │   ├── Eq
 │   │   ├── #0
 │   │   └── #2
-│   └── Eq
-│       ├── #0
-│       └── #3
+│   └── And
+│       ├── Eq
+│       │   ├── #0
+│       │   └── #3
+│       └── true
 ├── PhysicalScan { table: t1 }
 └── PhysicalScan { table: t2 }
 0 0 0 200
@@ -254,7 +296,16 @@ LogicalProjection { exprs: [ #0, #1, #2, #3 ] }
     │   └── true
     ├── LogicalScan { table: t1 }
     └── LogicalScan { table: t2 }
-PhysicalNestedLoopJoin { join_type: Cross, cond: true }
+PhysicalNestedLoopJoin
+├── join_type: Inner
+├── cond:Or
+│   ├── Eq
+│   │   ├── #0
+│   │   └── #2
+│   ├── Eq
+│   │   ├── #0
+│   │   └── #3
+│   └── true
 ├── PhysicalScan { table: t1 }
 └── PhysicalScan { table: t2 }
 0 0 0 200
@@ -288,7 +339,19 @@ LogicalProjection { exprs: [ #0, #1, #2, #3 ] }
     │           └── #2
     ├── LogicalScan { table: t1 }
     └── LogicalScan { table: t2 }
-PhysicalHashJoin { join_type: Inner, left_keys: [ #0 ], right_keys: [ #0 ] }
+PhysicalNestedLoopJoin
+├── join_type: Inner
+├── cond:Or
+│   ├── Eq
+│   │   ├── #0
+│   │   └── #2
+│   └── And
+│       ├── Eq
+│       │   ├── #0
+│       │   └── #2
+│       └── Eq
+│           ├── #0
+│           └── #2
 ├── PhysicalScan { table: t1 }
 └── PhysicalScan { table: t2 }
 0 0 0 200

--- a/optd-sqlplannertest/tests/basic/filter.planner.sql
+++ b/optd-sqlplannertest/tests/basic/filter.planner.sql
@@ -95,11 +95,9 @@ PhysicalNestedLoopJoin
 │   ├── Eq
 │   │   ├── #0
 │   │   └── #2
-│   └── And
-│       ├── Eq
-│       │   ├── #0
-│       │   └── #3
-│       └── true
+│   └── Eq
+│       ├── #0
+│       └── #3
 ├── PhysicalScan { table: t1 }
 └── PhysicalScan { table: t2 }
 0 0 0 200
@@ -124,16 +122,7 @@ LogicalProjection { exprs: [ #0, #1, #2, #3 ] }
     └── LogicalJoin { join_type: Cross, cond: true }
         ├── LogicalScan { table: t1 }
         └── LogicalScan { table: t2 }
-PhysicalNestedLoopJoin
-├── join_type: Inner
-├── cond:Or
-│   ├── Eq
-│   │   ├── #0
-│   │   └── #2
-│   ├── Eq
-│   │   ├── #0
-│   │   └── #3
-│   └── true
+PhysicalNestedLoopJoin { join_type: Cross, cond: true }
 ├── PhysicalScan { table: t1 }
 └── PhysicalScan { table: t2 }
 0 0 0 200
@@ -167,19 +156,7 @@ LogicalProjection { exprs: [ #0, #1, #2, #3 ] }
     └── LogicalJoin { join_type: Cross, cond: true }
         ├── LogicalScan { table: t1 }
         └── LogicalScan { table: t2 }
-PhysicalNestedLoopJoin
-├── join_type: Inner
-├── cond:Or
-│   ├── Eq
-│   │   ├── #0
-│   │   └── #2
-│   └── And
-│       ├── Eq
-│       │   ├── #0
-│       │   └── #2
-│       └── Eq
-│           ├── #0
-│           └── #2
+PhysicalHashJoin { join_type: Inner, left_keys: [ #0 ], right_keys: [ #0 ] }
 ├── PhysicalScan { table: t1 }
 └── PhysicalScan { table: t2 }
 0 0 0 200
@@ -201,15 +178,7 @@ LogicalProjection { exprs: [ #0, #1, #2, #3 ] }
     │   └── false
     ├── LogicalScan { table: t1 }
     └── LogicalScan { table: t2 }
-PhysicalNestedLoopJoin
-├── join_type: Inner
-├── cond:And
-│   ├── Eq
-│   │   ├── #0
-│   │   └── #2
-│   └── false
-├── PhysicalScan { table: t1 }
-└── PhysicalScan { table: t2 }
+PhysicalEmptyRelation { produce_one_row: false }
 */
 
 -- Test SimplifyJoinCondRule (skip true filter for and)
@@ -229,16 +198,7 @@ LogicalProjection { exprs: [ #0, #1, #2, #3 ] }
     │   └── true
     ├── LogicalScan { table: t1 }
     └── LogicalScan { table: t2 }
-PhysicalNestedLoopJoin
-├── join_type: Inner
-├── cond:And
-│   ├── Eq
-│   │   ├── #0
-│   │   └── #2
-│   ├── Eq
-│   │   ├── #0
-│   │   └── #3
-│   └── true
+PhysicalHashJoin { join_type: Inner, left_keys: [ #0, #0 ], right_keys: [ #0, #1 ] }
 ├── PhysicalScan { table: t1 }
 └── PhysicalScan { table: t2 }
 */
@@ -267,11 +227,9 @@ PhysicalNestedLoopJoin
 │   ├── Eq
 │   │   ├── #0
 │   │   └── #2
-│   └── And
-│       ├── Eq
-│       │   ├── #0
-│       │   └── #3
-│       └── true
+│   └── Eq
+│       ├── #0
+│       └── #3
 ├── PhysicalScan { table: t1 }
 └── PhysicalScan { table: t2 }
 0 0 0 200
@@ -296,16 +254,7 @@ LogicalProjection { exprs: [ #0, #1, #2, #3 ] }
     │   └── true
     ├── LogicalScan { table: t1 }
     └── LogicalScan { table: t2 }
-PhysicalNestedLoopJoin
-├── join_type: Inner
-├── cond:Or
-│   ├── Eq
-│   │   ├── #0
-│   │   └── #2
-│   ├── Eq
-│   │   ├── #0
-│   │   └── #3
-│   └── true
+PhysicalNestedLoopJoin { join_type: Cross, cond: true }
 ├── PhysicalScan { table: t1 }
 └── PhysicalScan { table: t2 }
 0 0 0 200
@@ -339,19 +288,7 @@ LogicalProjection { exprs: [ #0, #1, #2, #3 ] }
     │           └── #2
     ├── LogicalScan { table: t1 }
     └── LogicalScan { table: t2 }
-PhysicalNestedLoopJoin
-├── join_type: Inner
-├── cond:Or
-│   ├── Eq
-│   │   ├── #0
-│   │   └── #2
-│   └── And
-│       ├── Eq
-│       │   ├── #0
-│       │   └── #2
-│       └── Eq
-│           ├── #0
-│           └── #2
+PhysicalHashJoin { join_type: Inner, left_keys: [ #0 ], right_keys: [ #0 ] }
 ├── PhysicalScan { table: t1 }
 └── PhysicalScan { table: t2 }
 0 0 0 200

--- a/optd-sqlplannertest/tests/tpch/tpch-11-15.planner.sql
+++ b/optd-sqlplannertest/tests/tpch/tpch-11-15.planner.sql
@@ -567,50 +567,50 @@ LogicalSort
 PhysicalSort
 ├── exprs:SortOrder { order: Asc }
 │   └── #0
-└── PhysicalProjection { exprs: [ #3, #4, #5, #7, #2 ] }
-    └── PhysicalHashJoin { join_type: Inner, left_keys: [ #1 ], right_keys: [ #0 ] }
-        ├── PhysicalHashJoin { join_type: Inner, left_keys: [ #0 ], right_keys: [ #1 ] }
-        │   ├── PhysicalAgg
-        │   │   ├── aggrs:Agg(Max)
-        │   │   │   └── [ #0 ]
-        │   │   ├── groups: []
-        │   │   └── PhysicalProjection { exprs: [ #1 ] }
-        │   │       └── PhysicalAgg
-        │   │           ├── aggrs:Agg(Sum)
-        │   │           │   └── Mul
-        │   │           │       ├── #1
-        │   │           │       └── Sub
-        │   │           │           ├── 1(float)
-        │   │           │           └── #2
-        │   │           ├── groups: [ #0 ]
-        │   │           └── PhysicalProjection { exprs: [ #2, #5, #6 ] }
-        │   │               └── PhysicalFilter
-        │   │                   ├── cond:And
-        │   │                   │   ├── Geq
-        │   │                   │   │   ├── #10
-        │   │                   │   │   └── 8401(i64)
-        │   │                   │   └── Lt
-        │   │                   │       ├── #10
-        │   │                   │       └── 8491(i64)
-        │   │                   └── PhysicalScan { table: lineitem }
-        │   └── PhysicalAgg
-        │       ├── aggrs:Agg(Sum)
-        │       │   └── Mul
-        │       │       ├── #1
-        │       │       └── Sub
-        │       │           ├── 1(float)
-        │       │           └── #2
-        │       ├── groups: [ #0 ]
-        │       └── PhysicalProjection { exprs: [ #2, #5, #6 ] }
-        │           └── PhysicalFilter
-        │               ├── cond:And
-        │               │   ├── Geq
-        │               │   │   ├── #10
-        │               │   │   └── 8401(i64)
-        │               │   └── Lt
-        │               │       ├── #10
-        │               │       └── 8491(i64)
-        │               └── PhysicalScan { table: lineitem }
-        └── PhysicalScan { table: supplier }
+└── PhysicalProjection { exprs: [ #1, #2, #3, #5, #9 ] }
+    └── PhysicalHashJoin { join_type: Inner, left_keys: [ #0 ], right_keys: [ #8 ] }
+        ├── PhysicalAgg
+        │   ├── aggrs:Agg(Max)
+        │   │   └── [ #0 ]
+        │   ├── groups: []
+        │   └── PhysicalProjection { exprs: [ #1 ] }
+        │       └── PhysicalAgg
+        │           ├── aggrs:Agg(Sum)
+        │           │   └── Mul
+        │           │       ├── #1
+        │           │       └── Sub
+        │           │           ├── 1(float)
+        │           │           └── #2
+        │           ├── groups: [ #0 ]
+        │           └── PhysicalProjection { exprs: [ #2, #5, #6 ] }
+        │               └── PhysicalFilter
+        │                   ├── cond:And
+        │                   │   ├── Geq
+        │                   │   │   ├── #10
+        │                   │   │   └── 8401(i64)
+        │                   │   └── Lt
+        │                   │       ├── #10
+        │                   │       └── 8491(i64)
+        │                   └── PhysicalScan { table: lineitem }
+        └── PhysicalHashJoin { join_type: Inner, left_keys: [ #0 ], right_keys: [ #0 ] }
+            ├── PhysicalScan { table: supplier }
+            └── PhysicalAgg
+                ├── aggrs:Agg(Sum)
+                │   └── Mul
+                │       ├── #1
+                │       └── Sub
+                │           ├── 1(float)
+                │           └── #2
+                ├── groups: [ #0 ]
+                └── PhysicalProjection { exprs: [ #2, #5, #6 ] }
+                    └── PhysicalFilter
+                        ├── cond:And
+                        │   ├── Geq
+                        │   │   ├── #10
+                        │   │   └── 8401(i64)
+                        │   └── Lt
+                        │       ├── #10
+                        │       └── 8491(i64)
+                        └── PhysicalScan { table: lineitem }
 */
 


### PR DESCRIPTION
* Re-infer properties each time before rule invoke
* Fix schema of depjoin
* Fix the position of the eliminate projection rule, in bottom-up, it should be applied before simplify expr

close https://github.com/cmu-db/optd/issues/197