### PR TITLE
refactor(core): drop value-bag dependency for statistics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2929,11 +2929,11 @@ dependencies = [
  "anyhow",
  "arrow-schema",
  "chrono",
+ "erased-serde",
  "itertools 0.13.0",
  "ordered-float 4.5.0",
  "serde",
  "tracing",
- "value-bag",
 ]
 
 [[package]]
@@ -2969,7 +2969,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "union-find",
- "value-bag",
 ]
 
 [[package]]
@@ -3841,15 +3840,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_buf"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a86be9d6c7d34718d2ec6f56c8d6a4671d1a7357c2a6921f47fe5a3ee6056cc"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3858,15 +3848,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.87",
-]
-
-[[package]]
-name = "serde_fmt"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d4ddca14104cd60529e8c7f7ba71a2c8acd8f7f5cfcdc2faf97eeb7c3010a4"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -4164,84 +4145,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "sval"
-version = "2.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6dc0f9830c49db20e73273ffae9b5240f63c42e515af1da1fceefb69fceafd8"
-
-[[package]]
-name = "sval_buffer"
-version = "2.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "429922f7ad43c0ef8fd7309e14d750e38899e32eb7e8da656ea169dd28ee212f"
-dependencies = [
- "sval",
- "sval_ref",
-]
-
-[[package]]
-name = "sval_dynamic"
-version = "2.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f16ff5d839396c11a30019b659b0976348f3803db0626f736764c473b50ff4"
-dependencies = [
- "sval",
-]
-
-[[package]]
-name = "sval_fmt"
-version = "2.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c01c27a80b6151b0557f9ccbe89c11db571dc5f68113690c1e028d7e974bae94"
-dependencies = [
- "itoa",
- "ryu",
- "sval",
-]
-
-[[package]]
-name = "sval_json"
-version = "2.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0deef63c70da622b2a8069d8600cf4b05396459e665862e7bdb290fd6cf3f155"
-dependencies = [
- "itoa",
- "ryu",
- "sval",
-]
-
-[[package]]
-name = "sval_nested"
-version = "2.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a39ce5976ae1feb814c35d290cf7cf8cd4f045782fe1548d6bc32e21f6156e9f"
-dependencies = [
- "sval",
- "sval_buffer",
- "sval_ref",
-]
-
-[[package]]
-name = "sval_ref"
-version = "2.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7c6ee3751795a728bc9316a092023529ffea1783499afbc5c66f5fabebb1fa"
-dependencies = [
- "sval",
-]
-
-[[package]]
-name = "sval_serde"
-version = "2.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a5572d0321b68109a343634e3a5d576bf131b82180c6c442dee06349dfc652a"
-dependencies = [
- "serde",
- "sval",
- "sval_nested",
-]
 
 [[package]]
 name = "syn"
@@ -4841,43 +4744,6 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "value-bag"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef4c4aa54d5d05a279399bfa921ec387b7aba77caf7a682ae8d86785b8fdad2"
-dependencies = [
- "value-bag-serde1",
- "value-bag-sval2",
-]
-
-[[package]]
-name = "value-bag-serde1"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb773bd36fd59c7ca6e336c94454d9c66386416734817927ac93d81cb3c5b0b"
-dependencies = [
- "erased-serde",
- "serde",
- "serde_buf",
- "serde_fmt",
-]
-
-[[package]]
-name = "value-bag-sval2"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a916a702cac43a88694c97657d449775667bcd14b70419441d05b7fea4a83a"
-dependencies = [
- "sval",
- "sval_buffer",
- "sval_dynamic",
- "sval_fmt",
- "sval_json",
- "sval_ref",
- "sval_serde",
-]
 
 [[package]]
 name = "version_check"

--- a/optd-core/Cargo.toml
+++ b/optd-core/Cargo.toml
@@ -18,4 +18,4 @@ itertools = "0.13"
 serde = { version = "1.0", features = ["derive", "rc"] }
 arrow-schema = "47.0.0"
 chrono = "0.4"
-value-bag = { version = "1", features = ["owned"] }
+erased-serde = "0.4"

