### PR TITLE
serialize variant tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3322,6 +3322,7 @@ dependencies = [
  "ordered-float 4.5.0",
  "pretty_assertions",
  "serde",
+ "strum 0.26.3",
  "tracing",
 ]
 
@@ -3355,6 +3356,7 @@ dependencies = [
  "optd-core",
  "pretty-xmlish",
  "serde",
+ "strum 0.26.3",
  "tracing",
  "tracing-subscriber",
 ]
@@ -5285,6 +5287,9 @@ name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
 
 [[package]]
 name = "strum_macros"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ repository = "https://github.com/cmu-db/optd"
 
 [workspace.dependencies]
 futures-lite = "2"
+strum = { version = "0.26", features = ["derive"] }

--- a/optd-core/Cargo.toml
+++ b/optd-core/Cargo.toml
@@ -19,6 +19,8 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 arrow-schema = "47.0.0"
 chrono = "0.4"
 erased-serde = "0.4"
+strum.workspace = true
+
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/optd-core/src/nodes.rs
+++ b/optd-core/src/nodes.rs
@@ -217,7 +217,10 @@ impl Value {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct VariantTag(pub u16);
+pub struct SerializedNodeTag(pub u16);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SerializedPredTag(pub u16);
 
 pub trait NodeType:
     PartialEq
@@ -229,8 +232,8 @@ pub trait NodeType:
     + Debug
     + Send
     + Sync
-    + TryFrom<VariantTag>
-    + Into<VariantTag>
+    + TryFrom<SerializedNodeTag>
+    + Into<SerializedNodeTag>
 {
     type PredType: PartialEq
         + Eq
@@ -241,8 +244,8 @@ pub trait NodeType:
         + Debug
         + Send
         + Sync
-        + TryFrom<VariantTag>
-        + Into<VariantTag>;
+        + TryFrom<SerializedPredTag>
+        + Into<SerializedPredTag>;
 
     fn is_logical(&self) -> bool;
 }

--- a/optd-core/src/nodes.rs
+++ b/optd-core/src/nodes.rs
@@ -216,10 +216,33 @@ impl Value {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct VariantTag(pub u16);
+
 pub trait NodeType:
-    PartialEq + Eq + Hash + Clone + 'static + Display + Debug + Send + Sync
+    PartialEq
+    + Eq
+    + Hash
+    + Clone
+    + 'static
+    + Display
+    + Debug
+    + Send
+    + Sync
+    + TryFrom<VariantTag>
+    + Into<VariantTag>
 {
-    type PredType: PartialEq + Eq + Hash + Clone + 'static + Display + Debug + Send + Sync;
+    type PredType: PartialEq
+        + Eq
+        + Hash
+        + Clone
+        + 'static
+        + Display
+        + Debug
+        + Send
+        + Sync
+        + TryFrom<VariantTag>
+        + Into<VariantTag>;
 
     fn is_logical(&self) -> bool;
 }

--- a/optd-core/src/tests/common.rs
+++ b/optd-core/src/tests/common.rs
@@ -3,19 +3,20 @@
 // Use of this source code is governed by an MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-use std::sync::Arc;
-
-use itertools::Itertools;
-
 use crate::{
     cascades::GroupId,
     logical_property::{LogicalProperty, LogicalPropertyBuilder},
-    nodes::{ArcPlanNode, ArcPredNode, NodeType, PlanNode, PlanNodeOrGroup, PredNode, Value},
+    nodes::{
+        ArcPlanNode, ArcPredNode, NodeType, PlanNode, PlanNodeOrGroup, PredNode, Value, VariantTag,
+    },
     physical_property::{PhysicalProperty, PhysicalPropertyBuilder},
 };
+use itertools::Itertools;
+use std::sync::Arc;
 
 #[allow(dead_code)]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, strum::FromRepr)]
+#[repr(u8)]
 pub(crate) enum MemoTestRelTyp {
     Join,
     Project,
@@ -33,12 +34,41 @@ pub(crate) enum MemoTestRelTyp {
     PhysicalHashAgg,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+impl TryFrom<VariantTag> for MemoTestRelTyp {
+    type Error = u16;
+
+    fn try_from(value: VariantTag) -> Result<Self, Self::Error> {
+        Self::from_repr(value.0 as u8).ok_or_else(|| value.0)
+    }
+}
+
+impl From<MemoTestRelTyp> for VariantTag {
+    fn from(value: MemoTestRelTyp) -> Self {
+        VariantTag(value as u16)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, strum::FromRepr)]
+#[repr(u8)]
 pub(crate) enum MemoTestPredTyp {
     List,
     Expr,
     TableName,
     ColumnRef,
+}
+
+impl TryFrom<VariantTag> for MemoTestPredTyp {
+    type Error = u16;
+
+    fn try_from(value: VariantTag) -> Result<Self, Self::Error> {
+        Self::from_repr(value.0 as u8).ok_or_else(|| value.0)
+    }
+}
+
+impl From<MemoTestPredTyp> for VariantTag {
+    fn from(value: MemoTestPredTyp) -> Self {
+        VariantTag(value as u16)
+    }
 }
 
 impl std::fmt::Display for MemoTestRelTyp {

--- a/optd-core/src/tests/common.rs
+++ b/optd-core/src/tests/common.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 #[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, strum::FromRepr)]
-#[repr(u8)]
+#[repr(u16)]
 pub(crate) enum MemoTestRelTyp {
     Join,
     Project,
@@ -38,7 +38,9 @@ impl TryFrom<VariantTag> for MemoTestRelTyp {
     type Error = u16;
 
     fn try_from(value: VariantTag) -> Result<Self, Self::Error> {
-        Self::from_repr(value.0 as u8).ok_or_else(|| value.0)
+        let VariantTag(v) = value;
+        let typ = Self::from_repr(v).ok_or_else(|| v)?;
+        Ok(typ)
     }
 }
 
@@ -49,7 +51,7 @@ impl From<MemoTestRelTyp> for VariantTag {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, strum::FromRepr)]
-#[repr(u8)]
+#[repr(u16)]
 pub(crate) enum MemoTestPredTyp {
     List,
     Expr,
@@ -61,7 +63,9 @@ impl TryFrom<VariantTag> for MemoTestPredTyp {
     type Error = u16;
 
     fn try_from(value: VariantTag) -> Result<Self, Self::Error> {
-        Self::from_repr(value.0 as u8).ok_or_else(|| value.0)
+        let VariantTag(v) = value;
+        let typ = Self::from_repr(v).ok_or_else(|| v)?;
+        Ok(typ)
     }
 }
 

--- a/optd-core/src/tests/common.rs
+++ b/optd-core/src/tests/common.rs
@@ -7,7 +7,8 @@ use crate::{
     cascades::GroupId,
     logical_property::{LogicalProperty, LogicalPropertyBuilder},
     nodes::{
-        ArcPlanNode, ArcPredNode, NodeType, PlanNode, PlanNodeOrGroup, PredNode, Value, VariantTag,
+        ArcPlanNode, ArcPredNode, NodeType, PlanNode, PlanNodeOrGroup, PredNode, SerializedNodeTag,
+        SerializedPredTag, Value,
     },
     physical_property::{PhysicalProperty, PhysicalPropertyBuilder},
 };
@@ -34,19 +35,19 @@ pub(crate) enum MemoTestRelTyp {
     PhysicalHashAgg,
 }
 
-impl TryFrom<VariantTag> for MemoTestRelTyp {
+impl TryFrom<SerializedNodeTag> for MemoTestRelTyp {
     type Error = u16;
 
-    fn try_from(value: VariantTag) -> Result<Self, Self::Error> {
-        let VariantTag(v) = value;
+    fn try_from(value: SerializedNodeTag) -> Result<Self, Self::Error> {
+        let SerializedNodeTag(v) = value;
         let typ = Self::from_repr(v).ok_or_else(|| v)?;
         Ok(typ)
     }
 }
 
-impl From<MemoTestRelTyp> for VariantTag {
+impl From<MemoTestRelTyp> for SerializedNodeTag {
     fn from(value: MemoTestRelTyp) -> Self {
-        VariantTag(value as u16)
+        SerializedNodeTag(value as u16)
     }
 }
 
@@ -59,19 +60,19 @@ pub(crate) enum MemoTestPredTyp {
     ColumnRef,
 }
 
-impl TryFrom<VariantTag> for MemoTestPredTyp {
+impl TryFrom<SerializedPredTag> for MemoTestPredTyp {
     type Error = u16;
 
-    fn try_from(value: VariantTag) -> Result<Self, Self::Error> {
-        let VariantTag(v) = value;
+    fn try_from(value: SerializedPredTag) -> Result<Self, Self::Error> {
+        let SerializedPredTag(v) = value;
         let typ = Self::from_repr(v).ok_or_else(|| v)?;
         Ok(typ)
     }
 }
 
-impl From<MemoTestPredTyp> for VariantTag {
+impl From<MemoTestPredTyp> for SerializedPredTag {
     fn from(value: MemoTestPredTyp) -> Self {
-        VariantTag(value as u16)
+        SerializedPredTag(value as u16)
     }
 }
 

--- a/optd-datafusion-repr/Cargo.toml
+++ b/optd-datafusion-repr/Cargo.toml
@@ -22,3 +22,4 @@ camelpaste = "0.1"
 datafusion-expr = "32.0.0"
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3.3"
+strum.workspace = true

--- a/optd-datafusion-repr/src/plan_nodes.rs
+++ b/optd-datafusion-repr/src/plan_nodes.rs
@@ -20,7 +20,6 @@ mod subquery;
 use std::fmt::Debug;
 
 pub use agg::{LogicalAgg, PhysicalAgg};
-use arrow_schema::DataType;
 pub use empty_relation::{
     decode_empty_relation_schema, LogicalEmptyRelation, PhysicalEmptyRelation,
 };
@@ -29,6 +28,7 @@ pub use join::{JoinType, LogicalJoin, PhysicalHashJoin, PhysicalNestedLoopJoin};
 pub use limit::{LogicalLimit, PhysicalLimit};
 use optd_core::nodes::{
     ArcPlanNode, ArcPredNode, NodeType, PlanNode, PlanNodeMeta, PlanNodeMetaMap, PredNode,
+    VariantTag,
 };
 pub use predicates::{
     BetweenPred, BinOpPred, BinOpType, CastPred, ColumnRefPred, ConstantPred, ConstantType,
@@ -44,7 +44,8 @@ pub use subquery::{DependentJoin, RawDependentJoin}; // Add missing import
 
 use crate::explain::{explain_plan_node, explain_pred_node};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, strum::FromRepr)]
+#[repr(u8)]
 pub enum DfPredType {
     List,
     Constant(ConstantType),
@@ -62,6 +63,63 @@ pub enum DfPredType {
     InList,
 }
 
+impl DfPredType {
+    /// See https://doc.rust-lang.org/std/mem/fn.discriminant.html.
+    fn discriminant(&self) -> u8 {
+        // SAFETY: Because `Self` is marked `repr(u8)`, its layout is a `repr(C)` `union`
+        // between `repr(C)` structs, each of which has the `u8` discriminant as its first
+        // field, so we can read the discriminant without offsetting the pointer.
+        unsafe { *<*const _>::from(self).cast::<u8>() }
+    }
+}
+
+impl TryFrom<VariantTag> for DfPredType {
+    type Error = u16;
+
+    fn try_from(value: VariantTag) -> Result<Self, Self::Error> {
+        let VariantTag(v) = value;
+        let [discriminant, rest] = v.to_be_bytes();
+        let typ = {
+            let typ = Self::from_repr(discriminant).ok_or_else(|| v)?;
+            match typ {
+                DfPredType::Constant(_) => {
+                    DfPredType::Constant(ConstantType::from_repr(rest).ok_or_else(|| v)?)
+                }
+                DfPredType::UnOp(_) => {
+                    DfPredType::UnOp(UnOpType::from_repr(rest).ok_or_else(|| v)?)
+                }
+                DfPredType::BinOp(_) => {
+                    DfPredType::BinOp(BinOpType::from_repr(rest).ok_or_else(|| v)?)
+                }
+                DfPredType::LogOp(_) => {
+                    DfPredType::LogOp(LogOpType::from_repr(rest).ok_or_else(|| v)?)
+                }
+                DfPredType::SortOrder(_) => {
+                    DfPredType::SortOrder(SortOrderType::from_repr(rest).ok_or_else(|| v)?)
+                }
+                _ => typ,
+            }
+        };
+
+        Ok(typ)
+    }
+}
+
+impl From<DfPredType> for VariantTag {
+    fn from(value: DfPredType) -> Self {
+        let discriminant = (value.discriminant() as u16) << 8;
+        let tag = match value {
+            DfPredType::Constant(constant_type) => discriminant | constant_type as u16,
+            DfPredType::UnOp(un_op_type) => discriminant | un_op_type as u16,
+            DfPredType::BinOp(bin_op_type) => discriminant | bin_op_type as u16,
+            DfPredType::LogOp(log_op_type) => discriminant | log_op_type as u16,
+            DfPredType::SortOrder(sort_order_type) => discriminant | sort_order_type as u16,
+            _ => discriminant,
+        };
+        VariantTag(tag)
+    }
+}
+
 impl std::fmt::Display for DfPredType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self)
@@ -70,7 +128,8 @@ impl std::fmt::Display for DfPredType {
 
 /// DfNodeType FAQ:
 ///   - The define_plan_node!() macro defines what the children of each join node are
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, strum::FromRepr)]
+#[repr(u8)]
 pub enum DfNodeType {
     // Developers: update `is_logical` function after adding new plan nodes
     // Plan nodes
@@ -96,9 +155,65 @@ pub enum DfNodeType {
     PhysicalLimit,
 }
 
+impl DfNodeType {
+    /// See https://doc.rust-lang.org/std/mem/fn.discriminant.html.
+    fn discriminant(&self) -> u8 {
+        // SAFETY: Because `Self` is marked `repr(u8)`, its layout is a `repr(C)` `union`
+        // between `repr(C)` structs, each of which has the `u8` discriminant as its first
+        // field, so we can read the discriminant without offsetting the pointer.
+        unsafe { *<*const _>::from(self).cast::<u8>() }
+    }
+}
+
 impl std::fmt::Display for DfNodeType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self)
+    }
+}
+
+impl TryFrom<VariantTag> for DfNodeType {
+    type Error = u16;
+
+    fn try_from(value: VariantTag) -> Result<Self, Self::Error> {
+        let VariantTag(v) = value;
+        let [discriminant, rest] = v.to_be_bytes();
+        let typ = {
+            let typ = Self::from_repr(discriminant).ok_or_else(|| v)?;
+            match typ {
+                DfNodeType::Join(_) => {
+                    DfNodeType::Join(JoinType::from_repr(rest).ok_or_else(|| v)?)
+                }
+                DfNodeType::RawDepJoin(_) => {
+                    DfNodeType::RawDepJoin(JoinType::from_repr(rest).ok_or_else(|| v)?)
+                }
+                DfNodeType::DepJoin(_) => {
+                    DfNodeType::DepJoin(JoinType::from_repr(rest).ok_or_else(|| v)?)
+                }
+                DfNodeType::PhysicalHashJoin(_) => {
+                    DfNodeType::PhysicalHashJoin(JoinType::from_repr(rest).ok_or_else(|| v)?)
+                }
+                DfNodeType::PhysicalNestedLoopJoin(_) => {
+                    DfNodeType::PhysicalNestedLoopJoin(JoinType::from_repr(rest).ok_or_else(|| v)?)
+                }
+                _ => typ,
+            }
+        };
+        Ok(typ)
+    }
+}
+
+impl From<DfNodeType> for VariantTag {
+    fn from(value: DfNodeType) -> Self {
+        let discriminant = value.discriminant();
+        let rest = match value {
+            DfNodeType::Join(join_type) => join_type as u8,
+            DfNodeType::RawDepJoin(join_type) => join_type as u8,
+            DfNodeType::DepJoin(join_type) => join_type as u8,
+            DfNodeType::PhysicalHashJoin(join_type) => join_type as u8,
+            DfNodeType::PhysicalNestedLoopJoin(join_type) => join_type as u8,
+            _ => 0,
+        };
+        VariantTag(u16::from_be_bytes([discriminant, rest]))
     }
 }
 

--- a/optd-datafusion-repr/src/plan_nodes.rs
+++ b/optd-datafusion-repr/src/plan_nodes.rs
@@ -16,6 +16,7 @@ mod projection;
 mod scan;
 mod sort;
 mod subquery;
+pub mod tag;
 
 use std::fmt::Debug;
 
@@ -28,7 +29,6 @@ pub use join::{JoinType, LogicalJoin, PhysicalHashJoin, PhysicalNestedLoopJoin};
 pub use limit::{LogicalLimit, PhysicalLimit};
 use optd_core::nodes::{
     ArcPlanNode, ArcPredNode, NodeType, PlanNode, PlanNodeMeta, PlanNodeMetaMap, PredNode,
-    VariantTag,
 };
 pub use predicates::{
     BetweenPred, BinOpPred, BinOpType, CastPred, ColumnRefPred, ConstantPred, ConstantType,
@@ -44,7 +44,7 @@ pub use subquery::{DependentJoin, RawDependentJoin}; // Add missing import
 
 use crate::explain::{explain_plan_node, explain_pred_node};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, strum::FromRepr)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[repr(u8)]
 pub enum DfPredType {
     List,
@@ -71,7 +71,7 @@ impl std::fmt::Display for DfPredType {
 
 /// DfNodeType FAQ:
 ///   - The define_plan_node!() macro defines what the children of each join node are
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, strum::FromRepr)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[repr(u8)]
 pub enum DfNodeType {
     // Developers: update `is_logical` function after adding new plan nodes
@@ -214,136 +214,4 @@ pub fn dispatch_plan_explain_to_string(
     let mut out = String::new();
     config.unicode(&mut out, &plan_node.explain(meta_map));
     out
-}
-
-impl DfPredType {
-    /// ## Serialization
-    /// A variant tag for [`DfPredType`] has two parts. An `u8` discriminant
-    /// followed an `u8` extra field (could be [`ConstantType`], [`UnOpType`], etc.),
-    /// listed in big-endian order.
-    ///
-    /// ```
-    /// ----------------------------------------
-    /// | discriminant (u8) | extra field (u8) |
-    /// ----------------------------------------
-    /// ```
-    /// See https://doc.rust-lang.org/std/mem/fn.discriminant.html.
-    fn discriminant(&self) -> u8 {
-        // SAFETY: Because `Self` is marked `repr(u8)`, its layout is a `repr(C)` `union`
-        // between `repr(C)` structs, each of which has the `u8` discriminant as its first
-        // field, so we can read the discriminant without offsetting the pointer.
-        unsafe { *<*const _>::from(self).cast::<u8>() }
-    }
-}
-
-impl TryFrom<VariantTag> for DfPredType {
-    type Error = u16;
-
-    fn try_from(value: VariantTag) -> Result<Self, Self::Error> {
-        let VariantTag(v) = value;
-        let [discriminant, rest] = v.to_be_bytes();
-        let typ = {
-            let typ = Self::from_repr(discriminant).ok_or_else(|| v)?;
-            match typ {
-                DfPredType::Constant(_) => {
-                    DfPredType::Constant(ConstantType::from_repr(rest).ok_or_else(|| v)?)
-                }
-                DfPredType::UnOp(_) => {
-                    DfPredType::UnOp(UnOpType::from_repr(rest).ok_or_else(|| v)?)
-                }
-                DfPredType::BinOp(_) => {
-                    DfPredType::BinOp(BinOpType::from_repr(rest).ok_or_else(|| v)?)
-                }
-                DfPredType::LogOp(_) => {
-                    DfPredType::LogOp(LogOpType::from_repr(rest).ok_or_else(|| v)?)
-                }
-                DfPredType::SortOrder(_) => {
-                    DfPredType::SortOrder(SortOrderType::from_repr(rest).ok_or_else(|| v)?)
-                }
-                _ => typ,
-            }
-        };
-
-        Ok(typ)
-    }
-}
-
-impl From<DfPredType> for VariantTag {
-    fn from(value: DfPredType) -> Self {
-        let discriminant = value.discriminant();
-        let rest = match value {
-            DfPredType::Constant(constant_type) => constant_type as u8,
-            DfPredType::UnOp(un_op_type) => un_op_type as u8,
-            DfPredType::BinOp(bin_op_type) => bin_op_type as u8,
-            DfPredType::LogOp(log_op_type) => log_op_type as u8,
-            DfPredType::SortOrder(sort_order_type) => sort_order_type as u8,
-            _ => 0,
-        };
-        VariantTag(u16::from_be_bytes([discriminant, rest]))
-    }
-}
-
-impl DfNodeType {
-    /// ## Serialization
-    /// A variant tag for [`DfNodeType`] has two parts. An `u8` discriminant
-    /// followed an `u8` extra field ([`JoinType`] for now), listed in big-endian order.
-    ///
-    /// ```
-    /// ----------------------------------------
-    /// | discriminant (u8) | extra field (u8) |
-    /// ----------------------------------------
-    /// ```
-    /// See https://doc.rust-lang.org/std/mem/fn.discriminant.html.
-    fn discriminant(&self) -> u8 {
-        // SAFETY: Because `Self` is marked `repr(u8)`, its layout is a `repr(C)` `union`
-        // between `repr(C)` structs, each of which has the `u8` discriminant as its first
-        // field, so we can read the discriminant without offsetting the pointer.
-        unsafe { *<*const _>::from(self).cast::<u8>() }
-    }
-}
-
-impl TryFrom<VariantTag> for DfNodeType {
-    type Error = u16;
-
-    fn try_from(value: VariantTag) -> Result<Self, Self::Error> {
-        let VariantTag(v) = value;
-        let [discriminant, rest] = v.to_be_bytes();
-        let typ = {
-            let typ = Self::from_repr(discriminant).ok_or_else(|| v)?;
-            match typ {
-                DfNodeType::Join(_) => {
-                    DfNodeType::Join(JoinType::from_repr(rest).ok_or_else(|| v)?)
-                }
-                DfNodeType::RawDepJoin(_) => {
-                    DfNodeType::RawDepJoin(JoinType::from_repr(rest).ok_or_else(|| v)?)
-                }
-                DfNodeType::DepJoin(_) => {
-                    DfNodeType::DepJoin(JoinType::from_repr(rest).ok_or_else(|| v)?)
-                }
-                DfNodeType::PhysicalHashJoin(_) => {
-                    DfNodeType::PhysicalHashJoin(JoinType::from_repr(rest).ok_or_else(|| v)?)
-                }
-                DfNodeType::PhysicalNestedLoopJoin(_) => {
-                    DfNodeType::PhysicalNestedLoopJoin(JoinType::from_repr(rest).ok_or_else(|| v)?)
-                }
-                _ => typ,
-            }
-        };
-        Ok(typ)
-    }
-}
-
-impl From<DfNodeType> for VariantTag {
-    fn from(value: DfNodeType) -> Self {
-        let discriminant = value.discriminant();
-        let rest = match value {
-            DfNodeType::Join(join_type) => join_type as u8,
-            DfNodeType::RawDepJoin(join_type) => join_type as u8,
-            DfNodeType::DepJoin(join_type) => join_type as u8,
-            DfNodeType::PhysicalHashJoin(join_type) => join_type as u8,
-            DfNodeType::PhysicalNestedLoopJoin(join_type) => join_type as u8,
-            _ => 0,
-        };
-        VariantTag(u16::from_be_bytes([discriminant, rest]))
-    }
 }

--- a/optd-datafusion-repr/src/plan_nodes.rs
+++ b/optd-datafusion-repr/src/plan_nodes.rs
@@ -63,63 +63,6 @@ pub enum DfPredType {
     InList,
 }
 
-impl DfPredType {
-    /// See https://doc.rust-lang.org/std/mem/fn.discriminant.html.
-    fn discriminant(&self) -> u8 {
-        // SAFETY: Because `Self` is marked `repr(u8)`, its layout is a `repr(C)` `union`
-        // between `repr(C)` structs, each of which has the `u8` discriminant as its first
-        // field, so we can read the discriminant without offsetting the pointer.
-        unsafe { *<*const _>::from(self).cast::<u8>() }
-    }
-}
-
-impl TryFrom<VariantTag> for DfPredType {
-    type Error = u16;
-
-    fn try_from(value: VariantTag) -> Result<Self, Self::Error> {
-        let VariantTag(v) = value;
-        let [discriminant, rest] = v.to_be_bytes();
-        let typ = {
-            let typ = Self::from_repr(discriminant).ok_or_else(|| v)?;
-            match typ {
-                DfPredType::Constant(_) => {
-                    DfPredType::Constant(ConstantType::from_repr(rest).ok_or_else(|| v)?)
-                }
-                DfPredType::UnOp(_) => {
-                    DfPredType::UnOp(UnOpType::from_repr(rest).ok_or_else(|| v)?)
-                }
-                DfPredType::BinOp(_) => {
-                    DfPredType::BinOp(BinOpType::from_repr(rest).ok_or_else(|| v)?)
-                }
-                DfPredType::LogOp(_) => {
-                    DfPredType::LogOp(LogOpType::from_repr(rest).ok_or_else(|| v)?)
-                }
-                DfPredType::SortOrder(_) => {
-                    DfPredType::SortOrder(SortOrderType::from_repr(rest).ok_or_else(|| v)?)
-                }
-                _ => typ,
-            }
-        };
-
-        Ok(typ)
-    }
-}
-
-impl From<DfPredType> for VariantTag {
-    fn from(value: DfPredType) -> Self {
-        let discriminant = (value.discriminant() as u16) << 8;
-        let tag = match value {
-            DfPredType::Constant(constant_type) => discriminant | constant_type as u16,
-            DfPredType::UnOp(un_op_type) => discriminant | un_op_type as u16,
-            DfPredType::BinOp(bin_op_type) => discriminant | bin_op_type as u16,
-            DfPredType::LogOp(log_op_type) => discriminant | log_op_type as u16,
-            DfPredType::SortOrder(sort_order_type) => discriminant | sort_order_type as u16,
-            _ => discriminant,
-        };
-        VariantTag(tag)
-    }
-}
-
 impl std::fmt::Display for DfPredType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self)
@@ -155,65 +98,9 @@ pub enum DfNodeType {
     PhysicalLimit,
 }
 
-impl DfNodeType {
-    /// See https://doc.rust-lang.org/std/mem/fn.discriminant.html.
-    fn discriminant(&self) -> u8 {
-        // SAFETY: Because `Self` is marked `repr(u8)`, its layout is a `repr(C)` `union`
-        // between `repr(C)` structs, each of which has the `u8` discriminant as its first
-        // field, so we can read the discriminant without offsetting the pointer.
-        unsafe { *<*const _>::from(self).cast::<u8>() }
-    }
-}
-
 impl std::fmt::Display for DfNodeType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self)
-    }
-}
-
-impl TryFrom<VariantTag> for DfNodeType {
-    type Error = u16;
-
-    fn try_from(value: VariantTag) -> Result<Self, Self::Error> {
-        let VariantTag(v) = value;
-        let [discriminant, rest] = v.to_be_bytes();
-        let typ = {
-            let typ = Self::from_repr(discriminant).ok_or_else(|| v)?;
-            match typ {
-                DfNodeType::Join(_) => {
-                    DfNodeType::Join(JoinType::from_repr(rest).ok_or_else(|| v)?)
-                }
-                DfNodeType::RawDepJoin(_) => {
-                    DfNodeType::RawDepJoin(JoinType::from_repr(rest).ok_or_else(|| v)?)
-                }
-                DfNodeType::DepJoin(_) => {
-                    DfNodeType::DepJoin(JoinType::from_repr(rest).ok_or_else(|| v)?)
-                }
-                DfNodeType::PhysicalHashJoin(_) => {
-                    DfNodeType::PhysicalHashJoin(JoinType::from_repr(rest).ok_or_else(|| v)?)
-                }
-                DfNodeType::PhysicalNestedLoopJoin(_) => {
-                    DfNodeType::PhysicalNestedLoopJoin(JoinType::from_repr(rest).ok_or_else(|| v)?)
-                }
-                _ => typ,
-            }
-        };
-        Ok(typ)
-    }
-}
-
-impl From<DfNodeType> for VariantTag {
-    fn from(value: DfNodeType) -> Self {
-        let discriminant = value.discriminant();
-        let rest = match value {
-            DfNodeType::Join(join_type) => join_type as u8,
-            DfNodeType::RawDepJoin(join_type) => join_type as u8,
-            DfNodeType::DepJoin(join_type) => join_type as u8,
-            DfNodeType::PhysicalHashJoin(join_type) => join_type as u8,
-            DfNodeType::PhysicalNestedLoopJoin(join_type) => join_type as u8,
-            _ => 0,
-        };
-        VariantTag(u16::from_be_bytes([discriminant, rest]))
     }
 }
 
@@ -327,4 +214,136 @@ pub fn dispatch_plan_explain_to_string(
     let mut out = String::new();
     config.unicode(&mut out, &plan_node.explain(meta_map));
     out
+}
+
+impl DfPredType {
+    /// ## Serialization
+    /// A variant tag for [`DfPredType`] has two parts. An `u8` discriminant
+    /// followed an `u8` extra field (could be [`ConstantType`], [`UnOpType`], etc.),
+    /// listed in big-endian order.
+    ///
+    /// ```
+    /// ----------------------------------------
+    /// | discriminant (u8) | extra field (u8) |
+    /// ----------------------------------------
+    /// ```
+    /// See https://doc.rust-lang.org/std/mem/fn.discriminant.html.
+    fn discriminant(&self) -> u8 {
+        // SAFETY: Because `Self` is marked `repr(u8)`, its layout is a `repr(C)` `union`
+        // between `repr(C)` structs, each of which has the `u8` discriminant as its first
+        // field, so we can read the discriminant without offsetting the pointer.
+        unsafe { *<*const _>::from(self).cast::<u8>() }
+    }
+}
+
+impl TryFrom<VariantTag> for DfPredType {
+    type Error = u16;
+
+    fn try_from(value: VariantTag) -> Result<Self, Self::Error> {
+        let VariantTag(v) = value;
+        let [discriminant, rest] = v.to_be_bytes();
+        let typ = {
+            let typ = Self::from_repr(discriminant).ok_or_else(|| v)?;
+            match typ {
+                DfPredType::Constant(_) => {
+                    DfPredType::Constant(ConstantType::from_repr(rest).ok_or_else(|| v)?)
+                }
+                DfPredType::UnOp(_) => {
+                    DfPredType::UnOp(UnOpType::from_repr(rest).ok_or_else(|| v)?)
+                }
+                DfPredType::BinOp(_) => {
+                    DfPredType::BinOp(BinOpType::from_repr(rest).ok_or_else(|| v)?)
+                }
+                DfPredType::LogOp(_) => {
+                    DfPredType::LogOp(LogOpType::from_repr(rest).ok_or_else(|| v)?)
+                }
+                DfPredType::SortOrder(_) => {
+                    DfPredType::SortOrder(SortOrderType::from_repr(rest).ok_or_else(|| v)?)
+                }
+                _ => typ,
+            }
+        };
+
+        Ok(typ)
+    }
+}
+
+impl From<DfPredType> for VariantTag {
+    fn from(value: DfPredType) -> Self {
+        let discriminant = value.discriminant();
+        let rest = match value {
+            DfPredType::Constant(constant_type) => constant_type as u8,
+            DfPredType::UnOp(un_op_type) => un_op_type as u8,
+            DfPredType::BinOp(bin_op_type) => bin_op_type as u8,
+            DfPredType::LogOp(log_op_type) => log_op_type as u8,
+            DfPredType::SortOrder(sort_order_type) => sort_order_type as u8,
+            _ => 0,
+        };
+        VariantTag(u16::from_be_bytes([discriminant, rest]))
+    }
+}
+
+impl DfNodeType {
+    /// ## Serialization
+    /// A variant tag for [`DfNodeType`] has two parts. An `u8` discriminant
+    /// followed an `u8` extra field ([`JoinType`] for now), listed in big-endian order.
+    ///
+    /// ```
+    /// ----------------------------------------
+    /// | discriminant (u8) | extra field (u8) |
+    /// ----------------------------------------
+    /// ```
+    /// See https://doc.rust-lang.org/std/mem/fn.discriminant.html.
+    fn discriminant(&self) -> u8 {
+        // SAFETY: Because `Self` is marked `repr(u8)`, its layout is a `repr(C)` `union`
+        // between `repr(C)` structs, each of which has the `u8` discriminant as its first
+        // field, so we can read the discriminant without offsetting the pointer.
+        unsafe { *<*const _>::from(self).cast::<u8>() }
+    }
+}
+
+impl TryFrom<VariantTag> for DfNodeType {
+    type Error = u16;
+
+    fn try_from(value: VariantTag) -> Result<Self, Self::Error> {
+        let VariantTag(v) = value;
+        let [discriminant, rest] = v.to_be_bytes();
+        let typ = {
+            let typ = Self::from_repr(discriminant).ok_or_else(|| v)?;
+            match typ {
+                DfNodeType::Join(_) => {
+                    DfNodeType::Join(JoinType::from_repr(rest).ok_or_else(|| v)?)
+                }
+                DfNodeType::RawDepJoin(_) => {
+                    DfNodeType::RawDepJoin(JoinType::from_repr(rest).ok_or_else(|| v)?)
+                }
+                DfNodeType::DepJoin(_) => {
+                    DfNodeType::DepJoin(JoinType::from_repr(rest).ok_or_else(|| v)?)
+                }
+                DfNodeType::PhysicalHashJoin(_) => {
+                    DfNodeType::PhysicalHashJoin(JoinType::from_repr(rest).ok_or_else(|| v)?)
+                }
+                DfNodeType::PhysicalNestedLoopJoin(_) => {
+                    DfNodeType::PhysicalNestedLoopJoin(JoinType::from_repr(rest).ok_or_else(|| v)?)
+                }
+                _ => typ,
+            }
+        };
+        Ok(typ)
+    }
+}
+
+impl From<DfNodeType> for VariantTag {
+    fn from(value: DfNodeType) -> Self {
+        let discriminant = value.discriminant();
+        let rest = match value {
+            DfNodeType::Join(join_type) => join_type as u8,
+            DfNodeType::RawDepJoin(join_type) => join_type as u8,
+            DfNodeType::DepJoin(join_type) => join_type as u8,
+            DfNodeType::PhysicalHashJoin(join_type) => join_type as u8,
+            DfNodeType::PhysicalNestedLoopJoin(join_type) => join_type as u8,
+            _ => 0,
+        };
+        VariantTag(u16::from_be_bytes([discriminant, rest]))
+    }
 }

--- a/optd-datafusion-repr/src/plan_nodes/join.rs
+++ b/optd-datafusion-repr/src/plan_nodes/join.rs
@@ -11,8 +11,12 @@ use serde::{Deserialize, Serialize};
 use super::macros::define_plan_node;
 use super::{ArcDfPlanNode, ArcDfPredNode, DfNodeType, DfPlanNode, DfReprPlanNode, ListPred};
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default, strum::FromRepr,
+)]
+#[repr(u8)]
 pub enum JoinType {
+    #[default]
     Inner = 1,
     FullOuter,
     LeftOuter,

--- a/optd-datafusion-repr/src/plan_nodes/join.rs
+++ b/optd-datafusion-repr/src/plan_nodes/join.rs
@@ -12,11 +12,20 @@ use super::macros::define_plan_node;
 use super::{ArcDfPlanNode, ArcDfPredNode, DfNodeType, DfPlanNode, DfReprPlanNode, ListPred};
 
 #[derive(
-    Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default, strum::FromRepr,
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    strum::FromRepr,
+    strum::EnumCount,
+    strum::EnumIter,
 )]
 #[repr(u8)]
 pub enum JoinType {
-    #[default]
     Inner = 1,
     FullOuter,
     LeftOuter,

--- a/optd-datafusion-repr/src/plan_nodes/predicates/bin_op_pred.rs
+++ b/optd-datafusion-repr/src/plan_nodes/predicates/bin_op_pred.rs
@@ -14,12 +14,20 @@ use crate::plan_nodes::{ArcDfPredNode, DfPredNode, DfPredType, DfReprPredNode};
 /// things I initially thought about splitting BinOpType into three "subenums". However, having two
 /// nested levels of     types leads to some really confusing code
 #[derive(
-    Copy, Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Default, strum::FromRepr,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    Debug,
+    Serialize,
+    Deserialize,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u8)]
 pub enum BinOpType {
     // numerical
-    #[default]
     Add,
     Sub,
     Mul,

--- a/optd-datafusion-repr/src/plan_nodes/predicates/bin_op_pred.rs
+++ b/optd-datafusion-repr/src/plan_nodes/predicates/bin_op_pred.rs
@@ -13,9 +13,13 @@ use crate::plan_nodes::{ArcDfPredNode, DfPredNode, DfPredType, DfReprPredNode};
 /// functions     to distinguish between them matches how datafusion::logical_expr::Operator does
 /// things I initially thought about splitting BinOpType into three "subenums". However, having two
 /// nested levels of     types leads to some really confusing code
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+#[derive(
+    Copy, Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Default, strum::FromRepr,
+)]
+#[repr(u8)]
 pub enum BinOpType {
     // numerical
+    #[default]
     Add,
     Sub,
     Mul,

--- a/optd-datafusion-repr/src/plan_nodes/predicates/constant_pred.rs
+++ b/optd-datafusion-repr/src/plan_nodes/predicates/constant_pred.rs
@@ -13,11 +13,19 @@ use serde::{Deserialize, Serialize};
 use crate::plan_nodes::{ArcDfPredNode, DfPredNode, DfPredType, DfReprPredNode};
 
 #[derive(
-    Copy, Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Default, strum::FromRepr,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    Debug,
+    Serialize,
+    Deserialize,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u8)]
 pub enum ConstantType {
-    #[default]
     Bool,
     Utf8String,
     UInt8,

--- a/optd-datafusion-repr/src/plan_nodes/predicates/constant_pred.rs
+++ b/optd-datafusion-repr/src/plan_nodes/predicates/constant_pred.rs
@@ -12,8 +12,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::plan_nodes::{ArcDfPredNode, DfPredNode, DfPredType, DfReprPredNode};
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+#[derive(
+    Copy, Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Default, strum::FromRepr,
+)]
+#[repr(u8)]
 pub enum ConstantType {
+    #[default]
     Bool,
     Utf8String,
     UInt8,

--- a/optd-datafusion-repr/src/plan_nodes/predicates/log_op_pred.rs
+++ b/optd-datafusion-repr/src/plan_nodes/predicates/log_op_pred.rs
@@ -12,8 +12,12 @@ use serde::{Deserialize, Serialize};
 use super::ListPred;
 use crate::plan_nodes::{ArcDfPredNode, DfPredNode, DfPredType, DfReprPredNode};
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+#[derive(
+    Copy, Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Default, strum::FromRepr,
+)]
+#[repr(u8)]
 pub enum LogOpType {
+    #[default]
     And,
     Or,
 }

