### PR TITLE
feat(sqllogictest): add initial TPC-H Q1-6 tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ dependencies = [
  "snap",
  "strum 0.25.0",
  "strum_macros 0.25.3",
- "thiserror",
+ "thiserror 1.0.68",
  "typed-builder",
  "uuid",
  "xz2",
@@ -1680,6 +1680,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1711,6 +1723,26 @@ name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
 
 [[package]]
 name = "env_filter"
@@ -1870,6 +1902,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs-err"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -3038,6 +3079,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "optd-sqllogictest"
+version = "0.1.1"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "clap 4.5.20",
+ "datafusion",
+ "datafusion-optd-cli",
+ "env_logger 0.9.3",
+ "itertools 0.13.0",
+ "lazy_static",
+ "mimalloc",
+ "optd-datafusion-bridge",
+ "optd-datafusion-repr",
+ "optd-datafusion-repr-adv-cost",
+ "regex",
+ "sqllogictest",
+ "thiserror 2.0.2",
+ "tokio",
+]
+
+[[package]]
 name = "optd-sqlplannertest"
 version = "0.1.1"
 dependencies = [
@@ -3093,6 +3156,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
 
 [[package]]
 name = "parking"
@@ -3493,7 +3562,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -4020,6 +4089,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "sqllogictest"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b6b8f606d3c4cdcaf2031c4320b79d7584e454b79562ba3d675f49701c160e"
+dependencies = [
+ "async-trait",
+ "educe",
+ "fs-err",
+ "futures",
+ "glob",
+ "humantime",
+ "itertools 0.13.0",
+ "libtest-mimic",
+ "md-5",
+ "owo-colors",
+ "regex",
+ "similar",
+ "subst",
+ "tempfile",
+ "thiserror 1.0.68",
+ "tracing",
+]
+
+[[package]]
 name = "sqlparser"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4138,6 +4231,16 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 2.0.87",
+]
+
+[[package]]
+name = "subst"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3c1ba4fd019bc866333a61fe205fc9b686e3cf5971dd8dfc116657d933031c"
+dependencies = [
+ "memchr",
+ "unicode-width",
 ]
 
 [[package]]
@@ -4290,7 +4393,16 @@ version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.68",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037e29b009aa709f293b974da5cd33b15783c049e07f8435778ce8c4871525d8"
+dependencies = [
+ "thiserror-impl 2.0.2",
 ]
 
 [[package]]
@@ -4298,6 +4410,17 @@ name = "thiserror-impl"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea4778c7e8ff768bdb32a58a2349903859fe719a320300d7d4ce8636f19a1e69"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "optd-gungnir",
     "optd-perfbench",
     "optd-datafusion-repr-adv-cost",
+    "optd-sqllogictest",
 ]
 resolver = "2"
 

--- a/optd-sqllogictest/Cargo.toml
+++ b/optd-sqllogictest/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "optd-sqllogictest"
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+thiserror = "2"
+sqllogictest = "0.22"
+clap = { version = "4.5.4", features = ["derive"] }
+anyhow = { version = "1", features = ["backtrace"] }
+async-trait = "0.1"
+datafusion-optd-cli = { path = "../datafusion-optd-cli", version = "32.0.0" }
+optd-datafusion-repr-adv-cost = { path = "../optd-datafusion-repr-adv-cost", version = "0.1" }
+datafusion = { version = "32.0.0", features = [
+    "avro",
+    "crypto_expressions",
+    "encoding_expressions",
+    "regex_expressions",
+    "unicode_expressions",
+    "compression",
+] }
+env_logger = "0.9"
+mimalloc = { version = "0.1", default-features = false }
+regex = "1.8"
+tokio = { version = "1.24", features = [
+    "macros",
+    "rt",
+    "rt-multi-thread",
+    "sync",
+    "parking_lot",
+] }
+optd-datafusion-bridge = { path = "../optd-datafusion-bridge", version = "0.1" }
+optd-datafusion-repr = { path = "../optd-datafusion-repr", version = "0.1" }
+itertools = "0.13"
+lazy_static = "1.4.0"
+
+[[test]]
+name = "harness"
+path = "./tests/harness.rs"
+harness = false

