### PR TITLE
refactor(core): add predicate into relnode

### DIFF
--- a/optd-core/src/cascades/optimizer.rs
+++ b/optd-core/src/cascades/optimizer.rs
@@ -12,7 +12,7 @@ use crate::{
     cost::CostModel,
     optimizer::Optimizer,
     property::{PropertyBuilder, PropertyBuilderAny},
-    rel_node::{RelNodeMeta, RelNodeMetaMap, RelNodeRef, RelNodeTyp},
+    rel_node::{ArcPredNode, RelNodeMeta, RelNodeMetaMap, RelNodeRef, RelNodeTyp},
     rules::RuleWrapper,
 };
 
@@ -68,6 +68,9 @@ pub struct GroupId(pub(super) usize);
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Default, Hash)]
 pub struct ExprId(pub usize);
 
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Default, Hash)]
+pub struct PredId(pub usize);
+
 impl Display for GroupId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "!{}", self.0)
@@ -77,6 +80,12 @@ impl Display for GroupId {
 impl Display for ExprId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+impl Display for PredId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "P{}", self.0)
     }
 }
 
@@ -328,6 +337,10 @@ impl<T: RelNodeTyp, M: Memo<T>> CascadesOptimizer<T, M> {
 
     pub fn get_predicate_binding(&self, group_id: GroupId) -> Option<RelNodeRef<T>> {
         self.memo.get_predicate_binding(group_id)
+    }
+
+    pub fn get_predicate(&self, pred_id: PredId) -> ArcPredNode<T> {
+        self.memo.get_pred(pred_id)
     }
 
     pub(super) fn is_group_explored(&self, group_id: GroupId) -> bool {

--- a/optd-core/src/cascades/tasks/apply_rule.rs
+++ b/optd-core/src/cascades/tasks/apply_rule.rs
@@ -115,6 +115,12 @@ fn match_node<T: RelNodeTyp, M: Memo<T>>(
                         .map(|x| RelNode::new_group(*x).into())
                         .collect_vec(),
                     data: node.data.clone(),
+                    // rule engine by default captures all predicates
+                    predicates: node
+                        .predicates
+                        .iter()
+                        .map(|x| optimizer.get_predicate(*x))
+                        .collect(),
                 },
             );
             assert!(res.is_none(), "dup pick");

--- a/optd-core/src/heuristics/optimizer.rs
+++ b/optd-core/src/heuristics/optimizer.rs
@@ -74,6 +74,7 @@ fn match_node<T: RelNodeTyp>(
                 typ: typ.clone(),
                 children: node.children.clone(),
                 data: node.data.clone(),
+                predicates: node.predicates.clone(),
             },
         );
         assert!(res.is_none(), "dup pick");
@@ -153,6 +154,7 @@ impl<T: RelNodeTyp> HeuristicsOptimizer<T> {
                         typ: root_rel.typ.clone(),
                         children: optimized_children,
                         data: root_rel.data.clone(),
+                        predicates: root_rel.predicates.clone(),
                     }
                     .into(),
                 )?;
@@ -165,6 +167,7 @@ impl<T: RelNodeTyp> HeuristicsOptimizer<T> {
                     typ: root_rel.typ.clone(),
                     children: optimized_children,
                     data: root_rel.data.clone(),
+                    predicates: root_rel.predicates.clone(),
                 }
                 .into();
                 Ok(node)

--- a/optd-datafusion-bridge/src/into_optd.rs
+++ b/optd-datafusion-bridge/src/into_optd.rs
@@ -394,6 +394,7 @@ impl OptdPlanContext<'_> {
                 typ: rel_node.typ.clone(),
                 children,
                 data: rel_node.data.clone(),
+                predicates: Vec::new(), /* TODO: refactor */
             }
             .into(),
         )