--- a/optd-datafusion-repr/src/plan_nodes/predicates/log_op_pred.rs
+++ b/optd-datafusion-repr/src/plan_nodes/predicates/log_op_pred.rs
@@ -13,11 +13,19 @@ use super::ListPred;
 use crate::plan_nodes::{ArcDfPredNode, DfPredNode, DfPredType, DfReprPredNode};
 
 #[derive(
-    Copy, Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Default, strum::FromRepr,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    Debug,
+    Serialize,
+    Deserialize,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u8)]
 pub enum LogOpType {
-    #[default]
     And,
     Or,
 }

--- a/optd-datafusion-repr/src/plan_nodes/predicates/sort_order_pred.rs
+++ b/optd-datafusion-repr/src/plan_nodes/predicates/sort_order_pred.rs
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+use core::str;
 use std::fmt::Display;
 
 use optd_core::nodes::PlanNodeMetaMap;
@@ -12,11 +13,19 @@ use serde::{Deserialize, Serialize};
 use crate::plan_nodes::{ArcDfPredNode, DfPredNode, DfPredType, DfReprPredNode};
 
 #[derive(
-    Copy, Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Default, strum::FromRepr,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    Debug,
+    Serialize,
+    Deserialize,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u8)]
 pub enum SortOrderType {
-    #[default]
     Asc,
     Desc,
 }