--- a/optd-sqllogictest/Cargo.toml
+++ b/optd-sqllogictest/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "optd-sqllogictest"
+description = "sqllogictest for optd"
 version.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/optd-sqllogictest/slt/_tpch_tables.slt.part
+++ b/optd-sqllogictest/slt/_tpch_tables.slt.part
@@ -1,0 +1,140 @@
+statement ok
+CREATE TABLE NATION  (
+    N_NATIONKEY  INT NOT NULL,
+    N_NAME       CHAR(25) NOT NULL,
+    N_REGIONKEY  INT NOT NULL,
+    N_COMMENT    VARCHAR(152)
+);
+
+statement ok
+CREATE TABLE REGION  (
+    R_REGIONKEY  INT NOT NULL,
+    R_NAME       CHAR(25) NOT NULL,
+    R_COMMENT    VARCHAR(152)
+);
+
+statement ok
+CREATE TABLE PART  (
+    P_PARTKEY     INT NOT NULL,
+    P_NAME        VARCHAR(55) NOT NULL,
+    P_MFGR        CHAR(25) NOT NULL,
+    P_BRAND       CHAR(10) NOT NULL,
+    P_TYPE        VARCHAR(25) NOT NULL,
+    P_SIZE        INT NOT NULL,
+    P_CONTAINER   CHAR(10) NOT NULL,
+    P_RETAILPRICE DECIMAL(15,2) NOT NULL,
+    P_COMMENT     VARCHAR(23) NOT NULL
+);
+
+statement ok
+CREATE TABLE SUPPLIER (
+    S_SUPPKEY     INT NOT NULL,
+    S_NAME        CHAR(25) NOT NULL,
+    S_ADDRESS     VARCHAR(40) NOT NULL,
+    S_NATIONKEY   INT NOT NULL,
+    S_PHONE       CHAR(15) NOT NULL,
+    S_ACCTBAL     DECIMAL(15,2) NOT NULL,
+    S_COMMENT     VARCHAR(101) NOT NULL
+);
+
+statement ok
+CREATE TABLE PARTSUPP (
+    PS_PARTKEY     INT NOT NULL,
+    PS_SUPPKEY     INT NOT NULL,
+    PS_AVAILQTY    INT NOT NULL,
+    PS_SUPPLYCOST  DECIMAL(15,2)  NOT NULL,
+    PS_COMMENT     VARCHAR(199) NOT NULL
+);
+
+statement ok
+CREATE TABLE CUSTOMER (
+    C_CUSTKEY     INT NOT NULL,
+    C_NAME        VARCHAR(25) NOT NULL,
+    C_ADDRESS     VARCHAR(40) NOT NULL,
+    C_NATIONKEY   INT NOT NULL,
+    C_PHONE       CHAR(15) NOT NULL,
+    C_ACCTBAL     DECIMAL(15,2)   NOT NULL,
+    C_MKTSEGMENT  CHAR(10) NOT NULL,
+    C_COMMENT     VARCHAR(117) NOT NULL
+);
+
+statement ok
+CREATE TABLE ORDERS (
+    O_ORDERKEY       INT NOT NULL,
+    O_CUSTKEY        INT NOT NULL,
+    O_ORDERSTATUS    CHAR(1) NOT NULL,
+    O_TOTALPRICE     DECIMAL(15,2) NOT NULL,
+    O_ORDERDATE      DATE NOT NULL,
+    O_ORDERPRIORITY  CHAR(15) NOT NULL,  
+    O_CLERK          CHAR(15) NOT NULL, 
+    O_SHIPPRIORITY   INT NOT NULL,
+    O_COMMENT        VARCHAR(79) NOT NULL
+);
+
+statement ok
+CREATE TABLE LINEITEM (
+    L_ORDERKEY      INT NOT NULL,
+    L_PARTKEY       INT NOT NULL,
+    L_SUPPKEY       INT NOT NULL,
+    L_LINENUMBER    INT NOT NULL,
+    L_QUANTITY      DECIMAL(15,2) NOT NULL,
+    L_EXTENDEDPRICE DECIMAL(15,2) NOT NULL,
+    L_DISCOUNT      DECIMAL(15,2) NOT NULL,
+    L_TAX           DECIMAL(15,2) NOT NULL,
+    L_RETURNFLAG    CHAR(1) NOT NULL,
+    L_LINESTATUS    CHAR(1) NOT NULL,
+    L_SHIPDATE      DATE NOT NULL,
+    L_COMMITDATE    DATE NOT NULL,
+    L_RECEIPTDATE   DATE NOT NULL,
+    L_SHIPINSTRUCT  CHAR(25) NOT NULL,
+    L_SHIPMODE      CHAR(10) NOT NULL,
+    L_COMMENT       VARCHAR(44) NOT NULL
+);
+
+statement ok
+CREATE EXTERNAL TABLE customer_tbl STORED AS CSV DELIMITER '|' LOCATION '../datafusion-optd-cli/tpch-sf0_01/customer.tbl';
+
+statement ok
+insert into customer select column_1, column_2, column_3, column_4, column_5, column_6, column_7, column_8 from customer_tbl;
+
+statement ok
+CREATE EXTERNAL TABLE lineitem_tbl STORED AS CSV DELIMITER '|' LOCATION '../datafusion-optd-cli/tpch-sf0_01/lineitem.tbl';
+
+statement ok
+insert into lineitem select column_1, column_2, column_3, column_4, column_5, column_6, column_7, column_8, column_9, column_10, column_11, column_12, column_13, column_14, column_15, column_16 from lineitem_tbl;
+
+statement ok
+CREATE EXTERNAL TABLE nation_tbl STORED AS CSV DELIMITER '|' LOCATION '../datafusion-optd-cli/tpch-sf0_01/nation.tbl';
+
+statement ok
+insert into nation select column_1, column_2, column_3, column_4 from nation_tbl;
+
+statement ok
+CREATE EXTERNAL TABLE orders_tbl STORED AS CSV DELIMITER '|' LOCATION '../datafusion-optd-cli/tpch-sf0_01/orders.tbl';
+
+statement ok
+insert into orders select column_1, column_2, column_3, column_4, column_5, column_6, column_7, column_8, column_9 from orders_tbl;
+
+statement ok
+CREATE EXTERNAL TABLE part_tbl STORED AS CSV DELIMITER '|' LOCATION '../datafusion-optd-cli/tpch-sf0_01/part.tbl';
+
+statement ok
+insert into part select column_1, column_2, column_3, column_4, column_5, column_6, column_7, column_8, column_9 from part_tbl;
+
+statement ok
+CREATE EXTERNAL TABLE partsupp_tbl STORED AS CSV DELIMITER '|' LOCATION '../datafusion-optd-cli/tpch-sf0_01/partsupp.tbl';
+
+statement ok
+insert into partsupp select column_1, column_2, column_3, column_4, column_5 from partsupp_tbl;
+
+statement ok
+CREATE EXTERNAL TABLE region_tbl STORED AS CSV DELIMITER '|' LOCATION '../datafusion-optd-cli/tpch-sf0_01/region.tbl';
+
+statement ok
+insert into region select column_1, column_2, column_3 from region_tbl;
+
+statement ok
+CREATE EXTERNAL TABLE supplier_tbl STORED AS CSV DELIMITER '|' LOCATION '../datafusion-optd-cli/tpch-sf0_01/supplier.tbl';
+
+statement ok
+insert into supplier select column_1, column_2, column_3, column_4, column_5, column_6, column_7 from supplier_tbl;