--- a/optd-datafusion-repr/src/plan_nodes.rs
+++ b/optd-datafusion-repr/src/plan_nodes.rs
@@ -143,6 +143,8 @@ impl std::fmt::Display for OptRelNodeTyp {
 }
 
 impl RelNodeTyp for OptRelNodeTyp {
+    type PredType = usize; /* TODO: refactor */
+
     fn is_logical(&self) -> bool {
         matches!(
             self,
@@ -343,6 +345,7 @@ impl Expr {
                     typ: self.0.typ.clone(),
                     children: children.into_iter().collect_vec(),
                     data: self.0.data.clone(),
+                    predicates: Vec::new(), /* TODO: refactor */
                 }
                 .into(),
             )
@@ -516,5 +519,6 @@ fn replace_typ(node: OptRelNodeRef, target_type: OptRelNodeTyp) -> OptRelNodeRef
         typ: target_type,
         children: node.children.clone(),
         data: node.data.clone(),
+        predicates: Vec::new(), /* TODO: refactor */
     })
 }

--- a/optd-datafusion-repr/src/plan_nodes/apply.rs
+++ b/optd-datafusion-repr/src/plan_nodes/apply.rs
@@ -74,6 +74,7 @@ impl LogicalApply {
                     cond.into_rel_node(),
                 ],
                 data: None,
+                predicates: Vec::new(), /* TODO: refactor */
             }
             .into(),
         ))

--- a/optd-datafusion-repr/src/plan_nodes/empty_relation.rs
+++ b/optd-datafusion-repr/src/plan_nodes/empty_relation.rs
@@ -52,6 +52,7 @@ impl LogicalEmptyRelation {
                 typ: OptRelNodeTyp::EmptyRelation,
                 children: vec![],
                 data: Some(Value::Serialized(serialized_data)),
+                predicates: Vec::new(), /* TODO: refactor */
             }
             .into(),
         ))

--- a/optd-datafusion-repr/src/plan_nodes/expr.rs
+++ b/optd-datafusion-repr/src/plan_nodes/expr.rs
@@ -163,6 +163,7 @@ impl ConstantExpr {
                 typ: OptRelNodeTyp::Constant(typ),
                 children: vec![],
                 data: Some(value),
+                predicates: Vec::new(), /* TODO: refactor */
             }
             .into(),
         ))
@@ -288,6 +289,7 @@ impl ColumnRefExpr {
                 typ: OptRelNodeTyp::ColumnRef,
                 children: vec![],
                 data: Some(Value::UInt64(u64_column_idx)),
+                predicates: Vec::new(), /* TODO: refactor */
             }
             .into(),
         ))
@@ -342,6 +344,7 @@ impl UnOpExpr {
                 typ: OptRelNodeTyp::UnOp(op_type),
                 children: vec![child.into_rel_node()],
                 data: None,
+                predicates: Vec::new(), /* TODO: refactor */
             }
             .into(),
         ))
@@ -435,6 +438,7 @@ impl BinOpExpr {
                 typ: OptRelNodeTyp::BinOp(op_type),
                 children: vec![left.into_rel_node(), right.into_rel_node()],
                 data: None,
+                predicates: Vec::new(), /* TODO: refactor */
             }
             .into(),
         ))
@@ -514,6 +518,7 @@ impl FuncExpr {
                 typ: OptRelNodeTyp::Func(func_id),
                 children: vec![argv.into_rel_node()],
                 data: None,
+                predicates: Vec::new(), /* TODO: refactor */
             }
             .into(),
         ))
@@ -582,6 +587,7 @@ impl SortOrderExpr {
                 typ: OptRelNodeTyp::SortOrder(order),
                 children: vec![child.into_rel_node()],
                 data: None,
+                predicates: Vec::new(), /* TODO: refactor */
             }
             .into(),
         ))
@@ -647,6 +653,7 @@ impl LogOpExpr {
                     .map(|x| x.into_rel_node())
                     .collect(),
                 data: None,
+                predicates: Vec::new(), /* TODO: refactor */
             }
             .into(),
         ))
@@ -735,6 +742,7 @@ impl BetweenExpr {
                     upper.into_rel_node(),
                 ],
                 data: None,
