### PR TITLE
fix(tests): avoid using df logical optimizer as possible

### DIFF
--- a/optd-datafusion-bridge/src/lib.rs
+++ b/optd-datafusion-bridge/src/lib.rs
@@ -118,6 +118,7 @@ impl OptdQueryPlanner {
         if let LogicalPlan::Dml(_) | LogicalPlan::Ddl(_) | LogicalPlan::EmptyRelation(_) =
             logical_plan
         {
+            // Fallback to the datafusion planner for DML/DDL operations. optd cannot handle this.
             let planner = DefaultPhysicalPlanner::default();
             return Ok(planner
                 .create_physical_plan(logical_plan, session_state)

--- a/optd-sqlplannertest/tests/basic/constant_predicate.yml
+++ b/optd-sqlplannertest/tests/basic/constant_predicate.yml
@@ -2,19 +2,19 @@
     create table t1(t1v1 int, t1v2 int);
     insert into t1 values (0, 0), (1, 1), (2, 2);
   tasks:
-    - execute[use_df_logical]
+    - execute
 - sql: |
     select * from t1 where t1v1 = 0;
   desc: Test whether the optimizer handles integer equality predicates correctly.
   tasks:
-    - execute[use_df_logical]
+    - execute
 - sql: |
     select * from t1 where t1v1 = 0 and t1v2 = 1;
   desc: Test whether the optimizer handles multiple integer equality predicates correctly.
   tasks:
-    - execute[use_df_logical]
+    - execute
 - sql: |
     select * from t1 where t1v1 = 0 and t1v2 != 1;
   desc: Test whether the optimizer handles multiple integer inequality predicates correctly.
   tasks:
-    - execute[use_df_logical]
+    - execute

--- a/optd-sqlplannertest/tests/pushdowns/fliter_transpose.yml
+++ b/optd-sqlplannertest/tests/pushdowns/fliter_transpose.yml
@@ -4,7 +4,7 @@
     insert into t1 values (0, 0), (1, 1), (2, 2);
     insert into t2 values (0, 200), (1, 201), (2, 202);
   tasks:
-    - execute[use_df_logical]
+    - execute
 - sql: |
     SELECT t1.t1v1, t1.t1v2, t2.t2v3
       FROM t1, t2

--- a/optd-sqlplannertest/tests/subqueries/subquery_unnesting.yml
+++ b/optd-sqlplannertest/tests/subqueries/subquery_unnesting.yml
@@ -3,7 +3,7 @@
     create table t2(t2v1 int, t2v3 int);
     create table t3(t3v2 int, t3v4 int);
   tasks:
-    - execute[use_df_logical]
+    - execute
 # - sql: |
 #     select * from t1 where t1v1 in (select t2v1 from t2);
 #   desc: Test whether the optimizer can unnest "in" subqueries. -- failing with unsupported expression


### PR DESCRIPTION
There was a time that the optd optimizer itself does not handle a lot of queries and we have to rely on the datafusion logical optimizer. Now we have our own logical optimizer and we can drop `use_df_logical` in a lot of places. The exceptions are TPC-H queries, where we still need to finish the subquery unnesting work before fully opt-in optd logical optimizer.