--- a/optd-sqllogictest/slt/basic.slt
+++ b/optd-sqllogictest/slt/basic.slt
@@ -1,0 +1,4 @@
+query I
+select 1;
+----
+1

--- a/optd-sqllogictest/slt/tpch-q1.slt
+++ b/optd-sqllogictest/slt/tpch-q1.slt
@@ -1,0 +1,27 @@
+include _tpch_tables.slt.part
+
+query
+SELECT
+    l_returnflag,
+    l_linestatus,
+    sum(l_quantity) as sum_qty,
+    sum(l_extendedprice) as sum_base_price,
+    sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
+    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
+    avg(l_quantity) as avg_qty,
+    avg(l_extendedprice) as avg_price,
+    avg(l_discount) as avg_disc,
+    count(*) as count_order
+FROM
+    lineitem
+WHERE
+    l_shipdate <= date '1998-12-01' - interval '90' day
+GROUP BY
+    l_returnflag, l_linestatus
+ORDER BY
+    l_returnflag, l_linestatus;
+----
+A F 37474.00 37569624.64 35676192.0970 37101416.222424 25.354533 25419.231826 0.050866 1478
+N F 1041.00 1041301.07 999060.8980 1036450.802280 27.394736 27402.659736 0.042894 38
+N O 75168.00 75384955.37 71653166.3034 74498798.133073 25.558653 25632.422771 0.049697 2941
+R F 36511.00 36570841.24 34738472.8758 36169060.112193 25.059025 25100.096938 0.050027 1457