+                predicates: Vec::new(), /* TODO: refactor */
             }
             .into(),
         ))
@@ -788,6 +796,7 @@ impl DataTypeExpr {
                 typ: OptRelNodeTyp::DataType(typ),
                 children: vec![],
                 data: None,
+                predicates: Vec::new(), /* TODO: refactor */
             }
             .into(),
         ))
@@ -832,6 +841,7 @@ impl CastExpr {
                     DataTypeExpr::new(cast_to).into_rel_node(),
                 ],
                 data: None,
+                predicates: Vec::new(), /* TODO: refactor */
             }
             .into(),
         ))
@@ -885,6 +895,7 @@ impl LikeExpr {
                 typ: OptRelNodeTyp::Like,
                 children: vec![expr.into_rel_node(), pattern.into_rel_node()],
                 data: Some(Value::Serialized(Arc::new([negated, case_insensitive]))),
+                predicates: Vec::new(), /* TODO: refactor */
             }
             .into(),
         ))
@@ -953,6 +964,7 @@ impl InListExpr {
                 typ: OptRelNodeTyp::InList,
                 children: vec![expr.into_rel_node(), list.into_rel_node()],
                 data: Some(Value::Bool(negated)),
+                predicates: Vec::new(), /* TODO: refactor */
             }
             .into(),
         ))

--- a/optd-datafusion-repr/src/plan_nodes/macros.rs
+++ b/optd-datafusion-repr/src/plan_nodes/macros.rs
@@ -63,6 +63,7 @@ macro_rules! define_plan_node {
                             $($attr_name.into_rel_node()),*
                         ],
                         data,
+                        predicates: Vec::new(), /* TODO: refactor */
                     }
                     .into(),
                 ))

--- a/optd-datafusion-repr/src/plan_nodes/scan.rs
+++ b/optd-datafusion-repr/src/plan_nodes/scan.rs
@@ -37,6 +37,7 @@ impl LogicalScan {
                 typ: OptRelNodeTyp::Scan,
                 children: vec![],
                 data: Some(Value::String(table.into())),
+                predicates: Vec::new(), /* TODO: refactor */
             }
             .into(),
         ))

--- a/optd-datafusion-repr/src/plan_nodes/subquery.rs
+++ b/optd-datafusion-repr/src/plan_nodes/subquery.rs
@@ -45,6 +45,7 @@ impl ExternColumnRefExpr {
                 typ: OptRelNodeTyp::ExternColumnRef,
                 children: vec![],
                 data: Some(Value::UInt64(u64_column_idx)),
+                predicates: Vec::new(), /* TODO: refactor */
             }
             .into(),
         ))

--- a/optd-datafusion-repr/src/rules/filter.rs
+++ b/optd-datafusion-repr/src/rules/filter.rs
@@ -109,6 +109,7 @@ fn apply_simplify_filter(
                     typ: OptRelNodeTyp::Filter,
                     children: vec![child.into(), new_log_expr],
                     data: None,
+                    predicates: Vec::new(), /* TODO: refactor */
                 };
                 return vec![filter_node];
             }

--- a/optd-datafusion-repr/src/rules/joins.rs
+++ b/optd-datafusion-repr/src/rules/joins.rs
@@ -147,11 +147,13 @@ fn apply_join_assoc(
                 typ: OptRelNodeTyp::Join(JoinType::Inner),
                 children: vec![b.into(), c.into(), cond2.into_rel_node()],
                 data: None,
+                predicates: Vec::new(), /* TODO: refactor */
             }
             .into(),
             cond1.into(),
         ],
         data: None,
+        predicates: Vec::new(), /* TODO: refactor */
     };
     vec![node]
 }

--- a/optd-datafusion-repr/src/rules/physical.rs
+++ b/optd-datafusion-repr/src/rules/physical.rs
@@ -61,6 +61,7 @@ impl<O: Optimizer<OptRelNodeTyp>> Rule<OptRelNodeTyp, O> for PhysicalConversionR
             typ,
             data,
             children,