--- a/optd-datafusion-repr/src/plan_nodes/predicates/sort_order_pred.rs
+++ b/optd-datafusion-repr/src/plan_nodes/predicates/sort_order_pred.rs
@@ -11,8 +11,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::plan_nodes::{ArcDfPredNode, DfPredNode, DfPredType, DfReprPredNode};
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+#[derive(
+    Copy, Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Default, strum::FromRepr,
+)]
+#[repr(u8)]
 pub enum SortOrderType {
+    #[default]
     Asc,
     Desc,
 }

--- a/optd-datafusion-repr/src/plan_nodes/predicates/un_op_pred.rs
+++ b/optd-datafusion-repr/src/plan_nodes/predicates/un_op_pred.rs
@@ -12,11 +12,19 @@ use serde::{Deserialize, Serialize};
 use crate::plan_nodes::{ArcDfPredNode, DfPredNode, DfPredType, DfReprPredNode};
 
 #[derive(
-    Copy, Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Default, strum::FromRepr,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    Debug,
+    Serialize,
+    Deserialize,
+    strum::FromRepr,
+    strum::EnumIter,
 )]
 #[repr(u8)]
 pub enum UnOpType {
-    #[default]
     Neg = 1,
     Not,
 }

--- a/optd-datafusion-repr/src/plan_nodes/predicates/un_op_pred.rs
+++ b/optd-datafusion-repr/src/plan_nodes/predicates/un_op_pred.rs
@@ -11,8 +11,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::plan_nodes::{ArcDfPredNode, DfPredNode, DfPredType, DfReprPredNode};
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+#[derive(
+    Copy, Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Default, strum::FromRepr,
+)]
+#[repr(u8)]
 pub enum UnOpType {
+    #[default]
     Neg = 1,
     Not,
 }