--- a/optd-sqllogictest/slt/tpch-q2.slt.disabled
+++ b/optd-sqllogictest/slt/tpch-q2.slt.disabled
@@ -1,0 +1,50 @@
+include _tpch_tables.slt.part
+
+query
+select
+        s_acctbal,
+        s_name,
+        n_name,
+        p_partkey,
+        p_mfgr,
+        s_address,
+        s_phone,
+        s_comment
+from
+        part,
+        supplier,
+        partsupp,
+        nation,
+        region
+where
+        p_partkey = ps_partkey
+        and s_suppkey = ps_suppkey
+and p_size = 4
+and p_type like '%TIN'
+        and s_nationkey = n_nationkey
+        and n_regionkey = r_regionkey
+        and r_name = 'AFRICA'
+        and ps_supplycost = (
+                select
+                        min(ps_supplycost)
+                from
+                        partsupp,
+                        supplier,
+                        nation,
+                        region
+                where
+                        p_partkey = ps_partkey
+                        and s_suppkey = ps_suppkey
+                        and s_nationkey = n_nationkey
+                        and n_regionkey = r_regionkey
+                        and r_name = 'AFRICA'
+        )
+order by
+    s_acctbal desc,
+    n_name,
+    s_name,
+    p_partkey
+limit 100;
+----
+4641.08 Supplier#000000004 MOROCCO 100 Manufacturer#3 Bk7ah4CK8SYQTepEmvMkkgMwg 25-843-787-7479 riously even requests above the exp
+1365.79 Supplier#000000006 KENYA 185 Manufacturer#4 tQxuVm7s7CnK 24-696-997-4969 final accounts. regular dolphins use against the furiously ironic decoys.