+            predicates,
         } = input.remove(&0).unwrap();
 
         match typ {
@@ -69,6 +70,7 @@ impl<O: Optimizer<OptRelNodeTyp>> Rule<OptRelNodeTyp, O> for PhysicalConversionR
                     typ: OptRelNodeTyp::PhysicalNestedLoopJoin(x.to_join_type()),
                     children,
                     data,
+                    predicates,
                 };
                 vec![node]
             }
@@ -77,6 +79,7 @@ impl<O: Optimizer<OptRelNodeTyp>> Rule<OptRelNodeTyp, O> for PhysicalConversionR
                     typ: OptRelNodeTyp::PhysicalNestedLoopJoin(x),
                     children,
                     data,
+                    predicates,
                 };
                 vec![node]
             }
@@ -85,6 +88,7 @@ impl<O: Optimizer<OptRelNodeTyp>> Rule<OptRelNodeTyp, O> for PhysicalConversionR
                     typ: OptRelNodeTyp::PhysicalScan,
                     children,
                     data,
+                    predicates,
                 };
                 vec![node]
             }
@@ -93,6 +97,7 @@ impl<O: Optimizer<OptRelNodeTyp>> Rule<OptRelNodeTyp, O> for PhysicalConversionR
                     typ: OptRelNodeTyp::PhysicalFilter,
                     children,
                     data,
+                    predicates,
                 };
                 vec![node]
             }
@@ -101,6 +106,7 @@ impl<O: Optimizer<OptRelNodeTyp>> Rule<OptRelNodeTyp, O> for PhysicalConversionR
                     typ: OptRelNodeTyp::PhysicalProjection,
                     children,
                     data,
+                    predicates,
                 };
                 vec![node]
             }
@@ -109,6 +115,7 @@ impl<O: Optimizer<OptRelNodeTyp>> Rule<OptRelNodeTyp, O> for PhysicalConversionR
                     typ: OptRelNodeTyp::PhysicalSort,
                     children,
                     data,
+                    predicates,
                 };
                 vec![node]
             }
@@ -117,6 +124,7 @@ impl<O: Optimizer<OptRelNodeTyp>> Rule<OptRelNodeTyp, O> for PhysicalConversionR
                     typ: OptRelNodeTyp::PhysicalAgg,
                     children,
                     data,
+                    predicates,
                 };
                 vec![node]
             }
@@ -125,6 +133,7 @@ impl<O: Optimizer<OptRelNodeTyp>> Rule<OptRelNodeTyp, O> for PhysicalConversionR
                     typ: OptRelNodeTyp::PhysicalEmptyRelation,
                     children,
                     data,
+                    predicates,
                 };
                 vec![node]
             }
@@ -133,6 +142,7 @@ impl<O: Optimizer<OptRelNodeTyp>> Rule<OptRelNodeTyp, O> for PhysicalConversionR
                     typ: OptRelNodeTyp::PhysicalLimit,
                     children,
                     data,
+                    predicates,
                 };
                 vec![node]
             }

--- a/optd-datafusion-repr/src/rules/subquery/depjoin_pushdown.rs
+++ b/optd-datafusion-repr/src/rules/subquery/depjoin_pushdown.rs
@@ -48,6 +48,7 @@ fn rewrite_extern_column_refs(
                 typ: expr_rel.typ.clone(),
                 children,
                 data: expr_rel.data.clone(),
+                predicates: Vec::new(), /* TODO: refactor */
             }
             .into(),
         )


### PR DESCRIPTION
Extracted from https://github.com/cmu-db/optd/pull/193, this patch adds predicate to the relnode and refactors the memo table to store the predicates. Minimum changes are done to the df-repr to ensure it still works.

Follow-ups:
* Rename RelNode -> PlanNode
* Rename RelNodeTyp -> PlanNodeTyp
* Refactor RelNode to store RelNodeOrGroup
* Remove `data` from RelNode