--- a/optd-datafusion-repr/src/plan_nodes/tag.rs
+++ b/optd-datafusion-repr/src/plan_nodes/tag.rs
@@ -1,4 +1,4 @@
-use optd_core::nodes::VariantTag;
+use optd_core::nodes::{SerializedNodeTag, SerializedPredTag};
 use serde::{Deserialize, Serialize};
 
 use super::{
@@ -30,7 +30,7 @@ use super::{
     strum::EnumCount,
 )]
 #[repr(u8)]
-enum DfPredTypeFlat {
+enum DfPredTypeFlattened {
     List,
     Constant,
     ColumnRef,
@@ -71,7 +71,7 @@ enum DfPredTypeFlat {
     strum::EnumCount,
 )]
 #[repr(u8)]
-pub enum DfNodeTypeFlat {
+pub enum DfNodeTypeFlattened {
     // Logical plan nodes
     Projection,
     Filter,
@@ -95,40 +95,40 @@ pub enum DfNodeTypeFlat {
     PhysicalLimit,
 }
 
-impl TryFrom<VariantTag> for DfPredType {
+impl TryFrom<SerializedPredTag> for DfPredType {
     type Error = u16;
 
-    fn try_from(value: VariantTag) -> Result<Self, Self::Error> {
-        let VariantTag(v) = value;
+    fn try_from(value: SerializedPredTag) -> Result<Self, Self::Error> {
+        let SerializedPredTag(v) = value;
         let [discriminant, rest] = v.to_be_bytes();
         let typ = {
-            let flat = DfPredTypeFlat::from_repr(discriminant).ok_or_else(|| v)?;
-            match flat {
-                DfPredTypeFlat::Constant => {
+            let flattened = DfPredTypeFlattened::from_repr(discriminant).ok_or_else(|| v)?;
+            match flattened {
+                DfPredTypeFlattened::Constant => {
                     DfPredType::Constant(ConstantType::from_repr(rest).ok_or_else(|| v)?)
                 }
 
-                DfPredTypeFlat::UnOp => {
+                DfPredTypeFlattened::UnOp => {
                     DfPredType::UnOp(UnOpType::from_repr(rest).ok_or_else(|| v)?)
                 }
-                DfPredTypeFlat::BinOp => {
+                DfPredTypeFlattened::BinOp => {
                     DfPredType::BinOp(BinOpType::from_repr(rest).ok_or_else(|| v)?)
                 }
-                DfPredTypeFlat::LogOp => {
+                DfPredTypeFlattened::LogOp => {
                     DfPredType::LogOp(LogOpType::from_repr(rest).ok_or_else(|| v)?)
                 }
-                DfPredTypeFlat::SortOrder => {
+                DfPredTypeFlattened::SortOrder => {
                     DfPredType::SortOrder(SortOrderType::from_repr(rest).ok_or_else(|| v)?)
                 }
-                DfPredTypeFlat::ColumnRef => DfPredType::ColumnRef,
-                DfPredTypeFlat::ExternColumnRef => DfPredType::ExternColumnRef,
-                DfPredTypeFlat::List => DfPredType::List,
-                DfPredTypeFlat::Func => DfPredType::Func,
-                DfPredTypeFlat::Between => DfPredType::Between,
-                DfPredTypeFlat::Cast => DfPredType::Cast,
-                DfPredTypeFlat::Like => DfPredType::Like,
-                DfPredTypeFlat::DataType => DfPredType::DataType,
-                DfPredTypeFlat::InList => DfPredType::InList,
+                DfPredTypeFlattened::ColumnRef => DfPredType::ColumnRef,
+                DfPredTypeFlattened::ExternColumnRef => DfPredType::ExternColumnRef,
+                DfPredTypeFlattened::List => DfPredType::List,
+                DfPredTypeFlattened::Func => DfPredType::Func,
+                DfPredTypeFlattened::Between => DfPredType::Between,
+                DfPredTypeFlattened::Cast => DfPredType::Cast,
+                DfPredTypeFlattened::Like => DfPredType::Like,
+                DfPredTypeFlattened::DataType => DfPredType::DataType,
+                DfPredTypeFlattened::InList => DfPredType::InList,
             }
         };
 
@@ -136,121 +136,127 @@ impl TryFrom<VariantTag> for DfPredType {
     }
 }
 
-impl From<DfPredType> for VariantTag {
+impl From<DfPredType> for SerializedPredTag {
     fn from(value: DfPredType) -> Self {
         let (discriminant, rest) = {
             match value {
                 DfPredType::Constant(constant_type) => {
-                    (DfPredTypeFlat::Constant as u8, constant_type as u8)
+                    (DfPredTypeFlattened::Constant as u8, constant_type as u8)
                 }
-                DfPredType::UnOp(un_op_type) => (DfPredTypeFlat::UnOp as u8, un_op_type as u8),
-                DfPredType::BinOp(bin_op_type) => (DfPredTypeFlat::BinOp as u8, bin_op_type as u8),
-                DfPredType::LogOp(log_op_type) => (DfPredTypeFlat::LogOp as u8, log_op_type as u8),
+                DfPredType::UnOp(un_op_type) => (DfPredTypeFlattened::UnOp as u8, un_op_type as u8),
+                DfPredType::BinOp(bin_op_type) => {
+                    (DfPredTypeFlattened::BinOp as u8, bin_op_type as u8)
+                }
+                DfPredType::LogOp(log_op_type) => {
+                    (DfPredTypeFlattened::LogOp as u8, log_op_type as u8)
+                }
                 DfPredType::SortOrder(sort_order_type) => {
-                    (DfPredTypeFlat::SortOrder as u8, sort_order_type as u8)
+                    (DfPredTypeFlattened::SortOrder as u8, sort_order_type as u8)
                 }
-                DfPredType::List => (DfPredTypeFlat::List as u8, 0),
-                DfPredType::ColumnRef => (DfPredTypeFlat::ColumnRef as u8, 0),
-                DfPredType::ExternColumnRef => (DfPredTypeFlat::ExternColumnRef as u8, 0),
-                DfPredType::Func => (DfPredTypeFlat::Func as u8, 0),
-                DfPredType::Between => (DfPredTypeFlat::Between as u8, 0),
-                DfPredType::Cast => (DfPredTypeFlat::Cast as u8, 0),
-                DfPredType::Like => (DfPredTypeFlat::Like as u8, 0),
-                DfPredType::DataType => (DfPredTypeFlat::DataType as u8, 0),
-                DfPredType::InList => (DfPredTypeFlat::InList as u8, 0),
+                DfPredType::List => (DfPredTypeFlattened::List as u8, 0),
+                DfPredType::ColumnRef => (DfPredTypeFlattened::ColumnRef as u8, 0),
+                DfPredType::ExternColumnRef => (DfPredTypeFlattened::ExternColumnRef as u8, 0),
+                DfPredType::Func => (DfPredTypeFlattened::Func as u8, 0),
+                DfPredType::Between => (DfPredTypeFlattened::Between as u8, 0),
+                DfPredType::Cast => (DfPredTypeFlattened::Cast as u8, 0),
+                DfPredType::Like => (DfPredTypeFlattened::Like as u8, 0),
+                DfPredType::DataType => (DfPredTypeFlattened::DataType as u8, 0),
+                DfPredType::InList => (DfPredTypeFlattened::InList as u8, 0),
             }
         };
-        VariantTag(u16::from_be_bytes([discriminant, rest]))
+        SerializedPredTag(u16::from_be_bytes([discriminant, rest]))
     }
 }
 
-impl TryFrom<VariantTag> for DfNodeType {
+impl TryFrom<SerializedNodeTag> for DfNodeType {
     type Error = u16;
 
-    fn try_from(value: VariantTag) -> Result<Self, Self::Error> {
-        let VariantTag(v) = value;
+    fn try_from(value: SerializedNodeTag) -> Result<Self, Self::Error> {
+        let SerializedNodeTag(v) = value;
         let [discriminant, rest] = v.to_be_bytes();
         let typ = {
-            let flat = DfNodeTypeFlat::from_repr(discriminant).ok_or_else(|| v)?;
-            match flat {
-                DfNodeTypeFlat::Join => {
+            let flattened = DfNodeTypeFlattened::from_repr(discriminant).ok_or_else(|| v)?;
+            match flattened {
+                DfNodeTypeFlattened::Join => {
                     DfNodeType::Join(JoinType::from_repr(rest).ok_or_else(|| v)?)
                 }
-                DfNodeTypeFlat::RawDepJoin => {
+                DfNodeTypeFlattened::RawDepJoin => {
                     DfNodeType::RawDepJoin(JoinType::from_repr(rest).ok_or_else(|| v)?)
                 }
-                DfNodeTypeFlat::DepJoin => {
+                DfNodeTypeFlattened::DepJoin => {
                     DfNodeType::DepJoin(JoinType::from_repr(rest).ok_or_else(|| v)?)
                 }
-                DfNodeTypeFlat::PhysicalHashJoin => {
+                DfNodeTypeFlattened::PhysicalHashJoin => {
                     DfNodeType::PhysicalHashJoin(JoinType::from_repr(rest).ok_or_else(|| v)?)
                 }
-                DfNodeTypeFlat::PhysicalNestedLoopJoin => {
+                DfNodeTypeFlattened::PhysicalNestedLoopJoin => {
                     DfNodeType::PhysicalNestedLoopJoin(JoinType::from_repr(rest).ok_or_else(|| v)?)
                 }
-                DfNodeTypeFlat::Projection => DfNodeType::Projection,
-                DfNodeTypeFlat::Filter => DfNodeType::Filter,
-                DfNodeTypeFlat::Scan => DfNodeType::Scan,
-                DfNodeTypeFlat::Sort => DfNodeType::Sort,
-                DfNodeTypeFlat::Agg => DfNodeType::Agg,
-                DfNodeTypeFlat::EmptyRelation => DfNodeType::EmptyRelation,
-                DfNodeTypeFlat::Limit => DfNodeType::Limit,
-                DfNodeTypeFlat::PhysicalProjection => DfNodeType::PhysicalProjection,
-                DfNodeTypeFlat::PhysicalFilter => DfNodeType::PhysicalFilter,
-                DfNodeTypeFlat::PhysicalScan => DfNodeType::PhysicalScan,
-                DfNodeTypeFlat::PhysicalSort => DfNodeType::PhysicalSort,
-                DfNodeTypeFlat::PhysicalAgg => DfNodeType::PhysicalAgg,
-                DfNodeTypeFlat::PhysicalEmptyRelation => DfNodeType::PhysicalEmptyRelation,
-                DfNodeTypeFlat::PhysicalLimit => DfNodeType::PhysicalLimit,
+                DfNodeTypeFlattened::Projection => DfNodeType::Projection,
+                DfNodeTypeFlattened::Filter => DfNodeType::Filter,
+                DfNodeTypeFlattened::Scan => DfNodeType::Scan,
+                DfNodeTypeFlattened::Sort => DfNodeType::Sort,
+                DfNodeTypeFlattened::Agg => DfNodeType::Agg,
+                DfNodeTypeFlattened::EmptyRelation => DfNodeType::EmptyRelation,
+                DfNodeTypeFlattened::Limit => DfNodeType::Limit,
+                DfNodeTypeFlattened::PhysicalProjection => DfNodeType::PhysicalProjection,
+                DfNodeTypeFlattened::PhysicalFilter => DfNodeType::PhysicalFilter,
+                DfNodeTypeFlattened::PhysicalScan => DfNodeType::PhysicalScan,
+                DfNodeTypeFlattened::PhysicalSort => DfNodeType::PhysicalSort,
+                DfNodeTypeFlattened::PhysicalAgg => DfNodeType::PhysicalAgg,
+                DfNodeTypeFlattened::PhysicalEmptyRelation => DfNodeType::PhysicalEmptyRelation,
+                DfNodeTypeFlattened::PhysicalLimit => DfNodeType::PhysicalLimit,
             }
         };
         Ok(typ)
     }
 }
 
-impl From<DfNodeType> for VariantTag {
+impl From<DfNodeType> for SerializedNodeTag {
     fn from(value: DfNodeType) -> Self {
         let (discriminant, rest) = match value {
-            DfNodeType::Join(join_type) => (DfNodeTypeFlat::Join as u8, join_type as u8),
+            DfNodeType::Join(join_type) => (DfNodeTypeFlattened::Join as u8, join_type as u8),
             DfNodeType::RawDepJoin(join_type) => {
-                (DfNodeTypeFlat::RawDepJoin as u8, join_type as u8)
+                (DfNodeTypeFlattened::RawDepJoin as u8, join_type as u8)
             }
-            DfNodeType::DepJoin(join_type) => (DfNodeTypeFlat::DepJoin as u8, join_type as u8),
+            DfNodeType::DepJoin(join_type) => (DfNodeTypeFlattened::DepJoin as u8, join_type as u8),
             DfNodeType::PhysicalHashJoin(join_type) => {
-                (DfNodeTypeFlat::PhysicalHashJoin as u8, join_type as u8)
+                (DfNodeTypeFlattened::PhysicalHashJoin as u8, join_type as u8)
             }
             DfNodeType::PhysicalNestedLoopJoin(join_type) => (
-                DfNodeTypeFlat::PhysicalNestedLoopJoin as u8,
+                DfNodeTypeFlattened::PhysicalNestedLoopJoin as u8,
                 join_type as u8,
             ),
-            DfNodeType::Projection => (DfNodeTypeFlat::Projection as u8, 0),
-            DfNodeType::Filter => (DfNodeTypeFlat::Filter as u8, 0),
-            DfNodeType::Scan => (DfNodeTypeFlat::Scan as u8, 0),
-            DfNodeType::Sort => (DfNodeTypeFlat::Sort as u8, 0),
-            DfNodeType::Agg => (DfNodeTypeFlat::Agg as u8, 0),
-            DfNodeType::EmptyRelation => (DfNodeTypeFlat::EmptyRelation as u8, 0),
-            DfNodeType::Limit => (DfNodeTypeFlat::Limit as u8, 0),
-            DfNodeType::PhysicalProjection => (DfNodeTypeFlat::PhysicalProjection as u8, 0),
-            DfNodeType::PhysicalFilter => (DfNodeTypeFlat::PhysicalFilter as u8, 0),
-            DfNodeType::PhysicalScan => (DfNodeTypeFlat::PhysicalScan as u8, 0),
-            DfNodeType::PhysicalSort => (DfNodeTypeFlat::PhysicalSort as u8, 0),
-            DfNodeType::PhysicalAgg => (DfNodeTypeFlat::PhysicalAgg as u8, 0),
-            DfNodeType::PhysicalEmptyRelation => (DfNodeTypeFlat::PhysicalEmptyRelation as u8, 0),
-            DfNodeType::PhysicalLimit => (DfNodeTypeFlat::PhysicalLimit as u8, 0),
+            DfNodeType::Projection => (DfNodeTypeFlattened::Projection as u8, 0),
+            DfNodeType::Filter => (DfNodeTypeFlattened::Filter as u8, 0),
+            DfNodeType::Scan => (DfNodeTypeFlattened::Scan as u8, 0),
+            DfNodeType::Sort => (DfNodeTypeFlattened::Sort as u8, 0),
+            DfNodeType::Agg => (DfNodeTypeFlattened::Agg as u8, 0),
+            DfNodeType::EmptyRelation => (DfNodeTypeFlattened::EmptyRelation as u8, 0),
+            DfNodeType::Limit => (DfNodeTypeFlattened::Limit as u8, 0),
+            DfNodeType::PhysicalProjection => (DfNodeTypeFlattened::PhysicalProjection as u8, 0),
+            DfNodeType::PhysicalFilter => (DfNodeTypeFlattened::PhysicalFilter as u8, 0),
+            DfNodeType::PhysicalScan => (DfNodeTypeFlattened::PhysicalScan as u8, 0),
+            DfNodeType::PhysicalSort => (DfNodeTypeFlattened::PhysicalSort as u8, 0),
+            DfNodeType::PhysicalAgg => (DfNodeTypeFlattened::PhysicalAgg as u8, 0),
+            DfNodeType::PhysicalEmptyRelation => {
+                (DfNodeTypeFlattened::PhysicalEmptyRelation as u8, 0)
+            }
+            DfNodeType::PhysicalLimit => (DfNodeTypeFlattened::PhysicalLimit as u8, 0),
         };
-        VariantTag(u16::from_be_bytes([discriminant, rest]))
+        SerializedNodeTag(u16::from_be_bytes([discriminant, rest]))
     }
 }
 
 #[cfg(test)]
-impl DfNodeTypeFlat {
+impl DfNodeTypeFlattened {
     fn is_join(&self) -> bool {
         match self {
-            DfNodeTypeFlat::Join
-            | DfNodeTypeFlat::RawDepJoin
-            | DfNodeTypeFlat::DepJoin
-            | DfNodeTypeFlat::PhysicalHashJoin
-            | DfNodeTypeFlat::PhysicalNestedLoopJoin => true,
+            DfNodeTypeFlattened::Join
+            | DfNodeTypeFlattened::RawDepJoin
+            | DfNodeTypeFlattened::DepJoin
+            | DfNodeTypeFlattened::PhysicalHashJoin
+            | DfNodeTypeFlattened::PhysicalNestedLoopJoin => true,
             _ => false,
         }
     }
@@ -267,22 +273,25 @@ mod tests {
     fn test_df_node_type_to_tag_e2e() {
         let mut valid_tags = Vec::new();
         let mut invalid_tags = Vec::new();
-        for flattened in DfNodeTypeFlat::iter() {
+        for flattened in DfNodeTypeFlattened::iter() {
             let discriminant = flattened as u8;
             if flattened.is_join() {
                 for join_type in JoinType::iter() {
-                    valid_tags.push(VariantTag(u16::from_be_bytes([
+                    valid_tags.push(SerializedNodeTag(u16::from_be_bytes([
                         discriminant,
                         join_type as u8,
                     ])));
                 }
-                invalid_tags.push(VariantTag(u16::from_be_bytes([discriminant, u8::MAX])));
+                invalid_tags.push(SerializedNodeTag(u16::from_be_bytes([
+                    discriminant,
+                    u8::MAX,
+                ])));
             } else {
-                valid_tags.push(VariantTag(u16::from_be_bytes([discriminant, 0])));
+                valid_tags.push(SerializedNodeTag(u16::from_be_bytes([discriminant, 0])));
             }
         }
-        invalid_tags.push(VariantTag(u16::from_be_bytes([
-            DfNodeTypeFlat::COUNT as u8,
+        invalid_tags.push(SerializedNodeTag(u16::from_be_bytes([
+            DfNodeTypeFlattened::COUNT as u8,
             0,
         ])));
 
@@ -291,7 +300,7 @@ mod tests {
         });
 
         valid_tags.iter().for_each(|&tag| {
-            let new_tag = VariantTag::from(DfNodeType::try_from(tag).unwrap());
+            let new_tag = SerializedNodeTag::from(DfNodeType::try_from(tag).unwrap());
             assert_eq!(tag, new_tag);
         });
 
@@ -309,59 +318,74 @@ mod tests {
     fn test_df_pred_type_to_tag_e2e() {
         let mut valid_tags = Vec::new();
         let mut invalid_tags = Vec::new();
-        for flattened in DfPredTypeFlat::iter() {
+        for flattened in DfPredTypeFlattened::iter() {
             let discriminant = flattened as u8;
             match flattened {
-                DfPredTypeFlat::Constant => {
+                DfPredTypeFlattened::Constant => {
                     for constant_type in ConstantType::iter() {
-                        valid_tags.push(VariantTag(u16::from_be_bytes([
+                        valid_tags.push(SerializedPredTag(u16::from_be_bytes([
                             discriminant,
                             constant_type as u8,
                         ])));
                     }
-                    invalid_tags.push(VariantTag(u16::from_be_bytes([discriminant, u8::MAX])));
+                    invalid_tags.push(SerializedPredTag(u16::from_be_bytes([
+                        discriminant,
+                        u8::MAX,
+                    ])));
                 }
-                DfPredTypeFlat::UnOp => {
+                DfPredTypeFlattened::UnOp => {
                     for un_op_type in UnOpType::iter() {
-                        valid_tags.push(VariantTag(u16::from_be_bytes([
+                        valid_tags.push(SerializedPredTag(u16::from_be_bytes([
                             discriminant,
                             un_op_type as u8,
                         ])));
                     }
-                    invalid_tags.push(VariantTag(u16::from_be_bytes([discriminant, u8::MAX])));
+                    invalid_tags.push(SerializedPredTag(u16::from_be_bytes([
+                        discriminant,
+                        u8::MAX,
+                    ])));
                 }
-                DfPredTypeFlat::BinOp => {
+                DfPredTypeFlattened::BinOp => {
                     for bin_op_type in BinOpType::iter() {
-                        valid_tags.push(VariantTag(u16::from_be_bytes([
+                        valid_tags.push(SerializedPredTag(u16::from_be_bytes([
                             discriminant,
                             bin_op_type as u8,
                         ])));
                     }
-                    invalid_tags.push(VariantTag(u16::from_be_bytes([discriminant, u8::MAX])));
+                    invalid_tags.push(SerializedPredTag(u16::from_be_bytes([
+                        discriminant,
+                        u8::MAX,
+                    ])));
                 }
-                DfPredTypeFlat::LogOp => {
+                DfPredTypeFlattened::LogOp => {
                     for log_op_type in LogOpType::iter() {
-                        valid_tags.push(VariantTag(u16::from_be_bytes([
+                        valid_tags.push(SerializedPredTag(u16::from_be_bytes([
                             discriminant,
                             log_op_type as u8,
                         ])));
                     }
-                    invalid_tags.push(VariantTag(u16::from_be_bytes([discriminant, u8::MAX])));
+                    invalid_tags.push(SerializedPredTag(u16::from_be_bytes([
+                        discriminant,
+                        u8::MAX,
+                    ])));
                 }
-                DfPredTypeFlat::SortOrder => {
+                DfPredTypeFlattened::SortOrder => {
                     for sort_order_type in SortOrderType::iter() {
-                        valid_tags.push(VariantTag(u16::from_be_bytes([
+                        valid_tags.push(SerializedPredTag(u16::from_be_bytes([
                             discriminant,
                             sort_order_type as u8,
                         ])));
                     }
-                    invalid_tags.push(VariantTag(u16::from_be_bytes([discriminant, u8::MAX])));
+                    invalid_tags.push(SerializedPredTag(u16::from_be_bytes([
+                        discriminant,
+                        u8::MAX,
+                    ])));
                 }
-                _ => valid_tags.push(VariantTag(u16::from_be_bytes([discriminant, 0]))),
+                _ => valid_tags.push(SerializedPredTag(u16::from_be_bytes([discriminant, 0]))),
             }
         }
-        invalid_tags.push(VariantTag(u16::from_be_bytes([
-            DfPredTypeFlat::COUNT as u8,
+        invalid_tags.push(SerializedPredTag(u16::from_be_bytes([
+            DfPredTypeFlattened::COUNT as u8,
             0,
         ])));
 
@@ -370,7 +394,7 @@ mod tests {
         });
 
         valid_tags.iter().for_each(|&tag| {
-            let new_tag = VariantTag::from(DfPredType::try_from(tag).unwrap());
+            let new_tag = SerializedPredTag::from(DfPredType::try_from(tag).unwrap());
             assert_eq!(tag, new_tag);
         });
 

--- a/optd-datafusion-repr/src/plan_nodes/tag.rs
+++ b/optd-datafusion-repr/src/plan_nodes/tag.rs
@@ -1,0 +1,386 @@
+use optd_core::nodes::VariantTag;
+use serde::{Deserialize, Serialize};
+
+use super::{
+    BinOpType, ConstantType, DfNodeType, DfPredType, JoinType, LogOpType, SortOrderType, UnOpType,
+};
+
+/// ## Serialization
+/// A variant tag for [`DfPredType`] has two parts. An `u8` discriminant
+/// followed an `u8` extra field (could be [`ConstantType`], [`UnOpType`], etc.),
+/// listed in big-endian order.
+///
+/// ```
+/// ----------------------------------------
+/// | discriminant (u8) | extra field (u8) |
+/// ----------------------------------------
+/// ```
+/// See https://doc.rust-lang.org/std/mem/fn.discriminant.html.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    strum::FromRepr,
+    strum::EnumIter,
+    strum::EnumCount,
+)]
+#[repr(u8)]
+enum DfPredTypeFlat {
+    List,
+    Constant,
+    ColumnRef,
+    ExternColumnRef,
+    UnOp,
+    BinOp,
+    LogOp,
+    Func,
+    SortOrder,
+    Between,
+    Cast,
+    Like,
+    DataType,
+    InList,
+}
+
+/// ## Serialization
+/// A variant tag for [`DfNodeType`] has two parts. An `u8` discriminant
+/// followed an `u8` extra field ([`JoinType`] for now), listed in big-endian order.
+///
+/// ```
+/// ----------------------------------------
+/// | discriminant (u8) | extra field (u8) |
+/// ----------------------------------------
+/// ```
+/// See https://doc.rust-lang.org/std/mem/fn.discriminant.html.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    strum::FromRepr,
+    strum::EnumIter,
+    strum::EnumCount,
+)]
+#[repr(u8)]
+pub enum DfNodeTypeFlat {
+    // Logical plan nodes
+    Projection,
+    Filter,
+    Scan,
+    Join,
+    RawDepJoin,
+    DepJoin,
+    Sort,
+    Agg,
+    EmptyRelation,
+    Limit,
+    // Physical plan nodes
+    PhysicalProjection,
+    PhysicalFilter,
+    PhysicalScan,
+    PhysicalSort,
+    PhysicalAgg,
+    PhysicalHashJoin,
+    PhysicalNestedLoopJoin,
+    PhysicalEmptyRelation,
+    PhysicalLimit,
+}
+
+impl TryFrom<VariantTag> for DfPredType {
+    type Error = u16;
+
+    fn try_from(value: VariantTag) -> Result<Self, Self::Error> {
+        let VariantTag(v) = value;
+        let [discriminant, rest] = v.to_be_bytes();
+        let typ = {
+            let flat = DfPredTypeFlat::from_repr(discriminant).ok_or_else(|| v)?;
+            match flat {
+                DfPredTypeFlat::Constant => {
+                    DfPredType::Constant(ConstantType::from_repr(rest).ok_or_else(|| v)?)
+                }
+
+                DfPredTypeFlat::UnOp => {
+                    DfPredType::UnOp(UnOpType::from_repr(rest).ok_or_else(|| v)?)
+                }
+                DfPredTypeFlat::BinOp => {
+                    DfPredType::BinOp(BinOpType::from_repr(rest).ok_or_else(|| v)?)
+                }
+                DfPredTypeFlat::LogOp => {
+                    DfPredType::LogOp(LogOpType::from_repr(rest).ok_or_else(|| v)?)
+                }
+                DfPredTypeFlat::SortOrder => {
+                    DfPredType::SortOrder(SortOrderType::from_repr(rest).ok_or_else(|| v)?)
+                }
+                DfPredTypeFlat::ColumnRef => DfPredType::ColumnRef,
+                DfPredTypeFlat::ExternColumnRef => DfPredType::ExternColumnRef,
+                DfPredTypeFlat::List => DfPredType::List,
+                DfPredTypeFlat::Func => DfPredType::Func,
+                DfPredTypeFlat::Between => DfPredType::Between,
+                DfPredTypeFlat::Cast => DfPredType::Cast,
+                DfPredTypeFlat::Like => DfPredType::Like,
+                DfPredTypeFlat::DataType => DfPredType::DataType,
+                DfPredTypeFlat::InList => DfPredType::InList,
+            }
+        };
+
+        Ok(typ)
+    }
+}
+
+impl From<DfPredType> for VariantTag {
+    fn from(value: DfPredType) -> Self {
+        let (discriminant, rest) = {
+            match value {
+                DfPredType::Constant(constant_type) => {
+                    (DfPredTypeFlat::Constant as u8, constant_type as u8)
+                }
+                DfPredType::UnOp(un_op_type) => (DfPredTypeFlat::UnOp as u8, un_op_type as u8),
+                DfPredType::BinOp(bin_op_type) => (DfPredTypeFlat::BinOp as u8, bin_op_type as u8),
+                DfPredType::LogOp(log_op_type) => (DfPredTypeFlat::LogOp as u8, log_op_type as u8),
+                DfPredType::SortOrder(sort_order_type) => {
+                    (DfPredTypeFlat::SortOrder as u8, sort_order_type as u8)
+                }
+                DfPredType::List => (DfPredTypeFlat::List as u8, 0),
+                DfPredType::ColumnRef => (DfPredTypeFlat::ColumnRef as u8, 0),
+                DfPredType::ExternColumnRef => (DfPredTypeFlat::ExternColumnRef as u8, 0),
+                DfPredType::Func => (DfPredTypeFlat::Func as u8, 0),
+                DfPredType::Between => (DfPredTypeFlat::Between as u8, 0),
+                DfPredType::Cast => (DfPredTypeFlat::Cast as u8, 0),
+                DfPredType::Like => (DfPredTypeFlat::Like as u8, 0),
+                DfPredType::DataType => (DfPredTypeFlat::DataType as u8, 0),
+                DfPredType::InList => (DfPredTypeFlat::InList as u8, 0),
+            }
+        };
+        VariantTag(u16::from_be_bytes([discriminant, rest]))
+    }
+}
+
+impl TryFrom<VariantTag> for DfNodeType {
+    type Error = u16;
+
+    fn try_from(value: VariantTag) -> Result<Self, Self::Error> {
+        let VariantTag(v) = value;
+        let [discriminant, rest] = v.to_be_bytes();
+        let typ = {
+            let flat = DfNodeTypeFlat::from_repr(discriminant).ok_or_else(|| v)?;
+            match flat {
+                DfNodeTypeFlat::Join => {
+                    DfNodeType::Join(JoinType::from_repr(rest).ok_or_else(|| v)?)
+                }
+                DfNodeTypeFlat::RawDepJoin => {
+                    DfNodeType::RawDepJoin(JoinType::from_repr(rest).ok_or_else(|| v)?)
+                }
+                DfNodeTypeFlat::DepJoin => {
+                    DfNodeType::DepJoin(JoinType::from_repr(rest).ok_or_else(|| v)?)
+                }
+                DfNodeTypeFlat::PhysicalHashJoin => {
+                    DfNodeType::PhysicalHashJoin(JoinType::from_repr(rest).ok_or_else(|| v)?)
+                }
+                DfNodeTypeFlat::PhysicalNestedLoopJoin => {
+                    DfNodeType::PhysicalNestedLoopJoin(JoinType::from_repr(rest).ok_or_else(|| v)?)
+                }
+                DfNodeTypeFlat::Projection => DfNodeType::Projection,
+                DfNodeTypeFlat::Filter => DfNodeType::Filter,
+                DfNodeTypeFlat::Scan => DfNodeType::Scan,
+                DfNodeTypeFlat::Sort => DfNodeType::Sort,
+                DfNodeTypeFlat::Agg => DfNodeType::Agg,
+                DfNodeTypeFlat::EmptyRelation => DfNodeType::EmptyRelation,
+                DfNodeTypeFlat::Limit => DfNodeType::Limit,
+                DfNodeTypeFlat::PhysicalProjection => DfNodeType::PhysicalProjection,
+                DfNodeTypeFlat::PhysicalFilter => DfNodeType::PhysicalFilter,
+                DfNodeTypeFlat::PhysicalScan => DfNodeType::PhysicalScan,
+                DfNodeTypeFlat::PhysicalSort => DfNodeType::PhysicalSort,
+                DfNodeTypeFlat::PhysicalAgg => DfNodeType::PhysicalAgg,
+                DfNodeTypeFlat::PhysicalEmptyRelation => DfNodeType::PhysicalEmptyRelation,
+                DfNodeTypeFlat::PhysicalLimit => DfNodeType::PhysicalLimit,
+            }
+        };
+        Ok(typ)
+    }
+}
+
+impl From<DfNodeType> for VariantTag {
+    fn from(value: DfNodeType) -> Self {
+        let (discriminant, rest) = match value {
+            DfNodeType::Join(join_type) => (DfNodeTypeFlat::Join as u8, join_type as u8),
+            DfNodeType::RawDepJoin(join_type) => {
+                (DfNodeTypeFlat::RawDepJoin as u8, join_type as u8)
+            }
+            DfNodeType::DepJoin(join_type) => (DfNodeTypeFlat::DepJoin as u8, join_type as u8),
+            DfNodeType::PhysicalHashJoin(join_type) => {
+                (DfNodeTypeFlat::PhysicalHashJoin as u8, join_type as u8)
+            }
+            DfNodeType::PhysicalNestedLoopJoin(join_type) => (
+                DfNodeTypeFlat::PhysicalNestedLoopJoin as u8,
+                join_type as u8,
+            ),
+            DfNodeType::Projection => (DfNodeTypeFlat::Projection as u8, 0),
+            DfNodeType::Filter => (DfNodeTypeFlat::Filter as u8, 0),
+            DfNodeType::Scan => (DfNodeTypeFlat::Scan as u8, 0),
+            DfNodeType::Sort => (DfNodeTypeFlat::Sort as u8, 0),
+            DfNodeType::Agg => (DfNodeTypeFlat::Agg as u8, 0),
+            DfNodeType::EmptyRelation => (DfNodeTypeFlat::EmptyRelation as u8, 0),
+            DfNodeType::Limit => (DfNodeTypeFlat::Limit as u8, 0),
+            DfNodeType::PhysicalProjection => (DfNodeTypeFlat::PhysicalProjection as u8, 0),
+            DfNodeType::PhysicalFilter => (DfNodeTypeFlat::PhysicalFilter as u8, 0),
+            DfNodeType::PhysicalScan => (DfNodeTypeFlat::PhysicalScan as u8, 0),
+            DfNodeType::PhysicalSort => (DfNodeTypeFlat::PhysicalSort as u8, 0),
+            DfNodeType::PhysicalAgg => (DfNodeTypeFlat::PhysicalAgg as u8, 0),
+            DfNodeType::PhysicalEmptyRelation => (DfNodeTypeFlat::PhysicalEmptyRelation as u8, 0),
+            DfNodeType::PhysicalLimit => (DfNodeTypeFlat::PhysicalLimit as u8, 0),
+        };
+        VariantTag(u16::from_be_bytes([discriminant, rest]))
+    }
+}
+
+#[cfg(test)]
+impl DfNodeTypeFlat {
+    fn is_join(&self) -> bool {
+        match self {
+            DfNodeTypeFlat::Join
+            | DfNodeTypeFlat::RawDepJoin
+            | DfNodeTypeFlat::DepJoin
+            | DfNodeTypeFlat::PhysicalHashJoin
+            | DfNodeTypeFlat::PhysicalNestedLoopJoin => true,
+            _ => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use itertools::Itertools;
+    use strum::{EnumCount, IntoEnumIterator};
+
+    use super::*;
+
+    #[test]
+    fn test_df_node_type_to_tag_e2e() {
+        let mut valid_tags = Vec::new();
+        let mut invalid_tags = Vec::new();
+        for flattened in DfNodeTypeFlat::iter() {
+            let discriminant = flattened as u8;
+            if flattened.is_join() {
+                for join_type in JoinType::iter() {
+                    valid_tags.push(VariantTag(u16::from_be_bytes([
+                        discriminant,
+                        join_type as u8,
+                    ])));
+                }
+                invalid_tags.push(VariantTag(u16::from_be_bytes([discriminant, u8::MAX])));
+            } else {
+                valid_tags.push(VariantTag(u16::from_be_bytes([discriminant, 0])));
+            }
+        }
+        invalid_tags.push(VariantTag(u16::from_be_bytes([
+            DfNodeTypeFlat::COUNT as u8,
+            0,
+        ])));
+
+        invalid_tags.into_iter().for_each(|tag| {
+            DfNodeType::try_from(tag).unwrap_err();
+        });
+
+        valid_tags.iter().for_each(|&tag| {
+            let new_tag = VariantTag::from(DfNodeType::try_from(tag).unwrap());
+            assert_eq!(tag, new_tag);
+        });
+
+        valid_tags.into_iter().combinations(2).for_each(|x| {
+            let a = x[0];
+            let b = x[1];
+            assert_ne!(a, b);
+            let a = DfNodeType::try_from(a).unwrap();
+            let b = DfNodeType::try_from(b).unwrap();
+            assert_ne!(a, b);
+        });
+    }
+
+    #[test]
+    fn test_df_pred_type_to_tag_e2e() {
+        let mut valid_tags = Vec::new();
+        let mut invalid_tags = Vec::new();
+        for flattened in DfPredTypeFlat::iter() {
+            let discriminant = flattened as u8;
+            match flattened {
+                DfPredTypeFlat::Constant => {
+                    for constant_type in ConstantType::iter() {
+                        valid_tags.push(VariantTag(u16::from_be_bytes([
+                            discriminant,
+                            constant_type as u8,
+                        ])));
+                    }
+                    invalid_tags.push(VariantTag(u16::from_be_bytes([discriminant, u8::MAX])));
+                }
+                DfPredTypeFlat::UnOp => {
+                    for un_op_type in UnOpType::iter() {
+                        valid_tags.push(VariantTag(u16::from_be_bytes([
+                            discriminant,
+                            un_op_type as u8,
+                        ])));
+                    }
+                    invalid_tags.push(VariantTag(u16::from_be_bytes([discriminant, u8::MAX])));
+                }
+                DfPredTypeFlat::BinOp => {
+                    for bin_op_type in BinOpType::iter() {
+                        valid_tags.push(VariantTag(u16::from_be_bytes([
+                            discriminant,
+                            bin_op_type as u8,
+                        ])));
+                    }
+                    invalid_tags.push(VariantTag(u16::from_be_bytes([discriminant, u8::MAX])));
+                }
+                DfPredTypeFlat::LogOp => {
+                    for log_op_type in LogOpType::iter() {
+                        valid_tags.push(VariantTag(u16::from_be_bytes([
+                            discriminant,
+                            log_op_type as u8,
+                        ])));
+                    }
+                    invalid_tags.push(VariantTag(u16::from_be_bytes([discriminant, u8::MAX])));
+                }
+                DfPredTypeFlat::SortOrder => {
+                    for sort_order_type in SortOrderType::iter() {
+                        valid_tags.push(VariantTag(u16::from_be_bytes([
+                            discriminant,
+                            sort_order_type as u8,
+                        ])));
+                    }
+                    invalid_tags.push(VariantTag(u16::from_be_bytes([discriminant, u8::MAX])));
+                }
+                _ => valid_tags.push(VariantTag(u16::from_be_bytes([discriminant, 0]))),
+            }
+        }
+        invalid_tags.push(VariantTag(u16::from_be_bytes([
+            DfPredTypeFlat::COUNT as u8,
+            0,
+        ])));
+
+        invalid_tags.into_iter().for_each(|tag| {
+            DfPredType::try_from(tag).unwrap_err();
+        });
+
+        valid_tags.iter().for_each(|&tag| {
+            let new_tag = VariantTag::from(DfPredType::try_from(tag).unwrap());
+            assert_eq!(tag, new_tag);
+        });
+
+        valid_tags.into_iter().combinations(2).for_each(|x| {
+            let a = x[0];
+            let b = x[1];
+            assert_ne!(a, b);
+            let a = DfPredType::try_from(a).unwrap();
+            let b = DfPredType::try_from(b).unwrap();
+            assert_ne!(a, b);
+        });
+    }
+}

--- a/optd-datafusion-repr/src/properties/schema.rs
+++ b/optd-datafusion-repr/src/properties/schema.rs
@@ -9,7 +9,6 @@ use arrow_schema::DataType;
 use itertools::Itertools;
 use optd_core::logical_property::{LogicalProperty, LogicalPropertyBuilder};
 use serde::{Deserialize, Serialize};
-use tracing_subscriber::registry::Data;
 
 use super::DEFAULT_NAME;
 use crate::plan_nodes::{


### PR DESCRIPTION
Serialize NodeType and PredType into variant tag (u16/i16).

- Added `strum` for helping with repr conversion.
- Arguably a lot of things can be simplified using a declarative macro.
- Added unit test `test_df_node_type_to_tag_e2e` and `test_df_pred_type_to_tag_e2e`.