--- a/optd-sqllogictest/slt/tpch-q3.slt
+++ b/optd-sqllogictest/slt/tpch-q3.slt
@@ -1,0 +1,36 @@
+include _tpch_tables.slt.part
+
+query
+SELECT
+    l_orderkey,
+    SUM(l_extendedprice * (1 - l_discount)) AS revenue,
+    o_orderdate,
+    o_shippriority 
+FROM
+    customer,
+    orders,
+    lineitem 
+WHERE
+    c_mktsegment = 'FURNITURE' 
+    AND c_custkey = o_custkey 
+    AND l_orderkey = o_orderkey 
+    AND o_orderdate < DATE '1995-03-29' 
+    AND l_shipdate > DATE '1995-03-29' 
+GROUP BY
+    l_orderkey,
+    o_orderdate,
+    o_shippriority 
+ORDER BY
+    revenue DESC,
+    o_orderdate LIMIT 10;
+----
+3588 199498.4104 1995-03-19 0
+4327 123939.6659 1995-03-16 0
+5347 118914.1310 1995-02-22 0
+450 111508.1186 1995-03-05 0
+1767 109576.4152 1995-03-14 0
+386 86258.3745 1995-01-25 0
+897 54854.6063 1995-03-20 0
+2982 54150.4719 1995-03-19 0
+3526 51178.7043 1995-03-16 0
+2277 42401.7338 1995-01-02 0

--- a/optd-sqllogictest/slt/tpch-q5.slt
+++ b/optd-sqllogictest/slt/tpch-q5.slt
@@ -1,0 +1,31 @@
+include _tpch_tables.slt.part
+
+query
+SELECT
+    n_name AS nation,
+    SUM(l_extendedprice * (1 - l_discount)) AS revenue
+FROM
+    customer,
+    orders,
+    lineitem,
+    supplier,
+    nation,
+    region
+WHERE
+    c_custkey = o_custkey
+    AND l_orderkey = o_orderkey
+    AND l_suppkey = s_suppkey
+    AND c_nationkey = s_nationkey
+    AND s_nationkey = n_nationkey
+    AND n_regionkey = r_regionkey
+    AND r_name = 'AFRICA' -- Specified region
+    AND o_orderdate >= DATE '1993-01-01'
+    AND o_orderdate < DATE '1994-01-01'
+GROUP BY
+    n_name
+ORDER BY
+    revenue DESC;
+----
+MOROCCO 119356.5868
+ETHIOPIA 62766.6740
+KENYA 3014.4444

--- a/optd-sqllogictest/slt/tpch-q6.slt
+++ b/optd-sqllogictest/slt/tpch-q6.slt
@@ -1,0 +1,14 @@
+include _tpch_tables.slt.part
+
+query
+SELECT
+    SUM(l_extendedprice * l_discount) AS revenue_loss
+FROM
+    lineitem
+WHERE
+    l_shipdate >= DATE '1997-01-01'
+    AND l_shipdate < DATE '1998-01-01'
+    AND l_discount BETWEEN 0.05 AND 0.07
+    AND l_quantity < 24;
+----
+94385.9721