--- a/optd-core/src/cascades/memo.rs
+++ b/optd-core/src/cascades/memo.rs
@@ -41,7 +41,7 @@ impl<T: NodeType> std::fmt::Display for MemoPlanNode<T> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct WinnerInfo {
     pub expr_id: ExprId,
     pub total_weighted_cost: f64,
@@ -51,7 +51,7 @@ pub struct WinnerInfo {
     pub statistics: Arc<Statistics>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum Winner {
     Unknown,
     Impossible,
@@ -81,7 +81,7 @@ impl Default for Winner {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Clone)]
 pub struct GroupInfo {
     pub winner: Winner,
 }

--- a/optd-core/src/cost.rs
+++ b/optd-core/src/cost.rs
@@ -7,8 +7,7 @@ use crate::cascades::{CascadesOptimizer, Memo, RelNodeContext};
 use crate::nodes::{ArcPredNode, NodeType};
 
 /// The statistics of a group.
-#[derive(Clone, Debug)]
-pub struct Statistics(pub value_bag::OwnedValueBag);
+pub struct Statistics(pub Box<dyn std::any::Any + Send + Sync + 'static>);
 
 /// The cost of an operation. The cost is represented as a vector of double values.
 /// For example, it can be represented as `[compute_cost, io_cost]`.

--- a/optd-core/src/nodes.rs
+++ b/optd-core/src/nodes.rs
@@ -358,7 +358,7 @@ impl<T: NodeType> PredNode<T> {
 }
 
 /// Metadata for a rel node.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct PlanNodeMeta {
     /// The group (id) of the `RelNode`
     pub group_id: GroupId,

--- a/optd-datafusion-repr/Cargo.toml
+++ b/optd-datafusion-repr/Cargo.toml
@@ -23,4 +23,3 @@ datafusion-expr = "32.0.0"
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3.3"
 union-find = { git = "https://github.com/Gun9niR/union-find-rs.git", rev = "794821514f7daefcbb8d5f38ef04e62fc18b5665" }
-value-bag = { version = "1", features = ["owned"] }

--- a/optd-datafusion-repr/src/cost/base_cost.rs
+++ b/optd-datafusion-repr/src/cost/base_cost.rs
@@ -8,9 +8,13 @@ use std::collections::HashMap;
 use itertools::Itertools;
 use optd_core::cascades::{CascadesOptimizer, NaiveMemo, RelNodeContext};
 use optd_core::cost::{Cost, CostModel, Statistics};
-use value_bag::ValueBag;
 
 use crate::plan_nodes::{ArcDfPredNode, ConstantPred, DfNodeType, DfReprPredNode};
+
+#[derive(Debug, Clone)]
+pub struct DfStatistics {
+    row_cnt: f64,
+}
 
 pub struct DfCostModel {
     table_stat: HashMap<String, usize>,
@@ -31,7 +35,7 @@ impl DfCostModel {
     }
 
     pub fn row_cnt(Statistics(stat): &Statistics) -> f64 {
-        stat.by_ref().as_f64()
+        stat.downcast_ref::<DfStatistics>().unwrap().row_cnt
     }
 
     pub fn cost(compute_cost: f64, io_cost: f64) -> Cost {
@@ -39,7 +43,7 @@ impl DfCostModel {
     }
 
     pub fn stat(row_cnt: f64) -> Statistics {
-        Statistics(ValueBag::from_f64(row_cnt).to_owned())
+        Statistics(Box::new(DfStatistics { row_cnt }))
     }
 
     pub fn cost_tuple(Cost(cost): &Cost) -> (f64, f64) {

--- a/optd-datafusion-repr/src/testing/dummy_cost.rs
+++ b/optd-datafusion-repr/src/testing/dummy_cost.rs
@@ -35,7 +35,7 @@ impl CostModel<DfNodeType, NaiveMemo<DfNodeType>> for DummyCostModel {
         _: Option<RelNodeContext>,
         _: Option<&CascadesOptimizer<DfNodeType>>,
     ) -> Statistics {
-        Statistics(ValueBag::empty().to_owned())
+        Statistics(Box::new(()))
     }
 
     fn explain_cost(&self, _: &Cost) -> String {

--- a/optd-datafusion-repr/src/testing/dummy_cost.rs
+++ b/optd-datafusion-repr/src/testing/dummy_cost.rs
@@ -5,7 +5,6 @@
 
 use optd_core::cascades::{CascadesOptimizer, NaiveMemo, RelNodeContext};
 use optd_core::cost::{Cost, CostModel, Statistics};
-use value_bag::ValueBag;
 
 use crate::plan_nodes::{ArcDfPredNode, DfNodeType};
 


### PR DESCRIPTION
value-bag was added for easy ser/deserialization of the statistics. However, after second thought, this wouldn't be possible to be compatible with serde API: when someone wants to deserialize something, they need to know the underlying type to deserialize, and this info is erased behind `dyn`.

Therefore, the correct approach to enable serialization for the properties is to have two new methods on the PropertyBuilder / CostModel trait: `serialize_stats(&self, &dyn Any) -> serde_json::Value` and `deserialize_stats(&self, serde_json::Value) -> Box<dyn Any>`.