### PR TITLE
fix(df-bridge): enumerate join order for materialized plan

### DIFF
--- a/optd-adaptive-demo/src/bin/optd-adaptive-tpch-q8.rs
+++ b/optd-adaptive-demo/src/bin/optd-adaptive-tpch-q8.rs
@@ -54,7 +54,7 @@ async fn main() -> Result<()> {
     };
 
     exec_from_files(
-        vec!["tpch/populate.sql".to_string()],
+        vec!["datafusion-optd-cli/tpch-sf0_01/populate.sql".to_string()],
         &mut ctx,
         &slient_print_options,
     )


### PR DESCRIPTION
This fixes the adaptive demo in README b/c it needs to retrieve the join order.