--- a/optd-sqllogictest/src/lib.rs
+++ b/optd-sqllogictest/src/lib.rs
@@ -1,0 +1,162 @@
+// Copyright (c) 2023-2024 CMU Database Group
+//
+// Use of this source code is governed by an MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+use datafusion::arrow::datatypes::DataType;
+use datafusion::arrow::util::display::{ArrayFormatter, FormatOptions};
+use datafusion::execution::context::{SessionConfig, SessionState};
+use datafusion::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
+use datafusion::prelude::SessionContext;
+use datafusion::sql::parser::DFParser;
+use datafusion::sql::sqlparser::dialect::GenericDialect;
+use datafusion_optd_cli::helper::unescape_input;
+use mimalloc::MiMalloc;
+use optd_datafusion_bridge::{DatafusionCatalog, OptdQueryPlanner};
+use optd_datafusion_repr_adv_cost::adv_stats::stats::DataFusionBaseTableStats;
+use optd_datafusion_repr_adv_cost::new_physical_adv_cost;
+use std::sync::Arc;
+use thiserror::Error;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use sqllogictest::{DBOutput, DefaultColumnType};
+
+#[derive(Default)]
+pub struct DatafusionDBMS {
+    ctx: SessionContext,
+}
+
+impl DatafusionDBMS {
+    async fn new_inner() -> Result<Self> {
+        let ctx = DatafusionDBMS::new_session_ctx().await?;
+        Ok(Self { ctx })
+    }
+
+    pub async fn new() -> Result<Self, DbError> {
+        Ok(Self::new_inner().await?)
+    }
+
+    async fn new_inner_no_optd() -> Result<Self> {
+        let ctx = DatafusionDBMS::new_session_ctx_no_optd().await?;
+        Ok(Self { ctx })
+    }
+
+    pub async fn new_no_optd() -> Result<Self, DbError> {
+        Ok(Self::new_inner_no_optd().await?)
+    }
+
+    /// Creates a new session context.
+    async fn new_session_ctx() -> Result<SessionContext> {
+        let mut session_config = SessionConfig::from_env()?.with_information_schema(true);
+        session_config.options_mut().optimizer.max_passes = 0;
+        let rn_config = RuntimeConfig::new();
+        let runtime_env = RuntimeEnv::new(rn_config.clone())?;
+        let optd_optimizer;
+        let ctx = {
+            let mut state =
+                SessionState::new_with_config_rt(session_config.clone(), Arc::new(runtime_env));
+            let optimizer = new_physical_adv_cost(
+                Arc::new(DatafusionCatalog::new(state.catalog_list())),
+                DataFusionBaseTableStats::default(),
+                false,
+            );
+            // clean up optimizer rules so that we can plug in our own optimizer
+            state = state.with_optimizer_rules(vec![]);
+            state = state.with_physical_optimizer_rules(vec![]);
+            // use optd-bridge query planner
+            optd_optimizer = Arc::new(OptdQueryPlanner::new(optimizer));
+            state = state.with_query_planner(optd_optimizer.clone());
+            SessionContext::new_with_state(state)
+        };
+        ctx.refresh_catalogs().await?;
+        Ok(ctx)
+    }
+
+    /// Creates a new session context without optd
+    async fn new_session_ctx_no_optd() -> Result<SessionContext> {
+        let session_config = SessionConfig::from_env()?.with_information_schema(true);
+        let rn_config = RuntimeConfig::new();
+        let runtime_env = RuntimeEnv::new(rn_config.clone())?;
+        let ctx = {
+            let state =
+                SessionState::new_with_config_rt(session_config.clone(), Arc::new(runtime_env));
+            SessionContext::new_with_state(state)
+        };
+        ctx.refresh_catalogs().await?;
+        Ok(ctx)
+    }
+
+    pub(crate) async fn execute(&self, sql: &str) -> Result<DBOutput<DefaultColumnType>> {
+        let sql = unescape_input(sql)?;
+        let dialect = Box::new(GenericDialect);
+        let statements = DFParser::parse_sql_with_dialect(&sql, dialect.as_ref())?;
+        assert!(
+            statements.len() == 1,
+            "only one statement per execution is supported"
+        );
+        let mut rows = Vec::new();
+        let mut types = Vec::new();
+        for statement in statements {
+            let df = {
+                let plan = self.ctx.state().statement_to_plan(statement).await?;
+                self.ctx.execute_logical_plan(plan).await?
+            };
+
+            let batches = df.collect().await?;
+            let options = FormatOptions::default();
+
+            for batch in batches {
+                if types.is_empty() {
+                    types = batch
+                        .schema()
+                        .fields()
+                        .iter()
+                        .map(|f| match f.data_type() {
+                            DataType::Utf8 => DefaultColumnType::Text,
+                            DataType::Int32 | DataType::Int64 => DefaultColumnType::Integer,
+                            DataType::Float32 | DataType::Float64 => {
+                                DefaultColumnType::FloatingPoint
+                            }
+                            _ => DefaultColumnType::Any,
+                        })
+                        .collect();
+                }
+                let converters = batch
+                    .columns()
+                    .iter()
+                    .map(|a| ArrayFormatter::try_new(a.as_ref(), &options))
+                    .collect::<Result<Vec<_>, _>>()?;
+                for row_idx in 0..batch.num_rows() {
+                    let mut row = Vec::with_capacity(batch.num_columns());
+                    for converter in converters.iter() {
+                        let mut buffer = String::with_capacity(8);
+                        converter.value(row_idx).write(&mut buffer)?;
+                        row.push(buffer);
+                    }
+                    rows.push(row);
+                }
+            }
+        }
+        Ok(DBOutput::Rows { types, rows })
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum DbError {
+    #[error("Error in DatafusionDBMS: {0}")]
+    Disconnect(#[from] anyhow::Error),
+}
+
+#[async_trait]
+impl sqllogictest::AsyncDB for DatafusionDBMS {
+    type Error = DbError;
+    type ColumnType = DefaultColumnType;
+
+    async fn run(&mut self, sql: &str) -> Result<DBOutput<Self::ColumnType>, DbError> {
+        Ok(self.execute(sql).await?)
+    }
+}

--- a/optd-sqllogictest/tests/harness.rs
+++ b/optd-sqllogictest/tests/harness.rs
@@ -1,0 +1,47 @@
+// Copyright (c) 2023-2024 CMU Database Group
+//
+// Use of this source code is governed by an MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+use std::path::Path;
+
+use optd_sqllogictest::DatafusionDBMS;
+use sqllogictest::{harness::Failed, Runner};
+use tokio::runtime::Runtime;
+
+// TODO: sqllogictest harness should support async new function
+
+fn main() {
+    let paths = sqllogictest::harness::glob("slt/**/*.slt").expect("failed to find test files");
+    let mut tests = vec![];
+
+    for entry in paths {
+        let path = entry.expect("failed to read glob entry");
+        tests.push(sqllogictest::harness::Trial::test(
+            path.to_str().unwrap().to_string(),
+            move || test(&path),
+        ));
+    }
+
+    if tests.is_empty() {
+        panic!("no test found for sqllogictest under: slt/**/*.slt");
+    }
+
+    sqllogictest::harness::run(&sqllogictest::harness::Arguments::from_args(), tests).exit();
+}
+
+fn build_runtime() -> Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+}
+
+fn test(filename: impl AsRef<Path>) -> Result<(), Failed> {
+    build_runtime().block_on(async {
+        // let mut tester = Runner::new(|| async { Ok(DatafusionDBMS::new_no_optd().await?) });
+        let mut tester = Runner::new(|| async { Ok(DatafusionDBMS::new().await?) });
+        tester.run_file_async(filename).await?;
+        Ok(())
+    })
+}

--- a/optd-sqllogictest/tests/harness.rs
+++ b/optd-sqllogictest/tests/harness.rs
@@ -40,7 +40,7 @@ fn build_runtime() -> Runtime {
 fn test(filename: impl AsRef<Path>) -> Result<(), Failed> {
     build_runtime().block_on(async {
         // let mut tester = Runner::new(|| async { Ok(DatafusionDBMS::new_no_optd().await?) });
-        let mut tester = Runner::new(|| async { Ok(DatafusionDBMS::new().await?) });
+        let mut tester = Runner::new(|| async { DatafusionDBMS::new().await });
         tester.run_file_async(filename).await?;
         Ok(())
     })


### PR DESCRIPTION
We don't really know if the generated plan is correct or not -- what we all know now is whether we can generate a plan. Therefore, it's important to also evaluate if the result is correct. In this patch, we add sqllogictest, the test infra to ensure the execution result is correct.

In `sqllogictest.rs`, you can replace the following statement to planning + execution solely with datafusion. This yields source-of-truth result.

```
DatafusionDBMS::new_no_optd().await?
```

Now we have TPC-H Q1-6. Note that Q2 doesn't work b/c there are too many NLJs and the datafusion built-in statistics would throw multiply overflow error.