### PR TITLE
refactor(core): rewrite memo table + enable filter-project rules in df-repr

### DIFF
--- a/optd-core/src/cascades/memo.rs
+++ b/optd-core/src/cascades/memo.rs
@@ -144,7 +144,7 @@ impl<T: RelNodeTyp> Memo<T> {
     }
 
     #[allow(dead_code)]
-    pub fn merge_group(&mut self, group_a: GroupId, group_b: GroupId) -> GroupId {
+    fn merge_group(&mut self, group_a: GroupId, group_b: GroupId) -> GroupId {
         use std::cmp::Ordering;
         let group_a = self.reduce_group(group_a);
         let group_b = self.reduce_group(group_b);
@@ -400,8 +400,8 @@ impl<T: RelNodeTyp> Memo<T> {
             .expect("expr not found in group mapping")
     }
 
-    /// Get the memoized representation of a node.
-    pub fn get_expr_memoed(&self, mut expr_id: ExprId) -> RelMemoNodeRef<T> {
+    /// Get the memoized representation of a node, only for debugging purpose
+    pub(crate) fn get_expr_memoed(&self, mut expr_id: ExprId) -> RelMemoNodeRef<T> {
         while let Some(new_expr_id) = self.dup_expr_mapping.get(&expr_id) {
             expr_id = *new_expr_id;
         }
@@ -411,20 +411,20 @@ impl<T: RelNodeTyp> Memo<T> {
             .clone()
     }
 
-    pub fn get_all_exprs_in_group(&self, group_id: GroupId) -> Vec<ExprId> {
+    pub(crate) fn get_all_exprs_in_group(&self, group_id: GroupId) -> Vec<ExprId> {
         let group = self.groups.get(&group_id).expect("group not found");
         let mut exprs = group.group_exprs.iter().copied().collect_vec();
         exprs.sort();
         exprs
     }
 
-    pub fn get_all_group_ids(&self) -> Vec<GroupId> {
+    pub(crate) fn get_all_group_ids(&self) -> Vec<GroupId> {
         let mut ids = self.groups.keys().copied().collect_vec();
         ids.sort();
         ids
     }
 
-    pub fn get_group_info(&self, group_id: GroupId) -> GroupInfo {
+    pub(crate) fn get_group_info(&self, group_id: GroupId) -> GroupInfo {
         let group_id = self.reduce_group(group_id);
         self.groups.get(&group_id).as_ref().unwrap().info.clone()
     }
@@ -520,5 +520,209 @@ impl<T: RelNodeTyp> Memo<T> {
     /// Return number of expressions in the memo table.
     pub fn compute_plan_space(&self) -> usize {
         self.expr_id_to_expr_node.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+    enum MemoTestRelTyp {
+        Group(GroupId),
+        List,
+        Join,
+        Project,
+        Scan,
+        Expr,
+    }
+
+    impl std::fmt::Display for MemoTestRelTyp {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Group(x) => write!(f, "{}", x),
+                other => write!(f, "{:?}", other),
+            }
+        }
+    }
+
+    impl RelNodeTyp for MemoTestRelTyp {
+        fn is_logical(&self) -> bool {
+            matches!(self, Self::Project | Self::Scan | Self::Join)
+        }
+
+        fn group_typ(group_id: GroupId) -> Self {
+            Self::Group(group_id)
+        }
+
+        fn list_typ() -> Self {
+            Self::List
+        }
+
+        fn extract_group(&self) -> Option<GroupId> {
+            if let Self::Group(group_id) = self {
+                Some(*group_id)
+            } else {
+                None
+            }
+        }
+    }
+
+    type MemoTestRelNode = RelNode<MemoTestRelTyp>;
+    type MemoTestRelNodeRef = RelNodeRef<MemoTestRelTyp>;
+
+    fn join(
+        left: impl Into<MemoTestRelNodeRef>,
+        right: impl Into<MemoTestRelNodeRef>,
+        cond: impl Into<MemoTestRelNodeRef>,
+    ) -> MemoTestRelNode {
+        RelNode {
+            typ: MemoTestRelTyp::Join,
+            children: vec![left.into(), right.into(), cond.into()],
+            data: None,
+        }
+    }
+
+    fn scan(table: &str) -> MemoTestRelNode {
+        RelNode {
+            typ: MemoTestRelTyp::Scan,
+            children: vec![],
+            data: Some(Value::String(table.to_string().into())),
+        }
+    }
+
+    fn project(
+        input: impl Into<MemoTestRelNodeRef>,
+        expr_list: impl Into<MemoTestRelNodeRef>,
+    ) -> MemoTestRelNode {
+        RelNode {
+            typ: MemoTestRelTyp::Project,
+            children: vec![input.into(), expr_list.into()],
+            data: None,
+        }
+    }
+
+    fn list(items: Vec<impl Into<MemoTestRelNodeRef>>) -> MemoTestRelNode {
+        RelNode {
+            typ: MemoTestRelTyp::List,
+            children: items.into_iter().map(|x| x.into()).collect(),
+            data: None,
+        }
+    }
+
+    fn expr(data: Value) -> MemoTestRelNode {
+        RelNode {
+            typ: MemoTestRelTyp::Expr,
+            children: vec![],
+            data: Some(data),
+        }
+    }
+
+    fn group(group_id: GroupId) -> MemoTestRelNode {
+        RelNode {
+            typ: MemoTestRelTyp::Group(group_id),
+            children: vec![],
+            data: None,
+        }
+    }
+
+    #[test]
+    fn group_merge_1() {
+        let mut memo = Memo::new(Arc::new([]));
+        let (group_id, _) =
+            memo.add_new_expr(join(scan("t1"), scan("t2"), expr(Value::Bool(true))).into());
+        memo.add_expr_to_group(
+            join(scan("t2"), scan("t1"), expr(Value::Bool(true))).into(),
+            group_id,
+        );
+        assert_eq!(memo.get_group(group_id).group_exprs.len(), 2);
+    }
+
+    #[test]
+    fn group_merge_2() {
+        let mut memo = Memo::new(Arc::new([]));
+        let (group_id_1, _) = memo.add_new_expr(
+            project(
+                join(scan("t1"), scan("t2"), expr(Value::Bool(true))),
+                list(vec![expr(Value::Int64(1))]),
+            )
+            .into(),
+        );
+        let (group_id_2, _) = memo.add_new_expr(
+            project(
+                join(scan("t1"), scan("t2"), expr(Value::Bool(true))),
+                list(vec![expr(Value::Int64(1))]),
+            )
+            .into(),
+        );
+        assert_eq!(group_id_1, group_id_2);
+    }
+
+    #[test]
+    fn group_merge_3() {
+        let mut memo = Memo::new(Arc::new([]));
+        let expr1 = Arc::new(project(scan("t1"), list(vec![expr(Value::Int64(1))])));
+        let expr2 = Arc::new(project(scan("t1-alias"), list(vec![expr(Value::Int64(1))])));
+        memo.add_new_expr(expr1.clone());
+        memo.add_new_expr(expr2.clone());
+        // merging two child groups causes parent to merge
+        let (group_id_expr, _) = memo.get_expr_info(scan("t1").into());
+        memo.add_expr_to_group(scan("t1-alias").into(), group_id_expr);
+        let (group_1, _) = memo.get_expr_info(expr1);
+        let (group_2, _) = memo.get_expr_info(expr2);
+        assert_eq!(group_1, group_2);
+    }
+
+    #[test]
+    fn group_merge_4() {
+        let mut memo = Memo::new(Arc::new([]));
+        let expr1 = Arc::new(project(
+            project(scan("t1"), list(vec![expr(Value::Int64(1))])),
+            list(vec![expr(Value::Int64(2))]),
+        ));
+        let expr2 = Arc::new(project(
+            project(scan("t1-alias"), list(vec![expr(Value::Int64(1))])),
+            list(vec![expr(Value::Int64(2))]),
+        ));
+        memo.add_new_expr(expr1.clone());
+        memo.add_new_expr(expr2.clone());
+        // merge two child groups, cascading merge
+        let (group_id_expr, _) = memo.get_expr_info(scan("t1").into());
+        memo.add_expr_to_group(scan("t1-alias").into(), group_id_expr);
+        let (group_1, _) = memo.get_expr_info(expr1.clone());
+        let (group_2, _) = memo.get_expr_info(expr2.clone());
+        assert_eq!(group_1, group_2);
+        let (group_1, _) = memo.get_expr_info(expr1.child(0));
+        let (group_2, _) = memo.get_expr_info(expr2.child(0));
+        assert_eq!(group_1, group_2);
+    }
+
+    #[test]
+    fn group_merge_5() {
+        let mut memo = Memo::new(Arc::new([]));
+        let expr1 = Arc::new(project(
+            project(scan("t1"), list(vec![expr(Value::Int64(1))])),
+            list(vec![expr(Value::Int64(2))]),
+        ));
+        let expr2 = Arc::new(project(
+            project(scan("t1-alias"), list(vec![expr(Value::Int64(1))])),
+            list(vec![expr(Value::Int64(2))]),
+        ));
+        let (_, expr1_id) = memo.add_new_expr(expr1.clone());
+        let (_, expr2_id) = memo.add_new_expr(expr2.clone());
+
+        // experimenting with group id in expr (i.e., when apply rules)
+        let (scan_t1, _) = memo.get_expr_info(scan("t1").into());
+        let (expr_middle_proj, _) = memo.get_expr_info(list(vec![expr(Value::Int64(1))]).into());
+        let proj_binding = project(group(scan_t1), group(expr_middle_proj));
+        let middle_proj_2 = memo.get_expr_memoed(expr2_id).children[0];
+
+        memo.add_expr_to_group(proj_binding.into(), middle_proj_2);
+
+        assert_eq!(
+            memo.get_expr_memoed(expr1_id),
+            memo.get_expr_memoed(expr2_id)
+        ); // these two expressions are merged
+        assert_eq!(memo.get_expr_info(expr1), memo.get_expr_info(expr2));
     }
 }

--- a/optd-core/src/cascades/memo.rs
+++ b/optd-core/src/cascades/memo.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::{hash_map::Entry, HashMap, HashSet},
-    fmt::Display,
     sync::Arc,
 };
 
@@ -58,29 +57,24 @@ pub(crate) struct Group {
     pub(crate) properties: Arc<[Box<dyn Any + Send + Sync + 'static>]>,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Default, Hash)]
-struct ReducedGroupId(usize);
-
-impl ReducedGroupId {
-    pub fn as_group_id(self) -> GroupId {
-        GroupId(self.0)
-    }
-}
-
-impl Display for ReducedGroupId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
 pub struct Memo<T: RelNodeTyp> {
-    expr_id_to_group_id: HashMap<ExprId, GroupId>,
+    // Source of truth.
+    groups: HashMap<GroupId, Group>,
     expr_id_to_expr_node: HashMap<ExprId, RelMemoNodeRef<T>>,
-    expr_node_to_expr_id: HashMap<RelMemoNode<T>, ExprId>,
-    groups: HashMap<ReducedGroupId, Group>,
+
+    // Internal states.
     group_expr_counter: usize,
-    merged_groups: HashMap<GroupId, GroupId>,
     property_builders: Arc<[Box<dyn PropertyBuilderAny<T>>]>,
+
+    // Indexes.
+    expr_node_to_expr_id: HashMap<RelMemoNode<T>, ExprId>,
+    expr_id_to_group_id: HashMap<ExprId, GroupId>,
+
+    // We update all group IDs in the memo table upon group merging, but
+    // there might be edge cases that some tasks still hold the old group ID.
+    // In this case, we need this mapping to redirect to the merged group ID.
+    merged_group_mapping: HashMap<GroupId, GroupId>,
+    dup_expr_mapping: HashMap<ExprId, ExprId>,
 }
 
 impl<T: RelNodeTyp> Memo<T> {
@@ -91,16 +85,17 @@ impl<T: RelNodeTyp> Memo<T> {
             expr_node_to_expr_id: HashMap::new(),
             groups: HashMap::new(),
             group_expr_counter: 0,
-            merged_groups: HashMap::new(),
+            merged_group_mapping: HashMap::new(),
             property_builders,
+            dup_expr_mapping: HashMap::new(),
         }
     }
 
     /// Get the next group id. Group id and expr id shares the same counter, so as to make it easier to debug...
-    fn next_group_id(&mut self) -> ReducedGroupId {
+    fn next_group_id(&mut self) -> GroupId {
         let id = self.group_expr_counter;
         self.group_expr_counter += 1;
-        ReducedGroupId(id)
+        GroupId(id)
     }
 
     /// Get the next expr id. Group id and expr id shares the same counter, so as to make it easier to debug...
@@ -110,68 +105,215 @@ impl<T: RelNodeTyp> Memo<T> {
         ExprId(id)
     }
 
-    fn merge_group_inner(
-        &mut self,
-        group_a: ReducedGroupId,
-        group_b: ReducedGroupId,
-    ) -> ReducedGroupId {
-        if group_a == group_b {
-            return group_a;
+    fn verify_integrity(&self) {
+        if cfg!(debug_assertions) {
+            let num_of_exprs = self.expr_id_to_expr_node.len();
+            assert_eq!(num_of_exprs, self.expr_node_to_expr_id.len());
+            assert_eq!(num_of_exprs, self.expr_id_to_group_id.len());
+
+            let mut valid_groups = HashSet::new();
+            for to in self.merged_group_mapping.values() {
+                assert_eq!(self.merged_group_mapping[to], *to);
+                valid_groups.insert(*to);
+            }
+            assert_eq!(valid_groups.len(), self.groups.len());
+
+            for (id, node) in self.expr_id_to_expr_node.iter() {
+                assert_eq!(self.expr_node_to_expr_id[node], *id);
+                for child in &node.children {
+                    assert!(
+                        valid_groups.contains(child),
+                        "invalid group used in expression {}, where {} does not exist any more",
+                        node,
+                        child
+                    );
+                }
+            }
+
+            let mut cnt = 0;
+            for (group_id, group) in &self.groups {
+                assert!(valid_groups.contains(group_id));
+                cnt += group.group_exprs.len();
+                assert!(!group.group_exprs.is_empty());
+                for expr in &group.group_exprs {
+                    assert_eq!(self.expr_id_to_group_id[expr], *group_id);
+                }
+            }
+            assert_eq!(cnt, num_of_exprs);
         }
-
-        // Copy all expressions from group a to group b
-        let group_a_exprs = self.get_all_exprs_in_group(group_a.as_group_id());
-        for expr_id in group_a_exprs {
-            let expr_node = self.expr_id_to_expr_node.get(&expr_id).unwrap();
-            self.add_expr_to_group(expr_id, group_b, expr_node.as_ref().clone());
-        }
-
-        self.merged_groups
-            .insert(group_a.as_group_id(), group_b.as_group_id());
-
-        // Remove all expressions from group a (so we don't accidentally access it)
-        self.clear_exprs_in_group(group_a);
-
-        group_b
     }
 
+    #[allow(dead_code)]
     pub fn merge_group(&mut self, group_a: GroupId, group_b: GroupId) -> GroupId {
-        let group_a_reduced = self.get_reduced_group_id(group_a);
-        let group_b_reduced = self.get_reduced_group_id(group_b);
-        self.merge_group_inner(group_a_reduced, group_b_reduced)
-            .as_group_id()
+        use std::cmp::Ordering;
+        let group_a = self.reduce_group(group_a);
+        let group_b = self.reduce_group(group_b);
+        let (merge_into, merge_from) = match group_a.0.cmp(&group_b.0) {
+            Ordering::Less => (group_a, group_b),
+            Ordering::Equal => return group_a,
+            Ordering::Greater => (group_b, group_a),
+        };
+        self.merge_group_inner(merge_into, merge_from);
+        self.verify_integrity();
+        merge_into
     }
 
-    fn get_group_id_of_expr_id(&self, expr_id: ExprId) -> GroupId {
-        self.expr_id_to_group_id[&expr_id]
+    /// Add an expression into the memo, returns the group id and the expr id.
+    pub fn add_new_expr(&mut self, rel_node: RelNodeRef<T>) -> (GroupId, ExprId) {
+        let (group_id, expr_id) = self
+            .add_new_group_expr_inner(rel_node, None)
+            .expect("should not trigger merge group");
+        self.verify_integrity();
+        (group_id, expr_id)
     }
 
-    fn get_reduced_group_id(&self, mut group_id: GroupId) -> ReducedGroupId {
-        while let Some(next_group_id) = self.merged_groups.get(&group_id) {
-            group_id = *next_group_id;
+    /// Add an expression into the memo, returns the expr id if rel_node is NOT a group.
+    pub fn add_expr_to_group(
+        &mut self,
+        rel_node: RelNodeRef<T>,
+        group_id: GroupId,
+    ) -> Option<ExprId> {
+        if let Some(input_group) = rel_node.typ.extract_group() {
+            let input_group = self.reduce_group(input_group);
+            let group_id = self.reduce_group(group_id);
+            self.merge_group_inner(input_group, group_id);
+            return None;
         }
-        ReducedGroupId(group_id.0)
+        let reduced_group_id = self.reduce_group(group_id);
+        let (returned_group_id, expr_id) = self
+            .add_new_group_expr_inner(rel_node, Some(reduced_group_id))
+            .unwrap();
+        assert_eq!(returned_group_id, reduced_group_id);
+        self.verify_integrity();
+        Some(expr_id)
     }
 
-    /// Add or get an expression into the memo, returns the group id and the expr id. If `GroupId` is `None`,
-    /// create a new group. Otherwise, add the expression to the group.
-    pub fn add_new_group_expr(
+    fn reduce_group(&self, group_id: GroupId) -> GroupId {
+        self.merged_group_mapping[&group_id]
+    }
+
+    fn merge_group_inner(&mut self, merge_into: GroupId, merge_from: GroupId) {
+        if merge_into == merge_from {
+            return;
+        }
+        trace!(event = "merge_group", merge_into = %merge_into, merge_from = %merge_from);
+        let group_merge_from = self.groups.remove(&merge_from).unwrap();
+        let group_merge_into = self.groups.get_mut(&merge_into).unwrap();
+        // TODO: update winner, cost and properties
+        for from_expr in group_merge_from.group_exprs {
+            let ret = self.expr_id_to_group_id.insert(from_expr, merge_into);
+            assert!(ret.is_some());
+            group_merge_into.group_exprs.insert(from_expr);
+        }
+        self.merged_group_mapping.insert(merge_from, merge_into);
+
+        // Update all indexes and other data structures
+        // 1. update merged group mapping -- could be optimized with union find
+        for (_, mapped_to) in self.merged_group_mapping.iter_mut() {
+            if *mapped_to == merge_from {
+                *mapped_to = merge_into;
+            }
+        }
+
+        let mut pending_recursive_merge = Vec::new();
+        // 2. update all group expressions and indexes
+        for (group_id, group) in self.groups.iter_mut() {
+            let mut new_expr_list = HashSet::new();
+            for expr_id in group.group_exprs.iter() {
+                let expr = self.expr_id_to_expr_node[expr_id].clone();
+                if expr.children.contains(&merge_from) {
+                    // Create the new expr node
+                    let old_expr = expr.as_ref().clone();
+                    let mut new_expr = expr.as_ref().clone();
+                    new_expr.children.iter_mut().for_each(|x| {
+                        if *x == merge_from {
+                            *x = merge_into;
+                        }
+                    });
+                    // Update all existing entries and indexes
+                    self.expr_id_to_expr_node
+                        .insert(*expr_id, Arc::new(new_expr.clone()));
+                    self.expr_node_to_expr_id.remove(&old_expr);
+                    if let Some(dup_expr) = self.expr_node_to_expr_id.get(&new_expr) {
+                        // If new_expr == some_other_old_expr in the memo table, unless they belong to the same group,
+                        // we should merge the two groups. This should not happen. We should simply drop this expression.
+                        let dup_group_id = self.expr_id_to_group_id[dup_expr];
+                        if dup_group_id != *group_id {
+                            pending_recursive_merge.push((dup_group_id, *group_id));
+                        }
+                        self.expr_id_to_expr_node.remove(expr_id);
+                        self.expr_id_to_group_id.remove(expr_id);
+                        self.dup_expr_mapping.insert(*expr_id, *dup_expr);
+                        new_expr_list.insert(*dup_expr); // adding this temporarily -- should be removed once recursive merge finishes
+                    } else {
+                        self.expr_node_to_expr_id.insert(new_expr, *expr_id);
+                        new_expr_list.insert(*expr_id);
+                    }
+                } else {
+                    new_expr_list.insert(*expr_id);
+                }
+            }
+            assert!(!new_expr_list.is_empty());
+            group.group_exprs = new_expr_list;
+        }
+        for (merge_from, merge_into) in pending_recursive_merge {
+            // We need to reduce because each merge would probably invalidate some groups in the last loop iteration.
+            let merge_from = self.reduce_group(merge_from);
+            let merge_into = self.reduce_group(merge_into);
+            self.merge_group_inner(merge_into, merge_from);
+        }
+    }
+
+    fn add_new_group_expr_inner(
         &mut self,
         rel_node: RelNodeRef<T>,
         add_to_group_id: Option<GroupId>,
-    ) -> (GroupId, ExprId) {
-        let node_current_group = rel_node.typ.extract_group();
-        if let (Some(grp_a), Some(grp_b)) = (add_to_group_id, node_current_group) {
-            self.merge_group(grp_a, grp_b);
+    ) -> anyhow::Result<(GroupId, ExprId)> {
+        assert!(rel_node.typ.extract_group().is_none());
+        let children_group_ids = rel_node
+            .children
+            .iter()
+            .map(|child| {
+                if let Some(group) = child.typ.extract_group() {
+                    self.reduce_group(group) // TODO: can I remove?
+                } else {
+                    // No merge / modification to the memo should occur for the following operation
+                    let (group, _) = self
+                        .add_new_group_expr_inner(child.clone(), None)
+                        .expect("should not trigger merge group");
+                    self.reduce_group(group) // TODO: can I remove?
+                }
+            })
+            .collect::<Vec<_>>();
+        let memo_node = RelMemoNode {
+            typ: rel_node.typ.clone(),
+            children: children_group_ids,
+            data: rel_node.data.clone(),
         };
-
-        let (group_id, expr_id) = self.add_new_group_expr_inner(
-            rel_node,
-            add_to_group_id.map(|x| self.get_reduced_group_id(x)),
-        );
-        (group_id.as_group_id(), expr_id)
+        if let Some(&expr_id) = self.expr_node_to_expr_id.get(&memo_node) {
+            let group_id = self.expr_id_to_group_id[&expr_id];
+            if let Some(add_to_group_id) = add_to_group_id {
+                let add_to_group_id = self.reduce_group(add_to_group_id);
+                self.merge_group_inner(add_to_group_id, group_id);
+                return Ok((add_to_group_id, expr_id));
+            }
+            return Ok((group_id, expr_id));
+        }
+        let expr_id = self.next_expr_id();
+        let group_id = if let Some(group_id) = add_to_group_id {
+            group_id
+        } else {
+            self.next_group_id()
+        };
+        self.expr_id_to_expr_node
+            .insert(expr_id, memo_node.clone().into());
+        self.expr_id_to_group_id.insert(expr_id, group_id);
+        self.expr_node_to_expr_id.insert(memo_node.clone(), expr_id);
+        self.append_expr_to_group(expr_id, group_id, memo_node);
+        Ok((group_id, expr_id))
     }
 
+    /// This is inefficient: usually the optimizer should have a MemoRef instead of passing the full rel node.
     pub fn get_expr_info(&self, rel_node: RelNodeRef<T>) -> (GroupId, ExprId) {
         let children_group_ids = rel_node
             .children
@@ -192,7 +334,7 @@ impl<T: RelNodeTyp> Memo<T> {
         let Some(&expr_id) = self.expr_node_to_expr_id.get(&memo_node) else {
             unreachable!("not found {}", memo_node)
         };
-        let group_id = self.get_group_id_of_expr_id(expr_id);
+        let group_id = self.expr_id_to_group_id[&expr_id];
         (group_id, expr_id)
     }
 
@@ -203,10 +345,7 @@ impl<T: RelNodeTyp> Memo<T> {
         let child_properties = memo_node
             .children
             .iter()
-            .map(|child| {
-                let group_id = self.get_reduced_group_id(*child);
-                self.groups[&group_id].properties.clone()
-            })
+            .map(|child| self.groups[child].properties.clone())
             .collect_vec();
         let mut props = Vec::with_capacity(self.property_builders.len());
         for (id, builder) in self.property_builders.iter().enumerate() {
@@ -224,16 +363,12 @@ impl<T: RelNodeTyp> Memo<T> {
         props
     }
 
-    fn clear_exprs_in_group(&mut self, group_id: ReducedGroupId) {
-        self.groups.remove(&group_id);
-    }
-
     /// If group_id exists, it adds expr_id to the existing group
     /// Otherwise, it creates a new group of that group_id and insert expr_id into the new group
-    fn add_expr_to_group(
+    fn append_expr_to_group(
         &mut self,
         expr_id: ExprId,
-        group_id: ReducedGroupId,
+        group_id: GroupId,
         memo_node: RelMemoNode<T>,
     ) {
         trace!(event = "add_expr_to_group", group_id = %group_id, expr_id = %expr_id, memo_node = %memo_node);
@@ -242,6 +377,7 @@ impl<T: RelNodeTyp> Memo<T> {
             group.group_exprs.insert(expr_id);
             return;
         }
+        // Create group and infer properties (only upon initializing a group).
         let mut group = Group {
             group_exprs: HashSet::new(),
             info: GroupInfo::default(),
@@ -249,216 +385,33 @@ impl<T: RelNodeTyp> Memo<T> {
         };
         group.group_exprs.insert(expr_id);
         self.groups.insert(group_id, group);
-    }
-
-    // return true: replace success, the expr_id is replaced by the new rel_node
-    // return false: replace failed as the new rel node already exists in other groups,
-    //             the old expr_id should be marked as all rules are fired for it
-    #[allow(dead_code)]
-    pub fn replace_group_expr(
-        &mut self,
-        expr_id: ExprId,
-        replace_group_id: GroupId,
-        rel_node: RelNodeRef<T>,
-    ) -> bool {
-        let replace_group_id = self.get_reduced_group_id(replace_group_id);
-
-        if let Entry::Occupied(mut entry) = self.groups.entry(replace_group_id) {
-            let group = entry.get_mut();
-            if !group.group_exprs.contains(&expr_id) {
-                unreachable!("expr not found in group in replace_group_expr");
-            }
-
-            let children_group_ids = rel_node
-                .children
-                .iter()
-                .map(|child| {
-                    if let Some(group) = child.typ.extract_group() {
-                        group
-                    } else {
-                        self.add_new_group_expr(child.clone(), None).0
-                    }
-                })
-                .collect::<Vec<_>>();
-
-            let memo_node = RelMemoNode {
-                typ: rel_node.typ.clone(),
-                children: children_group_ids,
-                data: rel_node.data.clone(),
-            };
-
-            // if the new expr already in the memo table, merge the group and remove old expr
-            if let Some(&new_expr_id) = self.expr_node_to_expr_id.get(&memo_node) {
-                if new_expr_id == expr_id {
-                    // This is not acceptable, as it means the expr returned by a heuristic rule is exactly
-                    // the same as the original expr, which should not happen
-                    // TODO: we can silently ignore this case without marking the original one as a deadend
-                    // But the rule creators should follow the definition of the heuristic rule
-                    // and return an empty vec if their rule does not do the real transformation
-                    unreachable!("replace_group_expr: you're replacing the old expr with the same expr, please check your rules registered as heuristic
-                        and make sure if it does not do any transformation, it should return an empty vec!");
-                }
-                let group_id = self.get_group_id_of_expr_id(new_expr_id);
-                let group_id = self.get_reduced_group_id(group_id);
-
-                self.merge_group_inner(replace_group_id, group_id);
-                return false;
-            }
-
-            self.expr_id_to_expr_node
-                .insert(expr_id, memo_node.clone().into());
-            self.expr_node_to_expr_id.insert(memo_node.clone(), expr_id);
-
-            return true;
-        }
-        unreachable!("group not found in replace_group_expr");
-    }
-
-    fn add_new_group_expr_inner(
-        &mut self,
-        rel_node: RelNodeRef<T>,
-        add_to_group_id: Option<ReducedGroupId>,
-    ) -> (ReducedGroupId, ExprId) {
-        let children_group_ids = rel_node
-            .children
-            .iter()
-            .map(|child| {
-                if let Some(group) = child.typ.extract_group() {
-                    group
-                } else {
-                    self.add_new_group_expr(child.clone(), None).0
-                }
-            })
-            .collect::<Vec<_>>();
-        let memo_node = RelMemoNode {
-            typ: rel_node.typ.clone(),
-            children: children_group_ids,
-            data: rel_node.data.clone(),
-        };
-        if let Some(&expr_id) = self.expr_node_to_expr_id.get(&memo_node) {
-            let group_id = self.get_group_id_of_expr_id(expr_id);
-            let group_id = self.get_reduced_group_id(group_id);
-            if let Some(add_to_group_id) = add_to_group_id {
-                self.merge_group_inner(add_to_group_id, group_id);
-            }
-            return (group_id, expr_id);
-        }
-        let expr_id = self.next_expr_id();
-        let group_id = if let Some(group_id) = add_to_group_id {
-            group_id
-        } else {
-            self.next_group_id()
-        };
-        self.expr_id_to_expr_node
-            .insert(expr_id, memo_node.clone().into());
-        self.expr_id_to_group_id
-            .insert(expr_id, group_id.as_group_id());
-        self.expr_node_to_expr_id.insert(memo_node.clone(), expr_id);
-        self.add_expr_to_group(expr_id, group_id, memo_node);
-        (group_id, expr_id)
+        self.merged_group_mapping.insert(group_id, group_id);
     }
 
     /// Get the group id of an expression.
     /// The group id is volatile, depending on whether the groups are merged.
-    pub fn get_group_id(&self, expr_id: ExprId) -> GroupId {
-        let group_id = self
+    pub fn get_group_id(&self, mut expr_id: ExprId) -> GroupId {
+        while let Some(new_expr_id) = self.dup_expr_mapping.get(&expr_id) {
+            expr_id = *new_expr_id;
+        }
+        *self
             .expr_id_to_group_id
             .get(&expr_id)
-            .expect("expr not found in group mapping");
-        self.get_reduced_group_id(*group_id).as_group_id()
+            .expect("expr not found in group mapping")
     }
 
     /// Get the memoized representation of a node.
-    pub fn get_expr_memoed(&self, expr_id: ExprId) -> RelMemoNodeRef<T> {
+    pub fn get_expr_memoed(&self, mut expr_id: ExprId) -> RelMemoNodeRef<T> {
+        while let Some(new_expr_id) = self.dup_expr_mapping.get(&expr_id) {
+            expr_id = *new_expr_id;
+        }
         self.expr_id_to_expr_node
             .get(&expr_id)
             .expect("expr not found in expr mapping")
             .clone()
     }
 
-    /// Get all bindings of a group.
-    /// TODO: this is not efficient. Should decide whether to expand the rule based on the matcher.
-    pub fn get_all_group_bindings(
-        &self,
-        group_id: GroupId,
-        physical_only: bool,
-        exclude_placeholder: bool,
-        level: Option<usize>,
-    ) -> Vec<RelNodeRef<T>> {
-        let group_id = self.get_reduced_group_id(group_id);
-        let group = self.groups.get(&group_id).expect("group not found");
-        group
-            .group_exprs
-            .iter()
-            .filter(|x| !physical_only || !self.get_expr_memoed(**x).typ.is_logical())
-            .map(|&expr_id| {
-                self.get_all_expr_bindings(expr_id, physical_only, exclude_placeholder, level)
-            })
-            .concat()
-    }
-
-    /// Get all bindings of an expression.
-    /// TODO: this is not efficient. Should decide whether to expand the rule based on the matcher.
-    pub fn get_all_expr_bindings(
-        &self,
-        expr_id: ExprId,
-        physical_only: bool,
-        exclude_placeholder: bool,
-        level: Option<usize>,
-    ) -> Vec<RelNodeRef<T>> {
-        let expr = self.get_expr_memoed(expr_id);
-        if let Some(level) = level {
-            if level == 0 {
-                if exclude_placeholder {
-                    return vec![];
-                } else {
-                    let node = Arc::new(RelNode {
-                        typ: expr.typ.clone(),
-                        children: expr
-                            .children
-                            .iter()
-                            .map(|x| Arc::new(RelNode::new_group(*x)))
-                            .collect_vec(),
-                        data: expr.data.clone(),
-                    });
-                    return vec![node];
-                }
-            }
-        }
-        let mut children = vec![];
-        let mut cumulative = 1;
-        for child in &expr.children {
-            let group_exprs = self.get_all_group_bindings(
-                *child,
-                physical_only,
-                exclude_placeholder,
-                level.map(|x| x - 1),
-            );
-            cumulative *= group_exprs.len();
-            children.push(group_exprs);
-        }
-        let mut result = vec![];
-        for i in 0..cumulative {
-            let mut selected_nodes = vec![];
-            let mut ii = i;
-            for child in children.iter().rev() {
-                let idx = ii % child.len();
-                ii /= child.len();
-                selected_nodes.push(child[idx].clone());
-            }
-            selected_nodes.reverse();
-            let node = Arc::new(RelNode {
-                typ: expr.typ.clone(),
-                children: selected_nodes,
-                data: expr.data.clone(),
-            });
-            result.push(node);
-        }
-        result
-    }
-
     pub fn get_all_exprs_in_group(&self, group_id: GroupId) -> Vec<ExprId> {
-        let group_id = self.get_reduced_group_id(group_id);
         let group = self.groups.get(&group_id).expect("group not found");
         let mut exprs = group.group_exprs.iter().copied().collect_vec();
         exprs.sort();
@@ -466,30 +419,19 @@ impl<T: RelNodeTyp> Memo<T> {
     }
 
     pub fn get_all_group_ids(&self) -> Vec<GroupId> {
-        let mut ids = self
-            .groups
-            .keys()
-            .copied()
-            .map(|x| x.as_group_id())
-            .collect_vec();
+        let mut ids = self.groups.keys().copied().collect_vec();
         ids.sort();
         ids
     }
 
     pub fn get_group_info(&self, group_id: GroupId) -> GroupInfo {
-        self.groups
-            .get(&self.get_reduced_group_id(group_id))
-            .as_ref()
-            .unwrap()
-            .info
-            .clone()
+        let group_id = self.reduce_group(group_id);
+        self.groups.get(&group_id).as_ref().unwrap().info.clone()
     }
 
     pub(crate) fn get_group(&self, group_id: GroupId) -> &Group {
-        self.groups
-            .get(&self.get_reduced_group_id(group_id))
-            .as_ref()
-            .unwrap()
+        let group_id = self.reduce_group(group_id);
+        self.groups.get(&group_id).as_ref().unwrap()
     }
 
     pub fn update_group_info(&mut self, group_id: GroupId, group_info: GroupInfo) {
@@ -498,12 +440,43 @@ impl<T: RelNodeTyp> Memo<T> {
                 assert!(
                     winner.cost.0[0] != 0.0,
                     "{}",
-                    self.get_expr_memoed(winner.expr_id)
+                    self.expr_id_to_expr_node[&winner.expr_id]
                 );
             }
         }
-        let grp = self.groups.get_mut(&self.get_reduced_group_id(group_id));
+        let grp = self.groups.get_mut(&group_id);
         grp.unwrap().info = group_info;
+    }
+
+    /// Get all bindings of a predicate group. Will panic if the group contains more than one bindings.
+    pub fn get_predicate_binding(&self, group_id: GroupId) -> Option<RelNodeRef<T>> {
+        self.get_predicate_binding_group_inner(group_id)
+    }
+
+    fn get_predicate_binding_expr_inner(&self, expr_id: ExprId) -> Option<RelNodeRef<T>> {
+        let expr = self.expr_id_to_expr_node[&expr_id].clone();
+        let mut children = Vec::with_capacity(expr.children.len());
+        for child in expr.children.iter() {
+            if let Some(child) = self.get_predicate_binding_group_inner(*child) {
+                children.push(child);
+            } else {
+                return None;
+            }
+        }
+        Some(Arc::new(RelNode {
+            typ: expr.typ.clone(),
+            data: expr.data.clone(),
+            children,
+        }))
+    }
+
+    fn get_predicate_binding_group_inner(&self, group_id: GroupId) -> Option<RelNodeRef<T>> {
+        let exprs = &self.groups[&group_id].group_exprs;
+        match exprs.len() {
+            0 => None,
+            1 => self.get_predicate_binding_expr_inner(*exprs.iter().next().unwrap()),
+            len => panic!("group {group_id} has {len} expressions"),
+        }
     }
 
     pub fn get_best_group_binding(
@@ -515,7 +488,7 @@ impl<T: RelNodeTyp> Memo<T> {
         if let Some(winner) = info.winner {
             if !winner.impossible {
                 let expr_id = winner.expr_id;
-                let expr = self.get_expr_memoed(expr_id);
+                let expr = self.expr_id_to_expr_node[&expr_id].clone();
                 let mut children = Vec::with_capacity(expr.children.len());
                 for child in &expr.children {
                     children.push(self.get_best_group_binding(*child, meta)?);

--- a/optd-core/src/cascades/optimizer.rs
+++ b/optd-core/src/cascades/optimizer.rs
@@ -32,7 +32,7 @@ pub struct OptimizerContext {
 
 #[derive(Default, Clone, Debug)]
 pub struct OptimizerProperties {
-    pub partial_explore_temporarily_disabled: bool,
+    pub panic_on_budget: bool,
     /// If the number of rules applied exceeds this number, we stop applying logical rules.
     pub partial_explore_iter: Option<usize>,
     /// Plan space can be expanded by this number of times before we stop applying logical rules.
@@ -88,12 +88,8 @@ impl<T: RelNodeTyp> CascadesOptimizer<T> {
         Self::new_with_prop(rules, cost, property_builders, Default::default())
     }
 
-    pub fn disable_explore_limit(&mut self) {
-        self.prop.partial_explore_temporarily_disabled = true;
-    }
-
-    pub fn enable_explore_limit(&mut self) {
-        self.prop.partial_explore_temporarily_disabled = false;
+    pub fn panic_on_explore_limit(&mut self, enabled: bool) {
+        self.prop.panic_on_budget = enabled;
     }
 
     pub fn new_with_prop(
@@ -241,7 +237,7 @@ impl<T: RelNodeTyp> CascadesOptimizer<T> {
             let new_tasks = task.execute(self)?;
             self.tasks.extend(new_tasks);
             iter += 1;
-            if !self.ctx.budget_used && !self.prop.partial_explore_temporarily_disabled {
+            if !self.ctx.budget_used {
                 let plan_space = self.memo.compute_plan_space();
                 if let Some(partial_explore_space) = self.prop.partial_explore_space {
                     if plan_space - plan_space_begin > partial_explore_space {
@@ -250,6 +246,9 @@ impl<T: RelNodeTyp> CascadesOptimizer<T> {
                             plan_space
                         );
                         self.ctx.budget_used = true;
+                        if self.prop.panic_on_budget {
+                            panic!("plan space size budget used");
+                        }
                     }
                 } else if let Some(partial_explore_iter) = self.prop.partial_explore_iter {
                     if iter >= partial_explore_iter {
@@ -258,6 +257,9 @@ impl<T: RelNodeTyp> CascadesOptimizer<T> {
                             plan_space
                         );
                         self.ctx.budget_used = true;
+                        if self.prop.panic_on_budget {
+                            panic!("plan space size budget used");
+                        }
                     }
                 }
             }

--- a/optd-core/src/cascades/optimizer.rs
+++ b/optd-core/src/cascades/optimizer.rs
@@ -190,12 +190,13 @@ impl<T: RelNodeTyp> CascadesOptimizer<T> {
             for expr_id in self.memo.get_all_exprs_in_group(group_id) {
                 let memo_node = self.memo.get_expr_memoed(expr_id);
                 println!("  expr_id={} | {}", expr_id, memo_node);
-                let bindings = self
-                    .memo
-                    .get_all_expr_bindings(expr_id, false, true, Some(1));
-                for binding in bindings {
-                    println!("    {}", binding);
-                }
+                // We removed get all bindings functionality
+                // let bindings = self
+                //     .memo
+                //     .get_all_expr_bindings(expr_id, false, true, Some(1));
+                // for binding in bindings {
+                //     println!("    {}", binding);
+                // }
             }
         }
     }
@@ -214,7 +215,7 @@ impl<T: RelNodeTyp> CascadesOptimizer<T> {
 
     /// Optimize a `RelNode`.
     pub fn step_optimize_rel(&mut self, root_rel: RelNodeRef<T>) -> Result<GroupId> {
-        let (group_id, _) = self.add_group_expr(root_rel, None);
+        let (group_id, _) = self.add_new_expr(root_rel);
         self.fire_optimize_tasks(group_id)?;
         Ok(group_id)
     }
@@ -261,11 +262,14 @@ impl<T: RelNodeTyp> CascadesOptimizer<T> {
                 }
             }
         }
+        // if self.ctx.budget_used {
+        //     self.dump(None);
+        // }
         Ok(())
     }
 
     fn optimize_inner(&mut self, root_rel: RelNodeRef<T>) -> Result<RelNodeRef<T>> {
-        let (group_id, _) = self.add_group_expr(root_rel, None);
+        let (group_id, _) = self.add_new_expr(root_rel);
         self.fire_optimize_tasks(group_id)?;
         self.memo.get_best_group_binding(group_id, &mut None)
     }
@@ -286,37 +290,16 @@ impl<T: RelNodeTyp> CascadesOptimizer<T> {
         self.memo.get_expr_info(expr)
     }
 
-    pub(super) fn add_group_expr(
-        &mut self,
-        expr: RelNodeRef<T>,
-        group_id: Option<GroupId>,
-    ) -> (GroupId, ExprId) {
-        self.memo.add_new_group_expr(expr, group_id)
+    pub fn add_new_expr(&mut self, rel_node: RelNodeRef<T>) -> (GroupId, ExprId) {
+        self.memo.add_new_expr(rel_node)
     }
 
-    #[allow(dead_code)]
-    pub(super) fn replace_group_expr(
+    pub fn add_expr_to_group(
         &mut self,
-        expr: RelNodeRef<T>,
+        rel_node: RelNodeRef<T>,
         group_id: GroupId,
-        expr_id: ExprId,
-    ) {
-        let replaced = self.memo.replace_group_expr(expr_id, group_id, expr);
-        if replaced {
-            // the old expr is replaced, so we clear the fired rules for old expr
-            self.fired_rules.entry(expr_id).or_default().clear();
-            return;
-        }
-
-        // We can mark the expr as a deadend
-        // However, even some of the exprs cannot be the winner for the group
-        // We still need the physical form of those expr to start the optimizeInput task
-        // So we don't mark the impl rules as fired
-        for i in 0..self.rules.len() {
-            if !self.rules[i].rule().is_impl_rule() {
-                self.fired_rules.entry(expr_id).or_default().insert(i);
-            }
-        }
+    ) -> Option<ExprId> {
+        self.memo.add_expr_to_group(rel_node, group_id)
     }
 
     pub(super) fn get_group_info(&self, group_id: GroupId) -> GroupInfo {
@@ -325,10 +308,6 @@ impl<T: RelNodeTyp> CascadesOptimizer<T> {
 
     pub(super) fn update_group_info(&mut self, group_id: GroupId, group_info: GroupInfo) {
         self.memo.update_group_info(group_id, group_info)
-    }
-
-    pub(super) fn merge_group(&mut self, group_a: GroupId, group_b: GroupId) {
-        self.memo.merge_group(group_a, group_b);
     }
 
     /// Get the properties of a Cascades group
@@ -354,22 +333,8 @@ impl<T: RelNodeTyp> CascadesOptimizer<T> {
         self.memo.get_expr_memoed(expr_id)
     }
 
-    pub(super) fn get_all_expr_bindings(
-        &self,
-        expr_id: ExprId,
-        level: Option<usize>,
-    ) -> Vec<RelNodeRef<T>> {
-        self.memo
-            .get_all_expr_bindings(expr_id, false, false, level)
-    }
-
-    pub fn get_all_group_bindings(
-        &self,
-        group_id: GroupId,
-        physical_only: bool,
-    ) -> Vec<RelNodeRef<T>> {
-        self.memo
-            .get_all_group_bindings(group_id, physical_only, true, Some(10))
+    pub fn get_predicate_binding(&self, group_id: GroupId) -> Option<RelNodeRef<T>> {
+        self.memo.get_predicate_binding(group_id)
     }
 
     pub(super) fn is_group_explored(&self, group_id: GroupId) -> bool {

--- a/optd-datafusion-repr/src/cost/base_cost/agg.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/agg.rs
@@ -1,9 +1,6 @@
-use std::sync::Arc;
-
 use optd_core::{
     cascades::{CascadesOptimizer, RelNodeContext},
     cost::Cost,
-    rel_node::RelNode,
 };
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -48,13 +45,9 @@ impl<
     ) -> f64 {
         if let (Some(context), Some(optimizer)) = (context, optimizer) {
             let group_by_id = context.children_group_ids[2];
-            let mut group_by_exprs: Vec<Arc<RelNode<OptRelNodeTyp>>> =
-                optimizer.get_all_group_bindings(group_by_id, false);
-            assert!(
-                group_by_exprs.len() == 1,
-                "ExprList expression should be the only expression in the GROUP BY group"
-            );
-            let group_by = group_by_exprs.pop().unwrap();
+            let group_by = optimizer
+                .get_predicate_binding(group_by_id)
+                .expect("no expression found?");
             let group_by = ExprList::from_rel_node(group_by).unwrap();
             if group_by.is_empty() {
                 1.0

--- a/optd-datafusion-repr/src/cost/base_cost/filter.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/filter.rs
@@ -51,11 +51,10 @@ impl<
                 optimizer.get_property_by_group::<ColumnRefPropertyBuilder>(context.group_id, 1);
             let column_refs = column_refs.base_table_column_refs();
             let expr_group_id = context.children_group_ids[1];
-            let expr_trees = optimizer.get_all_group_bindings(expr_group_id, false);
-            // there may be more than one expression tree in a group (you can see this trivially as you can just swap the order of two subtrees for commutative operators)
-            // however, we just take an arbitrary expression tree from the group to compute selectivity
-            let expr_tree = expr_trees.first().expect("expression missing");
-            self.get_filter_selectivity(expr_tree.clone(), &schema, column_refs)
+            let expr_tree = optimizer
+                .get_predicate_binding(expr_group_id)
+                .expect("no expression??");
+            self.get_filter_selectivity(expr_tree, &schema, column_refs)
         } else {
             DEFAULT_UNK_SEL
         };

--- a/optd-datafusion-repr/src/cost/base_cost/limit.rs
+++ b/optd-datafusion-repr/src/cost/base_cost/limit.rs
@@ -23,13 +23,9 @@ impl<
     ) -> Cost {
         let (row_cnt, compute_cost, _) = Self::cost_tuple(&children[0]);
         let row_cnt = if let (Some(context), Some(optimizer)) = (context, optimizer) {
-            let mut fetch_expr =
-                optimizer.get_all_group_bindings(context.children_group_ids[2], false);
-            assert!(
-                fetch_expr.len() == 1,
-                "fetch expression should be the only expr in the group"
-            );
-            let fetch_expr = fetch_expr.pop().unwrap();
+            let fetch_expr = optimizer
+                .get_predicate_binding(context.children_group_ids[2])
+                .expect("no expression found?");
             assert!(
                 matches!(
                     fetch_expr.typ,

--- a/optd-datafusion-repr/src/lib.rs
+++ b/optd-datafusion-repr/src/lib.rs
@@ -26,8 +26,8 @@ use rules::{
     EliminateJoinRule, EliminateLimitRule, EliminateProjectRule, FilterAggTransposeRule,
     FilterCrossJoinTransposeRule, FilterInnerJoinTransposeRule, FilterMergeRule,
     FilterProjectTransposeRule, FilterSortTransposeRule, HashJoinRule, JoinAssocRule,
-    JoinCommuteRule, PhysicalConversionRule, ProjectMergeRule, ProjectionPullUpJoin,
-    SimplifyFilterRule, SimplifyJoinCondRule,
+    JoinCommuteRule, PhysicalConversionRule, ProjectFilterTransposeRule, ProjectMergeRule,
+    ProjectionPullUpJoin, SimplifyFilterRule, SimplifyJoinCondRule,
 };
 
 pub use optd_core::rel_node::Value;
@@ -111,11 +111,6 @@ impl DatafusionOptimizer {
         for rule in rules {
             rule_wrappers.push(RuleWrapper::new_cascades(rule));
         }
-        // project transpose rules
-        // only do filter-project one way for now to reduce search space
-        // rule_wrappers.push(RuleWrapper::new_cascades(Arc::new(
-        //     ProjectFilterTransposeRule::new(),
-        // )));
         // add all filter pushdown rules as heuristic rules
         rule_wrappers.push(RuleWrapper::new_cascades(Arc::new(
             FilterProjectTransposeRule::new(),
@@ -145,6 +140,9 @@ impl DatafusionOptimizer {
         rule_wrappers.push(RuleWrapper::new_cascades(Arc::new(
             EliminateFilterRule::new(),
         )));
+        rule_wrappers.push(RuleWrapper::new_cascades(Arc::new(
+            ProjectFilterTransposeRule::new(),
+        )));
         rule_wrappers
     }
 
@@ -171,7 +169,7 @@ impl DatafusionOptimizer {
                     Box::new(ColumnRefPropertyBuilder::new(catalog.clone())),
                 ],
                 OptimizerProperties {
-                    partial_explore_temporarily_disabled: false,
+                    panic_on_budget: false,
                     partial_explore_iter: Some(1 << 20),
                     partial_explore_space: Some(1 << 10),
                 },

--- a/optd-sqlplannertest/src/lib.rs
+++ b/optd-sqlplannertest/src/lib.rs
@@ -96,10 +96,10 @@ impl DatafusionDBMS {
                 .lock()
                 .unwrap();
             let optimizer = guard.as_mut().unwrap().optd_optimizer_mut();
-            if flags.disable_explore_limit {
-                optimizer.disable_explore_limit();
+            if flags.panic_on_budget {
+                optimizer.panic_on_explore_limit(true);
             } else {
-                optimizer.enable_explore_limit();
+                optimizer.panic_on_explore_limit(false);
             }
             let rules = optimizer.rules();
             if flags.enable_logical_rules.is_empty() {
@@ -316,7 +316,7 @@ struct TestFlags {
     verbose: bool,
     enable_df_logical: bool,
     enable_logical_rules: Vec<String>,
-    disable_explore_limit: bool,
+    panic_on_budget: bool,
 }
 
 /// Extract the flags from a task. The flags are specified in square brackets.
@@ -342,8 +342,8 @@ fn extract_flags(task: &str) -> Result<TestFlags> {
                 } else {
                     bail!("Failed to parse logical_rules flag: {}", flag);
                 }
-            } else if flag == "disable_explore_limit" {
-                options.disable_explore_limit = true;
+            } else if flag == "panic_on_budget" {
+                options.panic_on_budget = true;
             } else {
                 bail!("Unknown flag: {}", flag);
             }

--- a/optd-sqlplannertest/tests/pushdowns/fliter_transpose.planner.sql
+++ b/optd-sqlplannertest/tests/pushdowns/fliter_transpose.planner.sql
@@ -15,7 +15,70 @@ SELECT t1.t1v1, t1.t1v2, t2.t2v3
   WHERE t1.t1v1 = t2.t2v1;
 
 /*
-Error
-Unknown logical rule: {"project_filter_transpose_rule"}
+LogicalProjection { exprs: [ #0, #1, #3 ] }
+└── LogicalFilter
+    ├── cond:Eq
+    │   ├── #0
+    │   └── #2
+    └── LogicalJoin { join_type: Cross, cond: true }
+        ├── LogicalScan { table: t1 }
+        └── LogicalScan { table: t2 }
+PhysicalProjection { exprs: [ #0, #1, #3 ] }
+└── PhysicalFilter
+    ├── cond:Eq
+    │   ├── #0
+    │   └── #2
+    └── PhysicalNestedLoopJoin { join_type: Cross, cond: true }
+        ├── PhysicalScan { table: t1 }
+        └── PhysicalScan { table: t2 }
+*/
+
+-- Test whether we can transpose filter and projection
+SELECT t1.t1v1, t1.t1v2, t2.t2v3
+  FROM t1, t2
+  WHERE t1.t1v1 = t2.t2v3;
+
+/*
+LogicalProjection { exprs: [ #0, #1, #3 ] }
+└── LogicalFilter
+    ├── cond:Eq
+    │   ├── #0
+    │   └── #3
+    └── LogicalJoin { join_type: Cross, cond: true }
+        ├── LogicalScan { table: t1 }
+        └── LogicalScan { table: t2 }
+PhysicalFilter
+├── cond:Eq
+│   ├── #0
+│   └── #2
+└── PhysicalProjection { exprs: [ #0, #1, #3 ] }
+    └── PhysicalNestedLoopJoin { join_type: Cross, cond: true }
+        ├── PhysicalScan { table: t1 }
+        └── PhysicalScan { table: t2 }
+*/
+
+-- Test whether we can transpose filter and projection
+SELECT * FROM (
+  SELECT t1.t1v1, t1.t1v2, t2.t2v3 FROM t1, t2
+) WHERE t1.t1v1 = t2.t2v3;
+
+/*
+LogicalProjection { exprs: [ #0, #1, #2 ] }
+└── LogicalFilter
+    ├── cond:Eq
+    │   ├── #0
+    │   └── #2
+    └── LogicalProjection { exprs: [ #0, #1, #3 ] }
+        └── LogicalJoin { join_type: Cross, cond: true }
+            ├── LogicalScan { table: t1 }
+            └── LogicalScan { table: t2 }
+PhysicalFilter
+├── cond:Eq
+│   ├── #0
+│   └── #2
+└── PhysicalProjection { exprs: [ #0, #1, #3 ] }
+    └── PhysicalNestedLoopJoin { join_type: Cross, cond: true }
+        ├── PhysicalScan { table: t1 }
+        └── PhysicalScan { table: t2 }
 */
 

--- a/optd-sqlplannertest/tests/pushdowns/fliter_transpose.yml
+++ b/optd-sqlplannertest/tests/pushdowns/fliter_transpose.yml
@@ -11,4 +11,18 @@
       WHERE t1.t1v1 = t2.t2v1;
   desc: Test whether we can transpose filter and projection
   tasks:
-    - explain[logical_rules:filter_project_transpose_rule+project_filter_transpose_rule]:logical_optd,physical_optd
+    - explain[logical_rules:filter_project_transpose_rule+project_filter_transpose_rule+project_merge_rule,panic_on_budget]:logical_optd,physical_optd
+- sql: |
+    SELECT t1.t1v1, t1.t1v2, t2.t2v3
+      FROM t1, t2
+      WHERE t1.t1v1 = t2.t2v3;
+  desc: Test whether we can transpose filter and projection
+  tasks:
+    - explain[logical_rules:filter_project_transpose_rule+project_filter_transpose_rule+project_merge_rule,panic_on_budget]:logical_optd,physical_optd
+- sql: |
+    SELECT * FROM (
+      SELECT t1.t1v1, t1.t1v2, t2.t2v3 FROM t1, t2
+    ) WHERE t1.t1v1 = t2.t2v3;
+  desc: Test whether we can transpose filter and projection
+  tasks:
+    - explain[logical_rules:filter_project_transpose_rule+project_filter_transpose_rule+project_merge_rule,panic_on_budget]:logical_optd,physical_optd

--- a/optd-sqlplannertest/tests/tpch/tpch-06-10.planner.sql
+++ b/optd-sqlplannertest/tests/tpch/tpch-06-10.planner.sql
@@ -298,12 +298,12 @@ PhysicalSort
             ├── PhysicalHashJoin { join_type: Inner, left_keys: [ #3 ], right_keys: [ #0 ] }
             │   ├── PhysicalHashJoin { join_type: Inner, left_keys: [ #0 ], right_keys: [ #2 ] }
             │   │   ├── PhysicalScan { table: supplier }
-            │   │   └── PhysicalHashJoin { join_type: Inner, left_keys: [ #17 ], right_keys: [ #0 ] }
-            │   │       ├── PhysicalHashJoin { join_type: Inner, left_keys: [ #0 ], right_keys: [ #0 ] }
-            │   │       │   ├── PhysicalFilter { cond: Between { expr: #10, lower: Cast { cast_to: Date32, expr: "1995-01-01" }, upper: Cast { cast_to: Date32, expr: "1996-12-31" } } }
-            │   │       │   │   └── PhysicalScan { table: lineitem }
-            │   │       │   └── PhysicalScan { table: orders }
-            │   │       └── PhysicalScan { table: customer }
+            │   │   └── PhysicalHashJoin { join_type: Inner, left_keys: [ #0 ], right_keys: [ #0 ] }
+            │   │       ├── PhysicalFilter { cond: Between { expr: #10, lower: Cast { cast_to: Date32, expr: "1995-01-01" }, upper: Cast { cast_to: Date32, expr: "1996-12-31" } } }
+            │   │       │   └── PhysicalScan { table: lineitem }
+            │   │       └── PhysicalHashJoin { join_type: Inner, left_keys: [ #1 ], right_keys: [ #0 ] }
+            │   │           ├── PhysicalScan { table: orders }
+            │   │           └── PhysicalScan { table: customer }
             │   └── PhysicalScan { table: nation }
             └── PhysicalScan { table: nation }
 */
@@ -468,12 +468,12 @@ PhysicalSort
                 │   │   │   │   └── PhysicalScan { table: part }
                 │   │   │   └── PhysicalScan { table: supplier }
                 │   │   └── PhysicalHashJoin { join_type: Inner, left_keys: [ #28 ], right_keys: [ #0 ] }
-                │   │       ├── PhysicalHashJoin { join_type: Inner, left_keys: [ #17 ], right_keys: [ #0 ] }
-                │   │       │   ├── PhysicalHashJoin { join_type: Inner, left_keys: [ #0 ], right_keys: [ #0 ] }
-                │   │       │   │   ├── PhysicalScan { table: lineitem }
-                │   │       │   │   └── PhysicalFilter { cond: Between { expr: #4, lower: Cast { cast_to: Date32, expr: "1995-01-01" }, upper: Cast { cast_to: Date32, expr: "1996-12-31" } } }
-                │   │       │   │       └── PhysicalScan { table: orders }
-                │   │       │   └── PhysicalScan { table: customer }
+                │   │       ├── PhysicalHashJoin { join_type: Inner, left_keys: [ #0 ], right_keys: [ #0 ] }
+                │   │       │   ├── PhysicalScan { table: lineitem }
+                │   │       │   └── PhysicalHashJoin { join_type: Inner, left_keys: [ #1 ], right_keys: [ #0 ] }
+                │   │       │       ├── PhysicalFilter { cond: Between { expr: #4, lower: Cast { cast_to: Date32, expr: "1995-01-01" }, upper: Cast { cast_to: Date32, expr: "1996-12-31" } } }
+                │   │       │       │   └── PhysicalScan { table: orders }
+                │   │       │       └── PhysicalScan { table: customer }
                 │   │       └── PhysicalScan { table: nation }
                 │   └── PhysicalScan { table: nation }
                 └── PhysicalFilter

--- a/optd-sqlplannertest/tests/tpch/tpch-11-15.planner.sql
+++ b/optd-sqlplannertest/tests/tpch/tpch-11-15.planner.sql
@@ -567,50 +567,50 @@ LogicalSort
 PhysicalSort
 ├── exprs:SortOrder { order: Asc }
 │   └── #0
-└── PhysicalProjection { exprs: [ #3, #4, #5, #7, #2 ] }
-    └── PhysicalHashJoin { join_type: Inner, left_keys: [ #1 ], right_keys: [ #0 ] }
-        ├── PhysicalHashJoin { join_type: Inner, left_keys: [ #0 ], right_keys: [ #1 ] }
-        │   ├── PhysicalAgg
-        │   │   ├── aggrs:Agg(Max)
-        │   │   │   └── [ #0 ]
-        │   │   ├── groups: []
-        │   │   └── PhysicalProjection { exprs: [ #1 ] }
-        │   │       └── PhysicalAgg
-        │   │           ├── aggrs:Agg(Sum)
-        │   │           │   └── Mul
-        │   │           │       ├── #1
-        │   │           │       └── Sub
-        │   │           │           ├── 1(float)
-        │   │           │           └── #2
-        │   │           ├── groups: [ #0 ]
-        │   │           └── PhysicalProjection { exprs: [ #2, #5, #6 ] }
-        │   │               └── PhysicalFilter
-        │   │                   ├── cond:And
-        │   │                   │   ├── Geq
-        │   │                   │   │   ├── #10
-        │   │                   │   │   └── 8401(i64)
-        │   │                   │   └── Lt
-        │   │                   │       ├── #10
-        │   │                   │       └── 8491(i64)
-        │   │                   └── PhysicalScan { table: lineitem }
-        │   └── PhysicalAgg
-        │       ├── aggrs:Agg(Sum)
-        │       │   └── Mul
-        │       │       ├── #1
-        │       │       └── Sub
-        │       │           ├── 1(float)
-        │       │           └── #2
-        │       ├── groups: [ #0 ]
-        │       └── PhysicalProjection { exprs: [ #2, #5, #6 ] }
-        │           └── PhysicalFilter
-        │               ├── cond:And
-        │               │   ├── Geq
-        │               │   │   ├── #10
-        │               │   │   └── 8401(i64)
-        │               │   └── Lt
-        │               │       ├── #10
-        │               │       └── 8491(i64)
-        │               └── PhysicalScan { table: lineitem }
-        └── PhysicalScan { table: supplier }
+└── PhysicalProjection { exprs: [ #1, #2, #3, #5, #9 ] }
+    └── PhysicalHashJoin { join_type: Inner, left_keys: [ #0 ], right_keys: [ #8 ] }
+        ├── PhysicalAgg
+        │   ├── aggrs:Agg(Max)
+        │   │   └── [ #0 ]
+        │   ├── groups: []
+        │   └── PhysicalProjection { exprs: [ #1 ] }
+        │       └── PhysicalAgg
+        │           ├── aggrs:Agg(Sum)
+        │           │   └── Mul
+        │           │       ├── #1
+        │           │       └── Sub
+        │           │           ├── 1(float)
+        │           │           └── #2
+        │           ├── groups: [ #0 ]
+        │           └── PhysicalProjection { exprs: [ #2, #5, #6 ] }
+        │               └── PhysicalFilter
+        │                   ├── cond:And
+        │                   │   ├── Geq
+        │                   │   │   ├── #10
+        │                   │   │   └── 8401(i64)
+        │                   │   └── Lt
+        │                   │       ├── #10
+        │                   │       └── 8491(i64)
+        │                   └── PhysicalScan { table: lineitem }
+        └── PhysicalHashJoin { join_type: Inner, left_keys: [ #0 ], right_keys: [ #0 ] }
+            ├── PhysicalScan { table: supplier }
+            └── PhysicalAgg
+                ├── aggrs:Agg(Sum)
+                │   └── Mul
+                │       ├── #1
+                │       └── Sub
+                │           ├── 1(float)
+                │           └── #2
+                ├── groups: [ #0 ]
+                └── PhysicalProjection { exprs: [ #2, #5, #6 ] }
+                    └── PhysicalFilter
+                        ├── cond:And
+                        │   ├── Geq
+                        │   │   ├── #10
+                        │   │   └── 8401(i64)
+                        │   └── Lt
+                        │       ├── #10
+                        │       └── 8491(i64)
+                        └── PhysicalScan { table: lineitem }
 */
 

--- a/optd-sqlplannertest/tests/tpch/tpch-16-20.planner.sql
+++ b/optd-sqlplannertest/tests/tpch/tpch-16-20.planner.sql
@@ -174,27 +174,27 @@ PhysicalProjection
     ├── aggrs:Agg(Sum)
     │   └── [ #0 ]
     ├── groups: []
-    └── PhysicalProjection { exprs: [ #14 ] }
+    └── PhysicalProjection { exprs: [ #5 ] }
         └── PhysicalNestedLoopJoin
             ├── join_type: Inner
             ├── cond:And
             │   ├── Eq
-            │   │   ├── #0
-            │   │   └── #0
+            │   │   ├── #16
+            │   │   └── #16
             │   └── Lt
-            │       ├── Cast { cast_to: Decimal128(30, 15), expr: #13 }
+            │       ├── Cast { cast_to: Decimal128(30, 15), expr: #4 }
             │       └── #25
-            ├── PhysicalHashJoin { join_type: Inner, left_keys: [ #0 ], right_keys: [ #1 ] }
-            │   ├── PhysicalFilter
-            │   │   ├── cond:And
-            │   │   │   ├── Eq
-            │   │   │   │   ├── #3
-            │   │   │   │   └── "Brand#13"
-            │   │   │   └── Eq
-            │   │   │       ├── #6
-            │   │   │       └── "JUMBO PKG"
-            │   │   └── PhysicalScan { table: part }
-            │   └── PhysicalScan { table: lineitem }
+            ├── PhysicalHashJoin { join_type: Inner, left_keys: [ #1 ], right_keys: [ #0 ] }
+            │   ├── PhysicalScan { table: lineitem }
+            │   └── PhysicalFilter
+            │       ├── cond:And
+            │       │   ├── Eq
+            │       │   │   ├── #3
+            │       │   │   └── "Brand#13"
+            │       │   └── Eq
+            │       │       ├── #6
+            │       │       └── "JUMBO PKG"
+            │       └── PhysicalScan { table: part }
             └── PhysicalProjection
                 ├── exprs:
                 │   ┌── Cast


### PR DESCRIPTION
* rewrite the memo table to fully resolve the group merging issues; add test cases; drop a few stale APIs from the memo table
* enable the filter-project set of rules and it won't run out of budget now