### PR TITLE
refactor(core): rm option around cost models

### DIFF
--- a/docs/src/cost_model.md
+++ b/docs/src/cost_model.md
@@ -11,7 +11,7 @@ pub trait CostModel<T: RelNodeTyp>: 'static + Send + Sync {
             node: &T,
             data: &Option<Value>,
             children: &[Cost],
-            context: Option<RelNodeContext>,
+            context: RelNodeContext,
     ) -> Cost;
 }
 ```

--- a/optd-core/src/cascades/tasks/optimize_inputs.rs
+++ b/optd-core/src/cascades/tasks/optimize_inputs.rs
@@ -110,12 +110,12 @@ impl OptimizeInputsTask {
                     .iter()
                     .map(|x| x.expect("child winner should always have statistics?"))
                     .collect::<Vec<_>>(),
-                Some(RelNodeContext {
+                RelNodeContext {
                     group_id,
                     expr_id: self.expr_id,
                     children_group_ids: expr.children.clone(),
-                }),
-                Some(optimizer),
+                },
+                optimizer,
             );
             optimizer.update_group_info(
                 group_id,
@@ -197,8 +197,8 @@ impl<T: NodeType, M: Memo<T>> Task<T, M> for OptimizeInputsTask {
                 &expr.typ,
                 &preds,
                 &input_statistics_ref,
-                Some(context.clone()),
-                Some(optimizer),
+                context.clone(),
+                optimizer,
             );
             let total_cost = cost.sum(&operation_cost, &input_cost);
 

--- a/optd-core/src/cost.rs
+++ b/optd-core/src/cost.rs
@@ -16,25 +16,29 @@ pub struct Statistics(pub Box<dyn std::any::Any + Send + Sync + 'static>);
 pub struct Cost(pub Vec<f64>);
 
 pub trait CostModel<T: NodeType, M: Memo<T>>: 'static + Send + Sync {
-    /// Compute the cost of a single operation
+    /// Compute the cost of a single operation. `RelNodeContext` might be
+    /// optional in the future when we implement physical property enforcers.
+    /// If we have not decided the winner for a child group yet, the statistics
+    /// for that group will be `None`.
     #[allow(clippy::too_many_arguments)]
     fn compute_operation_cost(
         &self,
         node: &T,
         predicates: &[ArcPredNode<T>],
         children_stats: &[Option<&Statistics>],
-        context: Option<RelNodeContext>,
-        optimizer: Option<&CascadesOptimizer<T, M>>,
+        context: RelNodeContext,
+        optimizer: &CascadesOptimizer<T, M>,
     ) -> Cost;
 
-    /// Derive the statistics of a single operation
+    /// Derive the statistics of a single operation. `RelNodeContext` might be
+    /// optional in the future when we implement physical property enforcers.
     fn derive_statistics(
         &self,
         node: &T,
         predicates: &[ArcPredNode<T>],
         children_stats: &[&Statistics],
-        context: Option<RelNodeContext>,
-        optimizer: Option<&CascadesOptimizer<T, M>>,
+        context: RelNodeContext,
+        optimizer: &CascadesOptimizer<T, M>,
     ) -> Statistics;
 
     fn explain_cost(&self, cost: &Cost) -> String;

--- a/optd-datafusion-repr/src/cost/adaptive_cost.rs
+++ b/optd-datafusion-repr/src/cost/adaptive_cost.rs
@@ -28,11 +28,9 @@ pub struct AdaptiveCostModel {
 }
 
 impl AdaptiveCostModel {
-    fn get_row_cnt(&self, context: &Option<RelNodeContext>) -> f64 {
+    fn get_row_cnt(&self, context: &RelNodeContext) -> f64 {
         let guard = self.runtime_row_cnt.lock().unwrap();
-        if let Some((runtime_row_cnt, iter)) =
-            guard.history.get(&context.as_ref().unwrap().group_id)
-        {
+        if let Some((runtime_row_cnt, iter)) = guard.history.get(&context.group_id) {
             if *iter + self.decay >= guard.iter_cnt {
                 return (*runtime_row_cnt).max(1) as f64;
             }
@@ -67,8 +65,8 @@ impl CostModel<DfNodeType, NaiveMemo<DfNodeType>> for AdaptiveCostModel {
         node: &DfNodeType,
         predicates: &[ArcDfPredNode],
         children: &[Option<&Statistics>],
-        context: Option<RelNodeContext>,
-        optimizer: Option<&CascadesOptimizer<DfNodeType>>,
+        context: RelNodeContext,
+        optimizer: &CascadesOptimizer<DfNodeType>,
     ) -> Cost {
         if let DfNodeType::PhysicalScan = node {
             let row_cnt = self.get_row_cnt(&context);
@@ -83,8 +81,8 @@ impl CostModel<DfNodeType, NaiveMemo<DfNodeType>> for AdaptiveCostModel {
         node: &DfNodeType,
         predicates: &[ArcDfPredNode],
         children: &[&Statistics],
-        context: Option<RelNodeContext>,
-        optimizer: Option<&CascadesOptimizer<DfNodeType>>,
+        context: RelNodeContext,
+        optimizer: &CascadesOptimizer<DfNodeType>,
     ) -> Statistics {
         if let DfNodeType::PhysicalScan = node {
             let row_cnt = self.get_row_cnt(&context);

--- a/optd-datafusion-repr/src/cost/base_cost.rs
+++ b/optd-datafusion-repr/src/cost/base_cost.rs
@@ -89,8 +89,8 @@ impl CostModel<DfNodeType, NaiveMemo<DfNodeType>> for DfCostModel {
         node: &DfNodeType,
         predicates: &[ArcDfPredNode],
         children: &[&Statistics],
-        _context: Option<RelNodeContext>,
-        _optimizer: Option<&CascadesOptimizer<DfNodeType>>,
+        _context: RelNodeContext,
+        _optimizer: &CascadesOptimizer<DfNodeType>,
     ) -> Statistics {
         match node {
             DfNodeType::PhysicalScan => {
@@ -132,8 +132,8 @@ impl CostModel<DfNodeType, NaiveMemo<DfNodeType>> for DfCostModel {
         node: &DfNodeType,
         predicates: &[ArcDfPredNode],
         children: &[Option<&Statistics>],
-        _context: Option<RelNodeContext>,
-        _optimizer: Option<&CascadesOptimizer<DfNodeType>>,
+        _context: RelNodeContext,
+        _optimizer: &CascadesOptimizer<DfNodeType>,
     ) -> Cost {
         let row_cnts = children
             .iter()

--- a/optd-datafusion-repr/src/testing/dummy_cost.rs
+++ b/optd-datafusion-repr/src/testing/dummy_cost.rs
@@ -19,8 +19,8 @@ impl CostModel<DfNodeType, NaiveMemo<DfNodeType>> for DummyCostModel {
         _: &DfNodeType,
         _: &[ArcDfPredNode],
         _: &[Option<&Statistics>],
-        _: Option<RelNodeContext>,
-        _: Option<&CascadesOptimizer<DfNodeType>>,
+        _: RelNodeContext,
+        _: &CascadesOptimizer<DfNodeType>,
     ) -> Cost {
         Cost(vec![1.0])
     }
@@ -31,8 +31,8 @@ impl CostModel<DfNodeType, NaiveMemo<DfNodeType>> for DummyCostModel {
         _: &DfNodeType,
         _: &[ArcDfPredNode],
         _: &[&Statistics],
-        _: Option<RelNodeContext>,
-        _: Option<&CascadesOptimizer<DfNodeType>>,
+        _: RelNodeContext,
+        _: &CascadesOptimizer<DfNodeType>,
     ) -> Statistics {
         Statistics(Box::new(()))
     }


### PR DESCRIPTION
`Option` was introduced during a transition time where we thought cost model can compute the cost solely based on the children cost but it turned out that we need the optimizer for a few derived logical properties. We can drop them now.